### PR TITLE
feat: add Profile and Statistics to main menu with keyboard shortcuts

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -238,6 +238,8 @@ fn handle_profile_stats_keys(key: KeyEvent, state: &AppState) -> Option<Message>
 fn handle_menu_keys(key: KeyEvent, state: &AppState) -> Option<Message> {
     match key.code {
         KeyCode::Char('q') => Some(Message::QuitApp),
+        KeyCode::Char('p') => Some(Message::ShowProfile),
+        KeyCode::Char('s') => Some(Message::ShowStatistics),
         KeyCode::Up | KeyCode::Char('k') => Some(Message::MenuUp),
         KeyCode::Down | KeyCode::Char('j') => Some(Message::MenuDown),
         KeyCode::Enter => Some(Message::MenuSelect),

--- a/src/ui/render/menu.rs
+++ b/src/ui/render/menu.rs
@@ -42,7 +42,7 @@ pub(super) fn render_main_menu(frame: &mut Frame, state: &mut AppState) {
 
     // Calculate visible area height for menu (excluding borders)
     let menu_height = chunks[2].height.saturating_sub(2) as usize; // -2 for borders (updated index)
-    let total_items = state.scenario_collection.count() + 1; // +1 for Quit option
+    let total_items = state.scenario_collection.count() + 3; // +3 for Profile, Statistics, Quit
 
     // Adjust scroll offset to keep selected item visible
     if state.selected_menu_item < state.menu_scroll_offset {
@@ -106,8 +106,42 @@ pub(super) fn render_main_menu(frame: &mut Frame, state: &mut AppState) {
         })
         .collect();
 
+    let scenario_count = state.scenario_collection.count();
+
+    // Add separator line
+    menu_items.push(ListItem::new("─".repeat(30)).style(Style::default().fg(Color::DarkGray)));
+
+    // Add View Profile option
+    let profile_index = scenario_count;
+    let profile_selected = profile_index == state.selected_menu_item;
+    let profile_style = if profile_selected {
+        Style::default()
+            .bg(Color::Blue)
+            .fg(Color::White)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::Cyan)
+    };
+    let profile_prefix = if profile_selected { "> " } else { "  " };
+    menu_items
+        .push(ListItem::new(format!("{}View Profile (p)", profile_prefix)).style(profile_style));
+
+    // Add Statistics option
+    let stats_index = scenario_count + 1;
+    let stats_selected = stats_index == state.selected_menu_item;
+    let stats_style = if stats_selected {
+        Style::default()
+            .bg(Color::Blue)
+            .fg(Color::White)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::Cyan)
+    };
+    let stats_prefix = if stats_selected { "> " } else { "  " };
+    menu_items.push(ListItem::new(format!("{}Statistics (s)", stats_prefix)).style(stats_style));
+
     // Add Quit option at the end
-    let quit_index = state.scenario_collection.count();
+    let quit_index = scenario_count + 2;
     let quit_selected = quit_index == state.selected_menu_item;
     let quit_style = if quit_selected {
         Style::default()

--- a/src/ui/state.rs
+++ b/src/ui/state.rs
@@ -487,8 +487,8 @@ pub fn update(state: &mut AppState, msg: Message) -> Result<(), UserError> {
         }
 
         Message::MenuDown => {
-            // Total menu items = filtered scenarios + Quit option
-            let max_items = state.scenario_collection.count() + 1;
+            // Total menu items = filtered scenarios + Profile + Statistics + Quit
+            let max_items = state.scenario_collection.count() + 3;
             if state.selected_menu_item < max_items - 1 {
                 state.selected_menu_item += 1;
             }
@@ -500,10 +500,16 @@ pub fn update(state: &mut AppState, msg: Message) -> Result<(), UserError> {
             let selected = state.selected_menu_item;
 
             if selected < scenario_count {
-                // Start selected scenario
+                // Start selected scenario (0..scenario_count-1)
                 update(state, Message::StartScenario(selected))?;
             } else if selected == scenario_count {
-                // Quit option (last item)
+                // View Profile (index = scenario_count)
+                update(state, Message::ShowProfile)?;
+            } else if selected == scenario_count + 1 {
+                // Statistics (index = scenario_count + 1)
+                update(state, Message::ShowStatistics)?;
+            } else if selected == scenario_count + 2 {
+                // Quit (index = scenario_count + 2)
                 update(state, Message::QuitApp)?;
             }
             Ok(())
@@ -1089,13 +1095,21 @@ mod tests {
         update(&mut state, Message::MenuDown).unwrap();
         assert_eq!(state.selected_menu_item, 1);
 
-        // Move down again
+        // Move down to Profile
         update(&mut state, Message::MenuDown).unwrap();
-        assert_eq!(state.selected_menu_item, 2); // Now on Quit
+        assert_eq!(state.selected_menu_item, 2); // Profile
+
+        // Move down to Statistics
+        update(&mut state, Message::MenuDown).unwrap();
+        assert_eq!(state.selected_menu_item, 3); // Statistics
+
+        // Move down to Quit
+        update(&mut state, Message::MenuDown).unwrap();
+        assert_eq!(state.selected_menu_item, 4); // Quit
 
         // Can't go past max items
         update(&mut state, Message::MenuDown).unwrap();
-        assert_eq!(state.selected_menu_item, 2);
+        assert_eq!(state.selected_menu_item, 4);
     }
 
     #[test]
@@ -1115,11 +1129,53 @@ mod tests {
         let scenario1 = create_test_scenario();
         let scenario2 = create_test_scenario();
         let mut state = create_test_app_state(vec![scenario1, scenario2]);
-        // Select Quit option (index = scenario count)
-        state.selected_menu_item = 2;
+        // Select Quit option (index = scenario_count + 2)
+        state.selected_menu_item = 4; // 2 scenarios + Profile + Statistics + Quit = index 4
 
         update(&mut state, Message::MenuSelect).unwrap();
 
+        assert!(!state.running);
+    }
+
+    #[test]
+    fn test_menu_select_profile() {
+        let scenario = create_test_scenario();
+        let mut state = create_test_app_state(vec![scenario]);
+        state.selected_menu_item = 1; // Profile is at index 1 (after 1 scenario)
+
+        update(&mut state, Message::MenuSelect).unwrap();
+        assert_eq!(state.screen, Screen::Profile);
+    }
+
+    #[test]
+    fn test_menu_select_statistics() {
+        let scenario = create_test_scenario();
+        let mut state = create_test_app_state(vec![scenario]);
+        state.selected_menu_item = 2; // Statistics is at index 2
+
+        update(&mut state, Message::MenuSelect).unwrap();
+        assert_eq!(state.screen, Screen::Statistics);
+    }
+
+    #[test]
+    fn test_menu_with_zero_scenarios() {
+        // Edge case: no scenarios loaded
+        let mut state = create_test_app_state(vec![]);
+
+        // Profile should be at index 0
+        update(&mut state, Message::MenuSelect).unwrap();
+        assert_eq!(state.screen, Screen::Profile);
+
+        // Statistics at index 1
+        state.selected_menu_item = 1;
+        state.screen = Screen::MainMenu;
+        update(&mut state, Message::MenuSelect).unwrap();
+        assert_eq!(state.screen, Screen::Statistics);
+
+        // Quit at index 2
+        state.selected_menu_item = 2;
+        state.running = true;
+        update(&mut state, Message::MenuSelect).unwrap();
         assert!(!state.running);
     }
 


### PR DESCRIPTION
## Summary

Completes Phase B user profile integration by adding Profile and Statistics screens to the main menu with keyboard shortcuts.

This PR finishes the last 5% of the profile and statistics system - the menu integration that makes these features discoverable to users.

## Changes

### Menu Integration
- ✅ Added "View Profile" and "Statistics" menu items after scenarios
- ✅ Added visual separator (─────) to group system options
- ✅ Updated menu navigation logic (+3 items: Profile, Statistics, Quit)
- ✅ Quit option moved from index N to index N+2

### Keyboard Shortcuts
- ✅ `p` key - Direct access to Profile screen (1 keypress)
- ✅ `s` key - Direct access to Statistics screen (1 keypress)
- ✅ Shortcuts shown in menu: "View Profile (p)", "Statistics (s)"
- ✅ All existing shortcuts preserved (q, 1-9, arrows, j/k)

### Files Modified
1. **src/ui/state.rs**
   - Updated MenuDown handler: `+1` → `+3` items
   - Updated MenuSelect handler: 4 branches (scenarios, profile, stats, quit)
   - Updated 2 existing tests, added 3 new tests

2. **src/main.rs**
   - Added 'p' and 's' shortcuts in `handle_menu_keys()`

3. **src/ui/render/menu.rs**
   - Updated total_items calculation
   - Added separator + Profile + Statistics items before Quit
   - Quit index calculation updated

## Testing

### Unit Tests ✅
- ✅ All 395 tests passing (100%)
- ✅ Updated `test_menu_navigation_down` (now tests Profile/Statistics navigation)
- ✅ Updated `test_menu_select_quit` (new Quit index)
- ✅ Added `test_menu_select_profile`
- ✅ Added `test_menu_select_statistics`
- ✅ Added `test_menu_with_zero_scenarios` (edge case)

### Code Quality ✅
- ✅ Zero clippy warnings
- ✅ Code formatted with `cargo +nightly fmt`
- ✅ Release build successful

### Manual Testing Checklist
- [ ] Arrow/j/k navigation through all menu items
- [ ] 'p' shortcut opens Profile screen
- [ ] 's' shortcut opens Statistics screen
- [ ] Profile screen displays correctly (level, XP, quests)
- [ ] Statistics screen displays correctly (performance breakdown)
- [ ] 'm' key returns to menu from Profile/Statistics
- [ ] Scenario selection still works (1-9 keys, Enter)
- [ ] Works with 0 scenarios (Profile at index 0)
- [ ] Works with 20+ scenarios (scrolling)

## Screenshots

### Before
- Profile/Statistics only accessible from results screen
- Menu: [Scenarios] → Quit

### After
- Profile/Statistics in main menu with shortcuts
- Menu: [Scenarios] → Separator → View Profile (p) → Statistics (s) → Quit

## Related

Implements Phase B from CLAUDE.md:
- ✅ Progress tracking and statistics
- ✅ User profiles
- ⏳ More intermediate scenarios (future)

Previous PRs:
- #36: Repeat (.) command
- #37: Phase 1.5 Foundation (metadata & filtering)

## Next Steps

After merge:
1. Consider adding mini profile summary in menu header (Level X, Y XP)
2. Implement filter UI controls (TODO stubs at state.rs:936-951)
3. Replace statistics placeholder data with real PerformanceTracker data
4. Add more achievements and quest types
5. Create demo GIF showing profile/statistics screens

---

Ready for review! 🚀