### PR TITLE
refactor: standardize error handling (Phase 3)

### DIFF
--- a/src/helix/simulator/mod.rs
+++ b/src/helix/simulator/mod.rs
@@ -124,9 +124,8 @@ impl<M: EditorMode> HelixSimulator<M> {
             };
 
             Some(crate::game::Selection::new(
-                CursorPosition::new(start_line, start_col)
-                    .map_err(|_| UserError::OperationFailed)?,
-                CursorPosition::new(end_line, end_col).map_err(|_| UserError::OperationFailed)?,
+                CursorPosition::new(start_line, start_col).map_err(UserError::from)?,
+                CursorPosition::new(end_line, end_col).map_err(UserError::from)?,
             ))
         } else {
             None
@@ -134,10 +133,10 @@ impl<M: EditorMode> HelixSimulator<M> {
 
         EditorState::new(
             self.doc.to_string(),
-            CursorPosition::new(line, col).map_err(|_| UserError::OperationFailed)?,
+            CursorPosition::new(line, col).map_err(UserError::from)?,
             selection,
         )
-        .map_err(|_| UserError::OperationFailed)
+        .map_err(UserError::from)
     }
 
     /// Convert simulator state to EditorState (alias for get_state)

--- a/src/security.rs
+++ b/src/security.rs
@@ -132,10 +132,8 @@ impl UserError {
 
 impl From<SecurityError> for UserError {
     fn from(err: SecurityError) -> Self {
-        // Log the detailed error internally
         tracing::error!("Security error occurred: {:?}", err);
 
-        // Return sanitized error to user
         match err {
             SecurityError::PathTraversal
             | SecurityError::InvalidPath
@@ -155,6 +153,38 @@ impl From<SecurityError> for UserError {
             SecurityError::InvalidState(msg) => UserError::InvalidState { message: msg },
 
             _ => UserError::OperationFailed,
+        }
+    }
+}
+
+impl From<crate::gamification::GamificationError> for UserError {
+    fn from(err: crate::gamification::GamificationError) -> Self {
+        use crate::gamification::GamificationError;
+        tracing::error!("Gamification error occurred: {:?}", err);
+
+        match err {
+            GamificationError::StorageError(_) => UserError::OperationFailed,
+            GamificationError::QuestNotFound(_) => UserError::OperationFailed,
+            GamificationError::InvalidLevel(_) => UserError::invalid_state("Invalid level"),
+            GamificationError::StreakFreezeUnavailable => UserError::OperationFailed,
+            GamificationError::AchievementAlreadyUnlocked(_) => UserError::OperationFailed,
+        }
+    }
+}
+
+impl From<crate::learning::LearningError> for UserError {
+    fn from(err: crate::learning::LearningError) -> Self {
+        use crate::learning::LearningError;
+        tracing::error!("Learning error occurred: {:?}", err);
+
+        match err {
+            LearningError::InvalidStability(_) | LearningError::InvalidDifficulty(_) => {
+                UserError::invalid_state("Invalid learning parameters")
+            }
+            LearningError::CommandNotFound(_) => {
+                UserError::command_failed("Command not found in registry")
+            }
+            LearningError::FsrsError(_) => UserError::OperationFailed,
         }
     }
 }

--- a/src/ui/state/handlers/gameplay.rs
+++ b/src/ui/state/handlers/gameplay.rs
@@ -24,7 +24,7 @@ fn process_session_result(
             Ok(false)
         }
         SessionAfterAction::Completed(s) => {
-            let feedback = s.feedback().map_err(|_| UserError::OperationFailed)?;
+            let feedback = s.feedback().map_err(UserError::from)?;
             state.ui.last_feedback = Some(feedback.clone());
             // Start success animation - keep Task screen, just mark completion time
             // The event loop will transition to Results after 1.5s delay

--- a/src/ui/state/handlers/profile.rs
+++ b/src/ui/state/handlers/profile.rs
@@ -57,7 +57,7 @@ pub fn handle_award_xp(ctx: &mut HandlerContext<'_>, amount: u64) -> Result<(), 
         ctx.progress
             .storage
             .save(&ctx.progress.profile)
-            .map_err(|_| UserError::OperationFailed)?;
+            .map_err(UserError::from)?;
         ctx.progress.mark_saved();
     }
     Ok(())

--- a/src/ui/state/handlers/scenario.rs
+++ b/src/ui/state/handlers/scenario.rs
@@ -109,12 +109,11 @@ fn record_scenario_completion(
         profile.perfect_scenarios += 1;
     }
 
-    // Save profile if leveled up
     if leveled_up {
         ctx.progress
             .storage
             .save(&ctx.progress.profile)
-            .map_err(|_| UserError::OperationFailed)?;
+            .map_err(UserError::from)?;
         ctx.progress.mark_saved();
     }
 
@@ -125,7 +124,7 @@ fn record_scenario_completion(
         ctx.progress
             .storage
             .save(&ctx.progress.profile)
-            .map_err(|_| UserError::OperationFailed)?;
+            .map_err(UserError::from)?;
         ctx.progress.mark_saved();
     }
 
@@ -158,11 +157,9 @@ pub fn handle_complete_scenario(state: &mut AppState) -> Result<HandlerOutcome, 
         let session = state.game.pending_completed_session.take();
         (feedback.clone(), session)
     } else {
-        // No feedback available, transition to results anyway with placeholder
         let results_data = if let Some(session) = state.game.pending_completed_session.take() {
-            let feedback = session.feedback().map_err(|_| UserError::OperationFailed)?;
-            ResultsData::from_completed(session, feedback)
-                .map_err(|_| UserError::OperationFailed)?
+            let feedback = session.feedback().map_err(UserError::from)?;
+            ResultsData::from_completed(session, feedback).map_err(UserError::from)?
         } else {
             // No session either, just go to menu
             return Ok(HandlerOutcome::Transition(Box::new(TypedScreen::Menu(
@@ -209,10 +206,11 @@ pub fn handle_complete_scenario(state: &mut AppState) -> Result<HandlerOutcome, 
             .scenario_history
             .record_completion(&scenario_id, feedback.score, total_base_xp);
 
-    // Get mastery info for UI display
-    let completion = profile.scenario_history.get(&scenario_id).unwrap();
-    let mastery_level = completion.mastery_level;
-    let mastery_multiplier = completion.xp_multiplier();
+    let (mastery_level, mastery_multiplier) = profile
+        .scenario_history
+        .get(&scenario_id)
+        .map(|c| (c.mastery_level, c.xp_multiplier()))
+        .unwrap_or((crate::learning::ScenarioMastery::Learning, 1.0));
 
     // Store mastery info for results display
     ctx.ui.scenario_mastery = Some((mastery_level, mastery_multiplier));
@@ -245,8 +243,8 @@ pub fn handle_complete_scenario(state: &mut AppState) -> Result<HandlerOutcome, 
         ))));
     };
 
-    let mut results_data = ResultsData::from_completed(session, feedback.clone())
-        .map_err(|_| UserError::OperationFailed)?;
+    let mut results_data =
+        ResultsData::from_completed(session, feedback.clone()).map_err(UserError::from)?;
     // Populate with XP breakdown and quest changes
     results_data.xp_breakdown = ctx.ui.xp_breakdown.clone();
     results_data.quest_changes = ctx.ui.quest_progress_changes.clone();


### PR DESCRIPTION
## Summary

- Add `From<GamificationError>` and `From<LearningError>` for `UserError` with internal error logging
- Replace 11 occurrences of `.map_err(|_| UserError::OperationFailed)` with proper `.map_err(UserError::from)`
- Fix potential panic in scenario.rs by replacing `unwrap()` with safe fallback

## Changes

| File | Change |
|------|--------|
| `src/security.rs` | Add `From` implementations with `tracing::error!` logging |
| `src/helix/simulator/mod.rs` | Use proper error conversion (4 sites) |
| `src/ui/state/handlers/scenario.rs` | Fix unwrap + error handling (5 sites) |
| `src/ui/state/handlers/profile.rs` | Error handling (1 site) |
| `src/ui/state/handlers/gameplay.rs` | Error handling (1 site) |

## Review Results

- Performance review: APPROVED
- Security review: APPROVED (fixed unwrap issue)
- Code review: APPROVED
- All 746 tests pass
- Clippy clean

## Test plan

- [x] All tests pass (`cargo nextest run`)
- [x] No clippy warnings
- [x] Error paths log internally before returning user-facing errors