### PR TITLE
feat: add Helix-style menu navigation with count prefixes

### DIFF
--- a/locales/en.toml
+++ b/locales/en.toml
@@ -6,8 +6,8 @@ main_menu = "Main Menu"
 main_menu_with_scroll = "Main Menu [%{first}-%{last}/%{total}]"
 main_menu_total = "Main Menu [%{total}]"
 quit = "Quit"
-instructions = "↑/↓ or j/k: Navigate | Enter: Select | q: Quit"
-instructions_with_numbers = "↑/↓ or j/k: Navigate | 1-9: Quick jump | Enter: Select | q: Quit"
+instructions = "j/k: Navigate | gg/G: First/Last | 5j: Move 5 | Enter: Select | q: Quit"
+instructions_with_numbers = "j/k: Navigate | gg/G: First/Last | 15G: Go to 15 | Enter: Select | q: Quit"
 
 [task]
 title = "Task"

--- a/src/input/handlers.rs
+++ b/src/input/handlers.rs
@@ -69,36 +69,196 @@ pub fn handle_profile_stats_keys(key: KeyEvent, state: &AppState) -> Option<Mess
     }
 }
 
+/// Get menu command buffer from state
+fn get_menu_buffer(state: &AppState) -> &str {
+    match &state.screen {
+        TypedScreen::Menu(data) => &data.command_buffer,
+        _ => "",
+    }
+}
+
+/// Parse menu command buffer and return appropriate message
+///
+/// Handles:
+/// - Count prefixes (3j, 10k)
+/// - Jump commands (gg, G, 15G, 15gg)
+/// - Simple navigation (j, k)
+fn parse_menu_command(buffer: &str) -> Option<Message> {
+    if buffer.is_empty() {
+        return None;
+    }
+
+    // Check for gg (goto first)
+    if buffer == "gg" {
+        return Some(Message::MenuJumpToFirst);
+    }
+
+    // Check for G (goto last) or {n}G (goto line n)
+    if buffer == "G" {
+        return Some(Message::MenuJumpToLast);
+    }
+
+    // Check for {n}G pattern
+    if let Some(num_str) = buffer.strip_suffix('G')
+        && let Ok(n) = num_str.parse::<usize>()
+    {
+        return Some(Message::MenuJumpTo(n));
+    }
+
+    // Check for {n}gg pattern
+    if let Some(num_str) = buffer.strip_suffix("gg")
+        && !num_str.is_empty()
+        && let Ok(n) = num_str.parse::<usize>()
+    {
+        return Some(Message::MenuJumpTo(n));
+    }
+
+    // Check for count + j/k pattern
+    if buffer.ends_with('j') || buffer.ends_with('k') {
+        let direction = buffer.chars().last().unwrap();
+        let count_str = &buffer[..buffer.len() - 1];
+
+        if count_str.is_empty() {
+            // Simple j or k
+            return match direction {
+                'j' => Some(Message::MenuDown),
+                'k' => Some(Message::MenuUp),
+                _ => None,
+            };
+        }
+
+        if let Ok(count) = count_str.parse::<usize>() {
+            return match direction {
+                'j' => Some(Message::MenuDownBy(count)),
+                'k' => Some(Message::MenuUpBy(count)),
+                _ => None,
+            };
+        }
+    }
+
+    None
+}
+
+/// Check if menu buffer is in a partial state (waiting for more input)
+fn is_menu_buffer_partial(buffer: &str) -> bool {
+    if buffer.is_empty() {
+        return false;
+    }
+
+    // "g" alone is partial (waiting for second g)
+    if buffer == "g" {
+        return true;
+    }
+
+    // Digits alone are partial (waiting for j/k/g/G)
+    if buffer.chars().all(|c| c.is_ascii_digit()) {
+        return true;
+    }
+
+    // Digits followed by "g" is partial (waiting for second g)
+    if buffer.ends_with('g') && buffer.len() > 1 {
+        let prefix = &buffer[..buffer.len() - 1];
+        if prefix.chars().all(|c| c.is_ascii_digit()) {
+            return true;
+        }
+    }
+
+    false
+}
+
 /// Handle keyboard events on the main menu screen
