### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
+
+# Minimal permissions for security best practices
 permissions:
   contents: read
+  # All other permissions are implicitly set to none
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/bug-ops/helix-trainer/security/code-scanning/5](https://github.com/bug-ops/helix-trainer/security/code-scanning/5)

To fix this problem, an explicit `permissions` block should be added to the workflow file at the root level, immediately after the `name: CI` declaration (and before `on:` and jobs). The block should specify the minimal permissions actually needed by the workflow. In this case, since the jobs only read repository contents, the recommended block is `permissions: contents: read`. No jobs require write access. If a job in the future requires additional permissions (for instance, interacting with issues or pull requests), those permissions can be specifically added in that job's own block. To implement the fix, insert the following section into `.github/workflows/ci.yml` after the workflow name.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
