### PR TITLE
feat: add numeric count prefix support for commands

### DIFF
--- a/scenarios/en/movement/basic-movement.toml
+++ b/scenarios/en/movement/basic-movement.toml
@@ -140,11 +140,11 @@ estimated_time_seconds = 5
 [[scenarios]]
 id = "move_left_multiple_001"
 name = "Move left three times"
-description = "Move cursor left multiple characters"
+description = "Move cursor left multiple characters using count prefix"
 
 hints = [
-    "'h' moves cursor left",
-    "Press multiple times for larger moves",
+    "Use count prefix: '<number><command>' executes command N times",
+    "'3h' moves cursor left 3 times",
 ]
 
 [scenarios.setup]
@@ -156,19 +156,19 @@ file_content = "Hello World"
 cursor_position = [0, 2]
 
 [scenarios.solution]
-commands = ["h", "h", "h"]
-description = "Press 'h' three times"
+commands = ["3h"]
+description = "Press '3h' to move left 3 times"
 
 [scenarios.scoring]
-optimal_count = 3
+optimal_count = 1
 max_points = 100
 tolerance = 0
 
 [scenarios.metadata]
 category = "movement"
 difficulty = "beginner"
-tags = ["character", "multiple"]
-commands_taught = ["h"]
+tags = ["character", "multiple", "count"]
+commands_taught = ["3h"]
 estimated_time_seconds = 10
 
 [[scenarios]]

--- a/src/game/command_context.rs
+++ b/src/game/command_context.rs
@@ -100,6 +100,24 @@ pub fn parse_command_buffer(buffer: &str) -> ParsedCommand {
     }
 }
 
