### PR TITLE
refactor: extract SELECTION_BG_COLOR constant for muted selection style

### DIFF
--- a/src/ui/render/editor.rs
+++ b/src/ui/render/editor.rs
@@ -87,12 +87,12 @@ pub(super) fn render_editor_with_diff<'a>(
                         ));
                     }
 
-                    // Selected text with highlight (muted blue background for better readability)
+                    // Selected text with highlight
                     if start_byte < end_byte && end_byte <= line_text.len() {
                         spans.push(Span::styled(
                             &line_text[start_byte..end_byte],
                             Style::default()
-                                .bg(Color::Rgb(60, 80, 120)) // Muted dark blue
+                                .bg(super::SELECTION_BG_COLOR)
                                 .fg(Color::White),
                         ));
                     }
@@ -208,12 +208,12 @@ pub(super) fn render_editor_with_selection<'a>(
                         ));
                     }
 
-                    // Selected text with highlight (muted blue background for better readability)
+                    // Selected text with highlight
                     if start_byte < end_byte {
                         spans.push(Span::styled(
                             &line_text[start_byte..end_byte],
                             Style::default()
-                                .bg(Color::Rgb(60, 80, 120)) // Muted dark blue
+                                .bg(super::SELECTION_BG_COLOR)
                                 .fg(Color::White),
                         ));
                     }

--- a/src/ui/render/menu.rs
+++ b/src/ui/render/menu.rs
@@ -50,9 +50,8 @@ fn build_menu_items(state: &AppState, selected_item: usize) -> Vec<ListItem<'_>>
             let selected = i == selected_item;
             let style = if selected {
                 Style::default()
-                    .bg(Color::Blue)
+                    .bg(super::SELECTION_BG_COLOR)
                     .fg(Color::White)
-                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(Color::White)
             };
@@ -99,9 +98,8 @@ fn build_menu_items(state: &AppState, selected_item: usize) -> Vec<ListItem<'_>>
     let due_count = state.progress.scheduler.get_due_reviews().len();
     let review_style = if review_selected {
         Style::default()
-            .bg(Color::Blue)
+            .bg(super::SELECTION_BG_COLOR)
             .fg(Color::White)
-            .add_modifier(Modifier::BOLD)
     } else if due_count > 0 {
         Style::default()
             .fg(Color::Yellow)
@@ -128,9 +126,8 @@ fn build_menu_items(state: &AppState, selected_item: usize) -> Vec<ListItem<'_>>
     let profile_selected = profile_index == selected_item;
     let profile_style = if profile_selected {
         Style::default()
-            .bg(Color::Blue)
+            .bg(super::SELECTION_BG_COLOR)
             .fg(Color::White)
-            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(Color::Cyan)
     };
@@ -143,9 +140,8 @@ fn build_menu_items(state: &AppState, selected_item: usize) -> Vec<ListItem<'_>>
     let stats_selected = stats_index == selected_item;
     let stats_style = if stats_selected {
         Style::default()
-            .bg(Color::Blue)
+            .bg(super::SELECTION_BG_COLOR)
             .fg(Color::White)
-            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(Color::Cyan)
     };
@@ -157,9 +153,8 @@ fn build_menu_items(state: &AppState, selected_item: usize) -> Vec<ListItem<'_>>
     let quit_selected = quit_index == selected_item;
     let quit_style = if quit_selected {
         Style::default()
-            .bg(Color::Blue)
+            .bg(super::SELECTION_BG_COLOR)
             .fg(Color::White)
-            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(Color::Red)
     };

--- a/src/ui/render/mod.rs
+++ b/src/ui/render/mod.rs
@@ -4,6 +4,14 @@
 //! Rendering functions may update view-related state (like scroll offsets) but
 //! do not modify business logic state.
 
+use ratatui::style::Color;
+
+/// Muted dark blue color for selection/hover highlighting
+///
+/// Used for menu item hover, editor selection, and mode selection.
+/// Provides better text readability than bright blue.
+pub(super) const SELECTION_BG_COLOR: Color = Color::Rgb(60, 80, 120);
+
 mod editor;
 mod helpers;
 mod menu;

--- a/src/ui/render/mode_selection.rs
+++ b/src/ui/render/mode_selection.rs
@@ -94,9 +94,8 @@ fn render_mode_option(
         (
             " > ",
             Style::default()
-                .bg(Color::Blue)
-                .fg(Color::White)
-                .add_modifier(Modifier::BOLD),
+                .bg(super::SELECTION_BG_COLOR)
+                .fg(Color::White),
         )
     } else {
         ("   ", Style::default().fg(Color::White))


### PR DESCRIPTION
## Summary
- Add `SELECTION_BG_COLOR` constant in `render/mod.rs` for consistent muted blue selection highlighting
- Apply muted blue selection to menu items, mode selection screen, and editor text selection
- Remove `BOLD` modifier from selected items for cleaner appearance

## Changes
- `src/ui/render/mod.rs` - New constant `SELECTION_BG_COLOR = Color::Rgb(60, 80, 120)`
- `src/ui/render/menu.rs` - Use constant for all 5 menu item hover styles
- `src/ui/render/mode_selection.rs` - Use constant for Training/Arcade mode selection
- `src/ui/render/editor.rs` - Use constant for text selection highlighting (2 places)

## Test plan
- [x] All 659 tests passing
- [x] Zero clippy warnings
- [x] Release build successful
- [ ] Manual verification: menu hover, mode selection, editor selection all use consistent muted blue