### PR TITLE
fix: count prefix commands (3w) count as 1 action instead of N

### DIFF
--- a/src/game/session/mod.rs
+++ b/src/game/session/mod.rs
@@ -499,6 +499,60 @@ impl GameSession<Active> {
         }
     }
 
+    /// Record a user action with count prefix (e.g., "3w" executes "w" 3 times)
+    ///
+    /// This method executes the base command `count` times through the simulator,
+    /// but records only ONE action in the history with the full command string.
+    /// This ensures that "3w" counts as 1 action, not 3.
+    ///
+    /// # Arguments
+    /// * `full_command` - The full command string (e.g., "3w")
+    /// * `base_command` - The base command to execute (e.g., "w")
+    /// * `count` - How many times to execute the base command
+    ///
+    /// # Errors
+    ///
+    /// Returns error if action count exceeds limits or command execution fails.
+    pub fn record_action_with_count(
+        mut self,
+        full_command: String,
+        base_command: &str,
+        count: usize,
+    ) -> Result<SessionAfterAction, UserError> {
+        // Validate action count doesn't exceed limits
+        security::arithmetic::validate_action_count(self.user_actions.len() + 1)
+            .map_err(UserError::from)?;
+
+        // Execute command `count` times through simulator
+        for _ in 0..count {
+            self.simulator.execute_command(base_command)?;
+
+            // Check completion after each execution
+            self.current_state = self.simulator.to_editor_state()?;
+            if self.check_completion() {
+                break;
+            }
+        }
+
+        // Sync current state with simulator (final state)
+        self.current_state = self.simulator.to_editor_state()?;
+
+        // Invalidate progress cache since state changed
+        self.progress_needs_update.set(true);
+
+        // Record ONE action in history with the full command
+        let elapsed = self.elapsed();
+        let action = UserAction::new(full_command, elapsed);
+        self.user_actions.push(action);
+
+        // Check if scenario is completed and return appropriate state
+        if self.check_completion() {
+            Ok(SessionAfterAction::Completed(self.into_completed()))
+        } else {
+            Ok(SessionAfterAction::StillActive(self))
+        }
+    }
+
     /// Transition to completed state (private helper)
     fn into_completed(self) -> GameSession<Completed> {
         GameSession {

--- a/src/ui/state/handlers/gameplay.rs
+++ b/src/ui/state/handlers/gameplay.rs
@@ -174,38 +174,9 @@ pub fn handle_execute_command(
                     crate::game::GameSession::new(scenario)?,
                 );
 
-                // Execute command `count` times using Option to track session state
-                let mut current_session = Some(session);
-
-                for _ in 0..count {
-                    if let Some(s) = current_session.take() {
-                        let result = s.record_action(base_cmd.to_string())?;
-                        match result {
-                            crate::game::SessionAfterAction::Completed(completed) => {
-                                // Session completed - process and break
-                                let completed_result =
-                                    crate::game::SessionAfterAction::Completed(completed);
-                                session_completed = process_session_result(
-                                    completed_result,
-                                    &mut task_data,
-                                    state,
-                                )?;
-                                // Leave current_session as None to signal completion
-                                break;
-                            }
-                            crate::game::SessionAfterAction::StillActive(active) => {
-                                current_session = Some(active);
-                            }
-                        }
-                    }
-                }
-
-                // If not completed during loop, finalize the session state
-                if let Some(remaining_session) = current_session {
-                    let final_result =
-                        crate::game::SessionAfterAction::StillActive(remaining_session);
-                    process_session_result(final_result, &mut task_data, state)?;
-                }
+                // Execute command with count - records as ONE action
+                let result = session.record_action_with_count(cmd.clone(), base_cmd, count)?;
+                session_completed = process_session_result(result, &mut task_data, state)?;
 
                 // Always restore Task screen - even when completed, we show success popup
                 state.screen = TypedScreen::Task(task_data);


### PR DESCRIPTION
## Summary

- Added `record_action_with_count` method to `GameSession` that executes base command N times but records only ONE action in history
- Updated `handle_execute_command` in gameplay handler to use the new method
- Commands like `3w` now correctly count as 1 action for scoring, not 3 separate actions

## Problem

When using count prefix commands like `3w` (move 3 words), the scoring system was counting each individual execution as a separate action, resulting in 3 actions instead of 1. This caused incorrect scores in scenarios where the optimal solution uses count prefixes.

## Solution

The `record_action_with_count` method:
1. Validates action count limits
2. Executes the base command `count` times through the simulator
3. Records only ONE action with the full command string (e.g., "3w")
4. Properly handles early completion if target is reached before all repetitions

## Test plan

- [x] All 741 tests pass
- [x] Zero clippy warnings
- [x] Scenario validation tests handle count prefixes correctly
- [x] Code formatted with nightly rustfmt