+/// Extract count prefix and command from a command string
+///
+/// Returns (count, command) where count defaults to 1 if no prefix.
+///
+/// # Examples
+/// - "3h" -> (3, "h")
+/// - "12j" -> (12, "j")
+/// - "h" -> (1, "h")
+/// - "gg" -> (1, "gg")
+pub fn extract_count_and_command(cmd: &str) -> (usize, &str) {
+    use crate::helix::registry::split_count_prefix;
+
+    match split_count_prefix(cmd) {
+        (Some(count), rest) if !rest.is_empty() => (count, rest),
+        _ => (1, cmd),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -557,5 +575,64 @@ mod tests {
         // Test other case-sensitive commands
         assert!(parse_command_buffer("w").is_complete()); // word forward
         assert!(parse_command_buffer("W").is_complete()); // WORD forward
+    }
+
+    // Count prefix tests
+    #[test]
+    fn test_parse_command_buffer_count_prefix_partial() {
+        // Just digits should be partial
+        assert!(parse_command_buffer("3").is_partial());
+        assert!(parse_command_buffer("12").is_partial());
+        assert!(parse_command_buffer("999").is_partial());
+    }
+
+    #[test]
+    fn test_parse_command_buffer_count_prefix_complete() {
+        // Count + single-key command
+        assert_eq!(
+            parse_command_buffer("3h"),
+            ParsedCommand::Complete("3h".to_string())
+        );
+        assert_eq!(
+            parse_command_buffer("5j"),
+            ParsedCommand::Complete("5j".to_string())
+        );
+        assert_eq!(
+            parse_command_buffer("10w"),
+            ParsedCommand::Complete("10w".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_command_buffer_count_prefix_invalid() {
+        // Count + goto prefix is invalid
+        assert!(parse_command_buffer("3g").is_invalid());
+        // Count + char-input prefix is invalid
+        assert!(parse_command_buffer("3f").is_invalid());
+        assert!(parse_command_buffer("3r").is_invalid());
+        // Count + multi-key is invalid
+        assert!(parse_command_buffer("3gg").is_invalid());
+    }
+
+    #[test]
+    fn test_extract_count_and_command_with_count() {
+        assert_eq!(extract_count_and_command("3h"), (3, "h"));
+        assert_eq!(extract_count_and_command("12j"), (12, "j"));
+        assert_eq!(extract_count_and_command("999k"), (999, "k"));
+    }
+
+    #[test]
+    fn test_extract_count_and_command_no_count() {
+        assert_eq!(extract_count_and_command("h"), (1, "h"));
+        assert_eq!(extract_count_and_command("gg"), (1, "gg"));
+        assert_eq!(extract_count_and_command("fx"), (1, "fx"));
+    }
+
+    #[test]
+    fn test_extract_count_and_command_edge_cases() {
+        // Just digits - should return (1, original)
+        assert_eq!(extract_count_and_command("3"), (1, "3"));
+        // Empty - should return (1, empty)
+        assert_eq!(extract_count_and_command(""), (1, ""));
     }
 }

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -10,7 +10,9 @@ pub mod editor_state;
 pub mod scorer;
 pub mod session;
 
-pub use command_context::{CommandContext, ParsedCommand, parse_command_buffer};
+pub use command_context::{
+    CommandContext, ParsedCommand, extract_count_and_command, parse_command_buffer,
+};
 pub use editor_state::{CursorPosition, EditorState, Selection};
 pub use scorer::{PerformanceRating, Scorer};
 pub use session::{

--- a/src/helix/registry/keytrie.rs
+++ b/src/helix/registry/keytrie.rs
@@ -1,19 +1,50 @@
 //! KeyTrie for multi-key sequence resolution
 //!
-//! Handles sequences like `gg`, `gh`, `fx`, `rx` by determining
-//! if a buffer contains a complete command, partial sequence, or invalid input.
+//! Handles sequences like `gg`, `gh`, `fx`, `rx`, and count prefixes like `3h`, `10j`
+//! by determining if a buffer contains a complete command, partial sequence, or invalid input.
 
 use std::collections::{HashMap, HashSet};
+
+/// Maximum allowed count prefix to prevent abuse
+pub const MAX_COUNT_PREFIX: usize = 999;
 
 /// Result of matching a key sequence against the trie
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum KeyMatch {
     /// Complete match - command ready to execute
     Complete(String),
-    /// Partial match - more keys needed (g, r, f, F, t, T)
+    /// Partial match - more keys needed (g, r, f, F, t, T, or digits)
     Partial,
     /// No match - invalid sequence
     Invalid,
+}
+
+/// Split a buffer into count prefix and command parts
+///
+/// # Examples
+/// - "3h" -> (Some(3), "h")
+/// - "12j" -> (Some(12), "j")
+/// - "h" -> (None, "h")
+/// - "3" -> (Some(3), "")
+/// - "3gg" -> (Some(3), "gg")
+pub fn split_count_prefix(buffer: &str) -> (Option<usize>, &str) {
+    let digit_end = buffer
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .map(|c| c.len_utf8())
+        .sum();
+
+    if digit_end == 0 {
+        return (None, buffer);
+    }
+
+    let count_str = &buffer[..digit_end];
+    let cmd_str = &buffer[digit_end..];
+
+    match count_str.parse::<usize>() {
+        Ok(count) if count <= MAX_COUNT_PREFIX => (Some(count), cmd_str),
+        _ => (None, buffer), // Invalid count, treat as invalid
+    }
 }
 
 /// KeyTrie for resolving multi-key command sequences
@@ -77,6 +108,38 @@ impl KeyTrie {
             return KeyMatch::Invalid;
         }
 
+        // Check for count prefix (e.g., "3h", "12j")
+        // Note: "0" alone is a command (goto line start), not a count prefix
+        let first_char = buffer.chars().next().unwrap();
+        let has_count_prefix =
+            first_char.is_ascii_digit() && first_char != '0' && !buffer.is_empty();
+
+        if has_count_prefix {
+            let (count, cmd_part) = split_count_prefix(buffer);
+
+            if count.is_some() {
+                // We have a count prefix
+                if cmd_part.is_empty() {
+                    // Just digits so far, waiting for command
+                    return KeyMatch::Partial;
+                }
+
+                // Validate the command part (only single-key commands with count)
+                // Multi-key commands like "3gg" and char-input like "3fx" are not supported
+                if cmd_part.len() == 1 {
+                    let cmd_char = cmd_part.chars().next().unwrap();
+                    // Don't allow count with char-input prefixes (f, t, r, etc.) or goto prefix
+                    if !self.char_input_prefixes.contains(&cmd_char) && cmd_char != 'g' {
+                        return KeyMatch::Complete(buffer.to_string());
+                    }
+                }
+
+                // Invalid count+command combination
+                return KeyMatch::Invalid;
+            }
+        }
+
+        // No count prefix - use standard resolution
         let len = buffer.len();
         let first_char = buffer.chars().next().unwrap();
 
@@ -211,5 +274,66 @@ mod tests {
         assert!(trie.is_multi_key_prefix('r'));
         assert!(!trie.is_multi_key_prefix('h'));
         assert!(!trie.is_multi_key_prefix('d'));
+    }
+
+    // Count prefix tests
+    #[test]
+    fn test_split_count_prefix_with_count() {
+        assert_eq!(split_count_prefix("3h"), (Some(3), "h"));
+        assert_eq!(split_count_prefix("12j"), (Some(12), "j"));
+        assert_eq!(split_count_prefix("999k"), (Some(999), "k"));
+    }
+
+    #[test]
+    fn test_split_count_prefix_no_count() {
+        assert_eq!(split_count_prefix("h"), (None, "h"));
+        assert_eq!(split_count_prefix("gg"), (None, "gg"));
+        assert_eq!(split_count_prefix("fx"), (None, "fx"));
+    }
+
+    #[test]
+    fn test_split_count_prefix_only_digits() {
+        assert_eq!(split_count_prefix("3"), (Some(3), ""));
+        assert_eq!(split_count_prefix("123"), (Some(123), ""));
+    }
+
+    #[test]
+    fn test_split_count_prefix_exceeds_max() {
+        // Count > MAX_COUNT_PREFIX should be treated as invalid
+        assert_eq!(split_count_prefix("1000h"), (None, "1000h"));
+        assert_eq!(split_count_prefix("9999j"), (None, "9999j"));
+    }
+
+    #[test]
+    fn test_count_prefix_partial() {
+        let trie = KeyTrie::new();
+        // Just digits should be partial (waiting for command)
+        assert_eq!(trie.resolve("3"), KeyMatch::Partial);
+        assert_eq!(trie.resolve("12"), KeyMatch::Partial);
+        assert_eq!(trie.resolve("999"), KeyMatch::Partial);
+    }
+
+    #[test]
+    fn test_count_prefix_complete() {
+        let trie = KeyTrie::new();
+        // Count + single-key command should be complete
+        assert_eq!(trie.resolve("3h"), KeyMatch::Complete("3h".to_string()));
+        assert_eq!(trie.resolve("5j"), KeyMatch::Complete("5j".to_string()));
+        assert_eq!(trie.resolve("10w"), KeyMatch::Complete("10w".to_string()));
+        assert_eq!(trie.resolve("99d"), KeyMatch::Complete("99d".to_string()));
+    }
+
+    #[test]
+    fn test_count_prefix_invalid_combinations() {
+        let trie = KeyTrie::new();
+        // Count + goto prefix (g) is invalid
+        assert_eq!(trie.resolve("3g"), KeyMatch::Invalid);
+        // Count + char-input prefix (f, t, r) is invalid
+        assert_eq!(trie.resolve("3f"), KeyMatch::Invalid);
+        assert_eq!(trie.resolve("3r"), KeyMatch::Invalid);
+        assert_eq!(trie.resolve("3t"), KeyMatch::Invalid);
+        // Count + multi-key command is invalid
+        assert_eq!(trie.resolve("3gg"), KeyMatch::Invalid);
+        assert_eq!(trie.resolve("3fx"), KeyMatch::Invalid);
     }
 }

--- a/src/helix/registry/mod.rs
+++ b/src/helix/registry/mod.rs
@@ -43,7 +43,7 @@ use std::sync::OnceLock;
 use crate::helix::simulator::NormalMode;
 
 pub use command_registry::{Command, CommandHandler, CommandRegistry};
-pub use keytrie::{KeyMatch, KeyTrie};
+pub use keytrie::{KeyMatch, KeyTrie, MAX_COUNT_PREFIX, split_count_prefix};
 pub use metadata::{Category, CommandMetadata, ModeTransition};
 
 /// Global normal mode command registry

--- a/src/input/handlers.rs
+++ b/src/input/handlers.rs
@@ -29,6 +29,26 @@ fn is_waiting_for_char_arg(state: &AppState) -> bool {
     }
 }
 
+/// Check if the command buffer contains a count prefix (digits like "3", "12")
+///
+/// When the buffer is building a count prefix, we should accept more digits
+/// or a command character to complete the sequence.
+fn is_building_count_prefix(state: &AppState) -> bool {
+    let buffer = match &state.screen {
+        TypedScreen::Task(task_data) => task_data.command_buffer(),
+        TypedScreen::MiniGame(minigame_data) => minigame_data.command_buffer(),
+        _ => return false,
+    };
+
+    // Check if buffer starts with a non-zero digit and contains only digits
+    if buffer.is_empty() {
+        return false;
+    }
+
+    let first_char = buffer.chars().next().unwrap();
+    first_char.is_ascii_digit() && first_char != '0' && buffer.chars().all(|c| c.is_ascii_digit())
+}
+
 /// Handle keyboard events on profile and statistics screens
 pub fn handle_profile_stats_keys(key: KeyEvent, state: &AppState) -> Option<Message> {
     match key.code {
@@ -138,6 +158,38 @@ where
                 _ => {}
             }
         }
+
+        // Check if we're building a count prefix (e.g., "3", "12")
+        // Accept digits to continue building the count, or a command to complete
+        if is_building_count_prefix(state) {
+            if let KeyCode::Char(c) = key.code {
+                // Accept more digits or a command character
+                return Some(make_message(Cow::Owned(c.to_string())));
+            }
+            // Non-char keys cancel the pending count
+            if matches!(
+                key.code,
+                KeyCode::Esc
+                    | KeyCode::Left
+                    | KeyCode::Right
+                    | KeyCode::Up
+                    | KeyCode::Down
+                    | KeyCode::Backspace
+                    | KeyCode::Enter
+            ) {
+                return Some(make_message(Cow::Borrowed("<cancel>")));
+            }
+        }
+
+        // Handle digit keys (1-9) to start count prefix
+        // Note: '0' is a command (goto line start), not a count prefix start
+        if let KeyCode::Char(c) = key.code
+            && c.is_ascii_digit()
+            && c != '0'
+        {
+            return Some(make_message(Cow::Owned(c.to_string())));
+        }
+
         map_key_to_helix_command(key).map(|cmd| make_message(Cow::Borrowed(cmd)))
     }
 }

--- a/src/ui/state/handlers/gameplay.rs
+++ b/src/ui/state/handlers/gameplay.rs
@@ -162,6 +162,9 @@ pub fn handle_execute_command(
                 task_data.last_command = Some(cmd.clone());
                 executed_command = Some(cmd.clone());
 
+                // Extract count and base command (e.g., "3h" -> count=3, base_cmd="h")
+                let (count, base_cmd) = crate::game::extract_count_and_command(&cmd);
+
                 // Clone scenario before taking session (to avoid borrow conflict)
                 let scenario = task_data.session.scenario().clone();
 
@@ -171,8 +174,38 @@ pub fn handle_execute_command(
                     crate::game::GameSession::new(scenario)?,
                 );
 
-                let result = session.record_action(cmd)?;
-                session_completed = process_session_result(result, &mut task_data, state)?;
+                // Execute command `count` times using Option to track session state
+                let mut current_session = Some(session);
+
+                for _ in 0..count {
+                    if let Some(s) = current_session.take() {
+                        let result = s.record_action(base_cmd.to_string())?;
+                        match result {
+                            crate::game::SessionAfterAction::Completed(completed) => {
+                                // Session completed - process and break
+                                let completed_result =
+                                    crate::game::SessionAfterAction::Completed(completed);
+                                session_completed = process_session_result(
+                                    completed_result,
+                                    &mut task_data,
+                                    state,
+                                )?;
+                                // Leave current_session as None to signal completion
+                                break;
+                            }
+                            crate::game::SessionAfterAction::StillActive(active) => {
+                                current_session = Some(active);
+                            }
+                        }
+                    }
+                }
+
+                // If not completed during loop, finalize the session state
+                if let Some(remaining_session) = current_session {
+                    let final_result =
+                        crate::game::SessionAfterAction::StillActive(remaining_session);
+                    process_session_result(final_result, &mut task_data, state)?;
+                }
 
                 // Always restore Task screen - even when completed, we show success popup
                 state.screen = TypedScreen::Task(task_data);

--- a/tests/scenario_validation.rs
+++ b/tests/scenario_validation.rs
@@ -9,7 +9,9 @@
 
 use helix_trainer::config::ScenarioLoader;
 use helix_trainer::game::GameSession;
-use helix_trainer::game::command_context::{ParsedCommand, parse_command_buffer};
+use helix_trainer::game::command_context::{
+    ParsedCommand, extract_count_and_command, parse_command_buffer,
+};
 use std::path::Path;
 use walkdir::WalkDir;
 
@@ -239,24 +241,57 @@ fn test_all_scenarios_execute_solution() {
                     if let Some(state) = session_or_completed.take() {
                         match state {
                             SessionAfterAction::StillActive(s) => {
-                                match s.record_action(cmd.clone()) {
-                                    Ok(result) => {
-                                        session_or_completed = Some(result);
-                                        // If completed, stop
-                                        if matches!(
-                                            session_or_completed,
-                                            Some(SessionAfterAction::Completed(_))
-                                        ) {
-                                            break;
+                                // Extract count and base command (e.g., "3h" -> count=3, base_cmd="h")
+                                let (count, base_cmd) = extract_count_and_command(cmd);
+
+                                // Execute base command `count` times
+                                let mut current_session = Some(s);
+                                let mut execution_error = None;
+
+                                for _ in 0..count {
+                                    if let Some(active) = current_session.take() {
+                                        match active.record_action(base_cmd.to_string()) {
+                                            Ok(result) => match result {
+                                                SessionAfterAction::Completed(c) => {
+                                                    session_or_completed =
+                                                        Some(SessionAfterAction::Completed(c));
+                                                    break;
+                                                }
+                                                SessionAfterAction::StillActive(next) => {
+                                                    current_session = Some(next);
+                                                }
+                                            },
+                                            Err(e) => {
+                                                execution_error = Some(e);
+                                                break;
+                                            }
                                         }
                                     }
-                                    Err(e) => {
-                                        failed_scenarios.push((
-                                            scenario.id.clone(),
-                                            format!("Failed at command {} '{}': {:?}", i, cmd, e),
-                                        ));
-                                        break;
-                                    }
+                                }
+
+                                // Handle execution error
+                                if let Some(e) = execution_error {
+                                    failed_scenarios.push((
+                                        scenario.id.clone(),
+                                        format!("Failed at command {} '{}': {:?}", i, cmd, e),
+                                    ));
+                                    break;
+                                }
+
+                                // If not completed, store remaining session
+                                if session_or_completed.is_none()
+                                    && let Some(remaining) = current_session
+                                {
+                                    session_or_completed =
+                                        Some(SessionAfterAction::StillActive(remaining));
+                                }
+
+                                // If completed, stop processing commands
+                                if matches!(
+                                    session_or_completed,
+                                    Some(SessionAfterAction::Completed(_))
+                                ) {
+                                    break;
                                 }
                             }
                             SessionAfterAction::Completed(c) => {


### PR DESCRIPTION
## Summary

Adds support for numeric count prefixes for commands, allowing users to execute commands multiple times with a single input:

- `3h` - moves cursor left 3 times
- `5j` - moves down 5 lines  
- `10w` - moves forward 10 words
- `2dd` - (not supported yet, only single-key commands)

## Changes

### Core Implementation

1. **KeyTrie** (`src/helix/registry/keytrie.rs`)
   - Parse count prefixes in command buffer (1-999)
   - `split_count_prefix()` function to extract count and command
   - '0' remains the "goto line start" command, not a count prefix

2. **command_context** (`src/game/command_context.rs`)
   - Added `extract_count_and_command()` helper function
   - Tests for count parsing edge cases

3. **gameplay handler** (`src/ui/state/handlers/gameplay.rs`)
   - Execute base command `count` times in a loop
   - Proper session state management during iteration

4. **input handlers** (`src/input/handlers.rs`)
   - Accept digit keys (1-9) to start count prefix
   - Accept more digits while building count
   - Accept command key to complete the sequence

5. **scenario validation** (`tests/scenario_validation.rs`)
   - Handle count commands properly in tests

### Limitations

- Count prefix only works with single-key commands
- `3gg`, `3fx`, `3r` are invalid (multi-key commands with count not supported)
- Maximum count is 999 (security limit)

### Updated Scenario

Updated "Move left three times" scenario to demonstrate the new `3h` syntax.

## Test plan

- [x] All 728 tests pass
- [x] Clippy clean
- [x] Scenario validation passes
- [x] Manual testing of count commands