### PR TITLE
feat: implement J (join), > (indent), < (dedent) commands

### DIFF
--- a/scenarios/basic.toml
+++ b/scenarios/basic.toml
@@ -289,3 +289,95 @@ hints = [
 optimal_count = 3
 max_points = 100
 tolerance = 1
+
+
+[[scenarios]]
+id = "join_lines_001"
+name = "Join two lines"
+description = "Join the current line with the line below"
+
+[scenarios.setup]
+file_content = "Hello
+World"
+cursor_position = [0, 0]
+
+[scenarios.target]
+file_content = "Hello World"
+cursor_position = [0, 0]
+
+[scenarios.solution]
+commands = ["J"]
+description = "Press 'J' to join lines"
+
+hints = [
+    "'J' joins the current line with the next line",
+    "A space is automatically added between the joined lines"
+]
+
+[scenarios.scoring]
+optimal_count = 1
+max_points = 100
+tolerance = 0
+
+[[scenarios]]
+id = "indent_line_001"
+name = "Indent code line"
+description = "Add indentation to a line of code"
+
+[scenarios.setup]
+file_content = "function hello() {
+return 42;
+}"
+cursor_position = [1, 0]
+
+[scenarios.target]
+file_content = "function hello() {
+  return 42;
+}"
+cursor_position = [1, 2]
+
+[scenarios.solution]
+commands = [">"]
+description = "Press '>'" to indent the line"
+
+hints = [
+    "'>'" adds 2 spaces of indentation at the start of the line",
+    "Use multiple times to add more indentation"
+]
+
+[scenarios.scoring]
+optimal_count = 1
+max_points = 100
+tolerance = 0
+
+[[scenarios]]
+id = "dedent_line_001"
+name = "Remove indentation"
+description = "Remove indentation from a line"
+
+[scenarios.setup]
+file_content = "function hello() {
+    return 42;
+}"
+cursor_position = [1, 0]
+
+[scenarios.target]
+file_content = "function hello() {
+  return 42;
+}"
+cursor_position = [1, 0]
+
+[scenarios.solution]
+commands = ["<"]
+description = "Press '<'" to remove indentation"
+
+hints = [
+    "'<'" removes up to 2 spaces of indentation from the start of the line",
+    "Use multiple times to remove more indentation"
+]
+
+[scenarios.scoring]
+optimal_count = 1
+max_points = 100
+tolerance = 0
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,6 +222,11 @@ fn handle_task_keys(key: KeyEvent, state: &AppState) -> Option<Message> {
         (KeyCode::Char('x'), KeyModifiers::NONE) => "x",
         (KeyCode::Char('d'), KeyModifiers::NONE) => "dd",
         (KeyCode::Char('c'), KeyModifiers::NONE) => "c",
+        (KeyCode::Char('J'), KeyModifiers::SHIFT) => "J",
+
+        // Indentation
+        (KeyCode::Char('>'), KeyModifiers::SHIFT) => ">",
+        (KeyCode::Char('<'), KeyModifiers::SHIFT) => "<",
 
         // Yank and paste
         (KeyCode::Char('y'), KeyModifiers::NONE) => "y",


### PR DESCRIPTION
## Summary
Implement 3 essential Helix text manipulation commands: Join, Indent, and Dedent

## Changes

### Commands Implemented
1. **J - Join Lines**
   - Joins current line with next line
   - Automatically adds space between joined lines
   - Handles edge case on last line (no-op)

2. **> - Indent Line**
   - Adds 2 spaces at beginning of line
   - Cursor maintains relative position
   - Can be applied multiple times for deeper indentation

3. **< - Dedent Line**
   - Removes up to 2 leading spaces
   - Handles partial dedent gracefully
   - No-op if no leading spaces

### Implementation Details

**join_lines()** ([simulator.rs:427-453](https://github.com/bug-ops/helix-trainer/blob/feat/join-indent-commands/src/helix/simulator.rs#L427-L453))
```rust
// Find newline at end of current line
// Replace with space using Transaction API
// Supports undo
```

**indent_line()** ([simulator.rs:455-473](https://github.com/bug-ops/helix-trainer/blob/feat/join-indent-commands/src/helix/simulator.rs#L455-L473))
```rust
// Insert 2 spaces at line start
// Move cursor forward by 2
```

**dedent_line()** ([simulator.rs:475-509](https://github.com/bug-ops/helix-trainer/blob/feat/join-indent-commands/src/helix/simulator.rs#L475-L509))
```rust
// Count leading spaces (max 2)
// Remove them
// Move cursor back appropriately
```

### Keyboard Mappings
Added to [main.rs:225-229](https://github.com/bug-ops/helix-trainer/blob/feat/join-indent-commands/src/main.rs#L225-L229):
- `Shift+J` → Join lines
- `Shift+>` → Indent
- `Shift+<` → Dedent

### Tests (7 new tests)
- `test_join_lines` - basic join functionality
- `test_join_lines_at_last_line` - edge case handling
- `test_indent_line` - basic indentation
- `test_dedent_line` - full dedent (2 spaces)
- `test_dedent_line_with_one_space` - partial dedent
- `test_dedent_line_no_spaces` - no-op case
- `test_multiple_indent` - repeated application

### Scenarios (3 new scenarios)
1. **join_lines_001** - Join "Hello\nWorld" → "Hello World"
2. **indent_line_001** - Indent code line
3. **dedent_line_001** - Remove indentation

## Verification
✅ **153 tests passing** (was 146, added 7)  
✅ **Zero clippy warnings**  
✅ **Formatted** with `cargo +nightly fmt`  
✅ **14 scenarios** total (was 11, added 3)

## Progress
**Phase A: 16/17 commands (94% complete)**
- ✅ Completed: J, >, <
- ⏳ Remaining: `.` (repeat last change)

These commands are essential for code editing workflows:
- **Join lines**: Combine multiline statements
- **Indent**: Structure code blocks
- **Dedent**: Adjust indentation levels

All commands support undo and maintain cursor position intelligently.