### PR TITLE
fix: empty screen when abandoning scenario with Ctrl+Q

### DIFF
--- a/src/ui/render/results.rs
+++ b/src/ui/render/results.rs
@@ -25,8 +25,9 @@ fn rating_description(rating: &PerformanceRating) -> String {
 pub(super) fn render_results_screen(frame: &mut Frame, state: &AppState) {
     let area = frame.area();
 
-    // Get feedback from UI state (set when session completed/abandoned)
-    if let Some(feedback) = &state.ui.last_feedback {
+    // Get feedback from ResultsData (guaranteed to exist via TypedScreen)
+    if let crate::ui::state::TypedScreen::Results(results_data) = &state.screen {
+        let feedback = &results_data.feedback;
         // Layout: title | horizontal(results | xp & quests) | instructions
         let chunks = Layout::default()
             .direction(Direction::Vertical)


### PR DESCRIPTION
## Summary

- Fixed empty screen bug when pressing Ctrl+Q to abandon a scenario

## Root Cause

Results renderer was using old API (`state.ui.last_feedback`) instead of new TypedScreen pattern introduced in PR #43. The `AbandonScenario` handler creates `ResultsData` with feedback, but the old renderer code only checked `last_feedback` which is only set by `CompleteScenario`.

## Fix

Changed `src/ui/render/results.rs` to extract feedback from `TypedScreen::Results(ResultsData)`, which is guaranteed to exist by the type system.

## Test plan

- [x] Manual test: Start scenario → Ctrl+Q → Results screen appears correctly
- [x] All 446 tests passing
- [x] Zero clippy warnings