-pub fn handle_menu_keys(key: KeyEvent, state: &AppState) -> Option<Message> {
+///
+/// Supports Helix-style navigation:
+/// - j/k: move down/up
+/// - 5j/10k: move down/up by count
+/// - gg: jump to first item
+/// - G: jump to last item
+/// - 15G/15gg: jump to item 15
+pub fn handle_menu_keys(key: KeyEvent, state: &mut AppState) -> Option<Message> {
     // Ctrl-Q exits application from anywhere
     if key.code == KeyCode::Char('q') && key.modifiers.contains(KeyModifiers::CONTROL) {
         return Some(Message::QuitApp);
     }
 
-    match key.code {
-        KeyCode::Char('q') => Some(Message::QuitApp),
-        KeyCode::Char('r') => Some(Message::StartReviewSession),
-        KeyCode::Char('p') => Some(Message::ShowProfile),
-        KeyCode::Char('s') => Some(Message::ShowStatistics),
-        KeyCode::Up | KeyCode::Char('k') => Some(Message::MenuUp),
-        KeyCode::Down | KeyCode::Char('j') => Some(Message::MenuDown),
-        KeyCode::Enter => Some(Message::MenuSelect),
-        // Quick jump with number keys (1-9)
-        KeyCode::Char(c) if c.is_ascii_digit() => {
-            let digit = c
-                .to_digit(10)
-                .expect("char is validated as ascii_digit by guard condition")
-                as usize;
-            if digit >= 1 && digit <= state.game.scenario_collection.count() {
-                // Jump to scenario (digit - 1 because scenarios are 0-indexed)
-                Some(Message::StartScenario(digit - 1))
-            } else {
-                None
+    // Get current buffer
+    let buffer = get_menu_buffer(state);
+
+    // Handle Escape - clear buffer
+    if key.code == KeyCode::Esc {
+        if let TypedScreen::Menu(ref mut data) = state.screen
+            && !data.command_buffer.is_empty()
+        {
+            data.command_buffer.clear();
+            return None; // Consumed the escape
+        }
+        return None;
+    }
+
+    // Handle Enter - always select
+    if key.code == KeyCode::Enter {
+        // Clear buffer first
+        if let TypedScreen::Menu(ref mut data) = state.screen {
+            data.command_buffer.clear();
+        }
+        return Some(Message::MenuSelect);
+    }
+
+    // Arrow keys bypass command buffer
+    if key.code == KeyCode::Up {
+        if let TypedScreen::Menu(ref mut data) = state.screen {
+            data.command_buffer.clear();
+        }
+        return Some(Message::MenuUp);
+    }
+    if key.code == KeyCode::Down {
+        if let TypedScreen::Menu(ref mut data) = state.screen {
+            data.command_buffer.clear();
+        }
+        return Some(Message::MenuDown);
+    }
+
+    // Handle character input
+    if let KeyCode::Char(c) = key.code {
+        // Special single-key commands (when buffer is empty)
+        if buffer.is_empty() {
+            match c {
+                'q' => return Some(Message::QuitApp),
+                'r' => return Some(Message::StartReviewSession),
+                'p' => return Some(Message::ShowProfile),
+                's' => return Some(Message::ShowStatistics),
+                'G' => return Some(Message::MenuJumpToLast),
+                _ => {}
             }
         }
-        _ => None,
+
+        // Build new buffer
+        let new_buffer = format!("{}{}", buffer, c);
+
+        // Check if it's a complete command
+        if let Some(msg) = parse_menu_command(&new_buffer) {
+            // Clear buffer and return message
+            if let TypedScreen::Menu(ref mut data) = state.screen {
+                data.command_buffer.clear();
+            }
+            return Some(msg);
+        }
+
+        // Check if it's a valid partial state
+        if is_menu_buffer_partial(&new_buffer) {
+            // Update buffer and wait for more input
+            if let TypedScreen::Menu(ref mut data) = state.screen {
+                data.command_buffer = new_buffer;
+            }
+            return None;
+        }
+
+        // Invalid sequence - clear buffer
+        if let TypedScreen::Menu(ref mut data) = state.screen {
+            data.command_buffer.clear();
+        }
     }
+
+    None
 }
 
 /// Handle special UI keys on task screen (F1, ?, Ctrl+Q)
@@ -338,32 +498,36 @@ mod tests {
     #[test]
     fn test_menu_key_q_quits() {
         let key = KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE);
-        let state = create_test_app_state();
-        let msg = handle_menu_keys(key, &state);
+        let mut state = create_test_app_state();
+        state.screen = TypedScreen::Menu(MenuData::default());
+        let msg = handle_menu_keys(key, &mut state);
         assert_eq!(msg, Some(Message::QuitApp));
     }
 
     #[test]
     fn test_menu_key_j_moves_down() {
         let key = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE);
-        let state = create_test_app_state();
-        let msg = handle_menu_keys(key, &state);
+        let mut state = create_test_app_state();
+        state.screen = TypedScreen::Menu(MenuData::default());
+        let msg = handle_menu_keys(key, &mut state);
         assert_eq!(msg, Some(Message::MenuDown));
     }
 
     #[test]
     fn test_menu_key_k_moves_up() {
         let key = KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE);
-        let state = create_test_app_state();
-        let msg = handle_menu_keys(key, &state);
+        let mut state = create_test_app_state();
+        state.screen = TypedScreen::Menu(MenuData::default());
+        let msg = handle_menu_keys(key, &mut state);
         assert_eq!(msg, Some(Message::MenuUp));
     }
 
     #[test]
     fn test_menu_key_enter_selects() {
         let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
-        let state = create_test_app_state();
-        let msg = handle_menu_keys(key, &state);
+        let mut state = create_test_app_state();
+        state.screen = TypedScreen::Menu(MenuData::default());
+        let msg = handle_menu_keys(key, &mut state);
         assert_eq!(msg, Some(Message::MenuSelect));
     }
 
@@ -434,8 +598,9 @@ mod tests {
     #[test]
     fn test_menu_key_ctrl_q_quits() {
         let key = KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL);
-        let state = create_test_app_state();
-        let msg = handle_menu_keys(key, &state);
+        let mut state = create_test_app_state();
+        state.screen = TypedScreen::Menu(MenuData::default());
+        let msg = handle_menu_keys(key, &mut state);
         assert_eq!(msg, Some(Message::QuitApp));
     }
 
@@ -464,9 +629,150 @@ mod tests {
     #[test]
     fn test_unknown_key_returns_none() {
         let key = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE);
-        let state = create_test_app_state();
-        let msg = handle_menu_keys(key, &state);
+        let mut state = create_test_app_state();
+        state.screen = TypedScreen::Menu(MenuData::default());
+        let msg = handle_menu_keys(key, &mut state);
         assert_eq!(msg, None);
+    }
+
+    // Tests for Helix-style menu navigation
+    mod menu_navigation_tests {
+        use super::*;
+
+        #[test]
+        fn test_menu_gg_jumps_to_first() {
+            let mut state = create_test_app_state();
+            state.screen = TypedScreen::Menu(MenuData::default());
+
+            // Press 'g' - partial, no message yet
+            let key_g = KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE);
+            let msg = handle_menu_keys(key_g, &mut state);
+            assert_eq!(msg, None);
+
+            // Press second 'g' - complete command
+            let msg = handle_menu_keys(key_g, &mut state);
+            assert_eq!(msg, Some(Message::MenuJumpToFirst));
+        }
+
+        #[test]
+        fn test_menu_shift_g_jumps_to_last() {
+            let mut state = create_test_app_state();
+            state.screen = TypedScreen::Menu(MenuData::default());
+
+            let key = KeyEvent::new(KeyCode::Char('G'), KeyModifiers::NONE);
+            let msg = handle_menu_keys(key, &mut state);
+            assert_eq!(msg, Some(Message::MenuJumpToLast));
+        }
+
+        #[test]
+        fn test_menu_5j_moves_down_5() {
+            let mut state = create_test_app_state();
+            state.screen = TypedScreen::Menu(MenuData::default());
+
+            // Press '5' - partial
+            let key_5 = KeyEvent::new(KeyCode::Char('5'), KeyModifiers::NONE);
+            let msg = handle_menu_keys(key_5, &mut state);
+            assert_eq!(msg, None);
+
+            // Press 'j' - complete
+            let key_j = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE);
+            let msg = handle_menu_keys(key_j, &mut state);
+            assert_eq!(msg, Some(Message::MenuDownBy(5)));
+        }
+
+        #[test]
+        fn test_menu_10k_moves_up_10() {
+            let mut state = create_test_app_state();
+            state.screen = TypedScreen::Menu(MenuData::default());
+
+            // Press '1' - partial
+            let key_1 = KeyEvent::new(KeyCode::Char('1'), KeyModifiers::NONE);
+            let msg = handle_menu_keys(key_1, &mut state);
+            assert_eq!(msg, None);
+
+            // Press '0' - partial
+            let key_0 = KeyEvent::new(KeyCode::Char('0'), KeyModifiers::NONE);
+            let msg = handle_menu_keys(key_0, &mut state);
+            assert_eq!(msg, None);
+
+            // Press 'k' - complete
+            let key_k = KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE);
+            let msg = handle_menu_keys(key_k, &mut state);
+            assert_eq!(msg, Some(Message::MenuUpBy(10)));
+        }
+
+        #[test]
+        fn test_menu_15_shift_g_jumps_to_15() {
+            let mut state = create_test_app_state();
+            state.screen = TypedScreen::Menu(MenuData::default());
+
+            // Press '1' - partial
+            let key_1 = KeyEvent::new(KeyCode::Char('1'), KeyModifiers::NONE);
+            let msg = handle_menu_keys(key_1, &mut state);
+            assert_eq!(msg, None);
+
+            // Press '5' - partial
+            let key_5 = KeyEvent::new(KeyCode::Char('5'), KeyModifiers::NONE);
+            let msg = handle_menu_keys(key_5, &mut state);
+            assert_eq!(msg, None);
+
+            // Press 'G' - complete
+            let key_shift_g = KeyEvent::new(KeyCode::Char('G'), KeyModifiers::NONE);
+            let msg = handle_menu_keys(key_shift_g, &mut state);
+            assert_eq!(msg, Some(Message::MenuJumpTo(15)));
+        }
+
+        #[test]
+        fn test_menu_15gg_jumps_to_15() {
+            let mut state = create_test_app_state();
+            state.screen = TypedScreen::Menu(MenuData::default());
+
+            // Press "15gg"
+            let key_1 = KeyEvent::new(KeyCode::Char('1'), KeyModifiers::NONE);
+            handle_menu_keys(key_1, &mut state);
+
+            let key_5 = KeyEvent::new(KeyCode::Char('5'), KeyModifiers::NONE);
+            handle_menu_keys(key_5, &mut state);
+
+            let key_g = KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE);
+            handle_menu_keys(key_g, &mut state);
+
+            let msg = handle_menu_keys(key_g, &mut state);
+            assert_eq!(msg, Some(Message::MenuJumpTo(15)));
+        }
+
+        #[test]
+        fn test_menu_escape_clears_buffer() {
+            let mut state = create_test_app_state();
+            state.screen = TypedScreen::Menu(MenuData::default());
+
+            // Start building "5j"
+            let key_5 = KeyEvent::new(KeyCode::Char('5'), KeyModifiers::NONE);
+            handle_menu_keys(key_5, &mut state);
+
+            // Press Escape - should clear buffer
+            let key_esc = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
+            handle_menu_keys(key_esc, &mut state);
+
+            // Now press 'j' - should be simple down, not 5j
+            let key_j = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE);
+            let msg = handle_menu_keys(key_j, &mut state);
+            assert_eq!(msg, Some(Message::MenuDown));
+        }
+
+        #[test]
+        fn test_menu_arrow_keys_still_work() {
+            let mut state = create_test_app_state();
+            state.screen = TypedScreen::Menu(MenuData::default());
+
+            let key_up = KeyEvent::new(KeyCode::Up, KeyModifiers::NONE);
+            let msg = handle_menu_keys(key_up, &mut state);
+            assert_eq!(msg, Some(Message::MenuUp));
+
+            let key_down = KeyEvent::new(KeyCode::Down, KeyModifiers::NONE);
+            let msg = handle_menu_keys(key_down, &mut state);
+            assert_eq!(msg, Some(Message::MenuDown));
+        }
     }
 
     // Unit tests for is_gameplay_insert_mode()

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -15,7 +15,10 @@ use handlers::*;
 ///
 /// This function is the main entry point for input handling.
 /// It dispatches to screen-specific handlers based on current screen state.
