### PR TITLE
ui: use muted blue background for text selection

### DIFF
--- a/src/ui/render/editor.rs
+++ b/src/ui/render/editor.rs
@@ -87,14 +87,13 @@ pub(super) fn render_editor_with_diff<'a>(
                         ));
                     }
 
-                    // Selected text with highlight
+                    // Selected text with highlight (muted blue background for better readability)
                     if start_byte < end_byte && end_byte <= line_text.len() {
                         spans.push(Span::styled(
                             &line_text[start_byte..end_byte],
                             Style::default()
-                                .bg(Color::Blue)
-                                .fg(Color::White)
-                                .add_modifier(Modifier::BOLD),
+                                .bg(Color::Rgb(60, 80, 120)) // Muted dark blue
+                                .fg(Color::White),
                         ));
                     }
 
@@ -209,14 +208,13 @@ pub(super) fn render_editor_with_selection<'a>(
                         ));
                     }
 
-                    // Selected text with highlight
+                    // Selected text with highlight (muted blue background for better readability)
                     if start_byte < end_byte {
                         spans.push(Span::styled(
                             &line_text[start_byte..end_byte],
                             Style::default()
-                                .bg(Color::Blue)
-                                .fg(Color::White)
-                                .add_modifier(Modifier::BOLD),
+                                .bg(Color::Rgb(60, 80, 120)) // Muted dark blue
+                                .fg(Color::White),
                         ));
                     }
 


### PR DESCRIPTION
## Summary

- Change selection highlight from bright blue (`Color::Blue`) to muted dark blue (`RGB 60, 80, 120`)
- Remove `BOLD` modifier from selected text for cleaner appearance
- Applied to both `render_editor_line()` and `render_editor_with_selection()` functions

## Before vs After

| Before | After |
|--------|-------|
| Bright blue (#0000FF) + Bold white text | Muted dark blue (60, 80, 120) + White text |

The new color provides better contrast and makes selected characters easier to read.

## Test plan

- [x] All 650 tests pass
- [x] Clippy reports no warnings
- [x] Visual inspection of selection highlighting