-pub fn handle_key_event(key: KeyEvent, state: &AppState) -> Option<Message> {
+///
+/// Note: Some handlers (like menu) need mutable access to state
+/// for command buffer management.
+pub fn handle_key_event(key: KeyEvent, state: &mut AppState) -> Option<Message> {
     use helix_trainer::ui::state::TypedScreen;
 
     match &state.screen {

--- a/src/ui/state/handlers/menu.rs
+++ b/src/ui/state/handlers/menu.rs
@@ -35,6 +35,63 @@ pub fn handle_menu_down(
     Ok(HandlerOutcome::Stay)
 }
 
+/// Handle MenuUpBy message
+///
+/// Moves menu selection up by N items (with bounds checking).
+pub fn handle_menu_up_by(data: &mut MenuData, count: usize) -> Result<HandlerOutcome, UserError> {
+    data.selected_item = data.selected_item.saturating_sub(count);
+    Ok(HandlerOutcome::Stay)
+}
+
+/// Handle MenuDownBy message
+///
+/// Moves menu selection down by N items (with bounds checking).
+pub fn handle_menu_down_by(
+    data: &mut MenuData,
+    ctx: &HandlerContext<'_>,
+    count: usize,
+) -> Result<HandlerOutcome, UserError> {
+    let max_items = ctx.game.scenario_collection.count() + 4;
+    let max_index = max_items.saturating_sub(1);
+    data.selected_item = (data.selected_item + count).min(max_index);
+    Ok(HandlerOutcome::Stay)
+}
+
+/// Handle MenuJumpToFirst message (gg)
+///
+/// Jumps to first menu item.
+pub fn handle_menu_jump_to_first(data: &mut MenuData) -> Result<HandlerOutcome, UserError> {
+    data.selected_item = 0;
+    Ok(HandlerOutcome::Stay)
+}
+
+/// Handle MenuJumpToLast message (G)
+///
+/// Jumps to last menu item.
+pub fn handle_menu_jump_to_last(
+    data: &mut MenuData,
+    ctx: &HandlerContext<'_>,
+) -> Result<HandlerOutcome, UserError> {
+    let max_items = ctx.game.scenario_collection.count() + 4;
+    data.selected_item = max_items.saturating_sub(1);
+    Ok(HandlerOutcome::Stay)
+}
+
+/// Handle MenuJumpTo message ({n}G or {n}gg)
+///
+/// Jumps to specific menu item (1-indexed like Helix line numbers).
+pub fn handle_menu_jump_to(
+    data: &mut MenuData,
+    ctx: &HandlerContext<'_>,
+    line: usize,
+) -> Result<HandlerOutcome, UserError> {
+    let max_items = ctx.game.scenario_collection.count() + 4;
+    // Convert 1-indexed to 0-indexed, clamping to valid range
+    let target = line.saturating_sub(1).min(max_items.saturating_sub(1));
+    data.selected_item = target;
+    Ok(HandlerOutcome::Stay)
+}
+
 /// Handle MenuSelect message
 ///
 /// Executes action based on currently selected menu item.

--- a/src/ui/state/mod.rs
+++ b/src/ui/state/mod.rs
@@ -162,6 +162,21 @@ pub enum Message {
     /// Menu navigation: move selection down
     MenuDown,
 
+    /// Menu navigation: move up by N items
+    MenuUpBy(usize),
+
+    /// Menu navigation: move down by N items
+    MenuDownBy(usize),
+
+    /// Menu navigation: jump to first item (gg)
+    MenuJumpToFirst,
+
+    /// Menu navigation: jump to last item (G)
+    MenuJumpToLast,
+
+    /// Menu navigation: jump to item N (1-indexed, like Helix)
+    MenuJumpTo(usize),
+
     /// Menu action: select current menu item
     MenuSelect,
 
@@ -544,16 +559,37 @@ pub fn update(state: &mut AppState, msg: Message) -> Result<(), UserError> {
         Message::MenuDown => {
             extract_screen!(state, Menu, mut data, ctx => handlers::handle_menu_down(data, &ctx))
         }
+        Message::MenuUpBy(count) => {
+            extract_screen!(state, Menu, data => handlers::menu::handle_menu_up_by(data, count))
+        }
+        Message::MenuDownBy(count) => {
+            extract_screen!(state, Menu, mut data, ctx => handlers::menu::handle_menu_down_by(data, &ctx, count))
+        }
+        Message::MenuJumpToFirst => {
+            extract_screen!(state, Menu, data => handlers::menu::handle_menu_jump_to_first(data))
+        }
+        Message::MenuJumpToLast => {
+            extract_screen!(state, Menu, mut data, ctx => handlers::menu::handle_menu_jump_to_last(data, &ctx))
+        }
+        Message::MenuJumpTo(line) => {
+            extract_screen!(state, Menu, mut data, ctx => handlers::menu::handle_menu_jump_to(data, &ctx, line))
+        }
         Message::MenuSelect => {
-            let (selected_item, scroll_offset) = if let TypedScreen::Menu(ref data) = state.screen {
-                (data.selected_item, data.scroll_offset)
-            } else {
-                return Err(UserError::invalid_state("Expected Menu screen"));
-            };
+            let (selected_item, scroll_offset, command_buffer) =
+                if let TypedScreen::Menu(ref data) = state.screen {
+                    (
+                        data.selected_item,
+                        data.scroll_offset,
+                        data.command_buffer.clone(),
+                    )
+                } else {
+                    return Err(UserError::invalid_state("Expected Menu screen"));
+                };
 
             let menu_data = MenuData {
                 selected_item,
                 scroll_offset,
+                command_buffer,
             };
             let outcome = handlers::menu::handle_menu_select(&menu_data, state)?;
             apply_outcome(state, outcome);

--- a/src/ui/state/screen.rs
+++ b/src/ui/state/screen.rs
@@ -78,6 +78,19 @@ pub struct MenuData {
 
     /// Scroll offset for menu list (top visible item index)
     pub scroll_offset: usize,
+
+    /// Command buffer for multi-key navigation (e.g., "g" waiting for "g", count prefix "12")
+    pub command_buffer: String,
+}
+
+impl CommandBufferAccess for MenuData {
+    fn command_buffer(&self) -> &str {
+        &self.command_buffer
+    }
+
+    fn command_buffer_mut(&mut self) -> &mut String {
+        &mut self.command_buffer
+    }
 }
 
 /// Data required for task screen (contains active session)


### PR DESCRIPTION
Closes #69

## Summary

Implement Helix-style navigation for menu screens, allowing users to practice Helix keybindings even while navigating the app.

## Features

### Basic Movement
- `j` - Move down one item (same as ↓)
- `k` - Move up one item (same as ↑)

### Count Prefix Support
- `5j` - Move down 5 items
- `10k` - Move up 10 items
- `3j` - Move down 3 items

### Jump Commands
- `gg` - Jump to first item
- `G` - Jump to last item
- `15G` or `15gg` - Jump to item 15

## Changes

- **MenuData**: Added `command_buffer` for multi-key command tracking
- **Message enum**: Added `MenuUpBy(n)`, `MenuDownBy(n)`, `MenuJumpToFirst`, `MenuJumpToLast`, `MenuJumpTo(n)`
- **handlers/menu.rs**: Added handler functions for new messages
- **input/handlers.rs**: Complete rewrite of `handle_menu_keys` with command buffer parsing
- **locales/en.toml**: Updated instructions to show new keybindings

## Accessibility

Arrow keys and Enter still work for users who prefer them.

## Testing

- Added 8 new unit tests for menu navigation
- All 741 tests pass
- Zero clippy warnings

## Acceptance Criteria

- [x] `j`/`k` navigation works in all menus
- [x] Count prefixes work (e.g., `5j`, `10k`)
- [x] `gg` jumps to first item
- [x] `G` jumps to last item
- [x] `{n}G` or `{n}gg` jumps to item N
- [x] Arrow keys still work
- [x] Visual indicator shows position (e.g., "Item 15 of 86") - already existed