### PR TITLE
Phase 5: Migrate minigame handlers to HandlerContext pattern

### DIFF
--- a/src/ui/state/handlers/minigame.rs
+++ b/src/ui/state/handlers/minigame.rs
@@ -5,7 +5,10 @@ use crate::constants::{MINIGAME_SCENARIO_BASE_XP, MINIGAME_STREAK_XP_MULTIPLIER}
 use crate::game::format_key_for_display;
 use crate::minigame::MiniGameSession;
 use crate::security::UserError;
-use crate::ui::state::{AppState, GameState, MiniGameData, ModeSelectionData, TypedScreen};
+use crate::ui::state::{
+    AppState, GameState, HandlerContext, HandlerOutcome, MiniGameData, ModeSelectionData,
+    TypedScreen,
+};
 use std::sync::Arc;
 
 /// Create and start a new mini-game session from available scenarios
@@ -32,43 +35,45 @@ pub(in crate::ui::state) fn create_minigame_session(game: &mut GameState) -> boo
 }
 
 /// Handle starting a mini-game session
-pub(in crate::ui::state) fn handle_start_minigame(state: &mut AppState) -> Result<(), UserError> {
-    // Navigate to mini-game screen first (renderer will show error if no scenarios)
-    state.screen = TypedScreen::MiniGame(MiniGameData::default());
-
-    // Use shared session creation
-    create_minigame_session(&mut state.game);
-
-    Ok(())
+pub(in crate::ui::state) fn handle_start_minigame(
+    ctx: &mut HandlerContext<'_>,
+) -> Result<HandlerOutcome, UserError> {
+    create_minigame_session(ctx.game);
+    Ok(HandlerOutcome::Transition(Box::new(TypedScreen::MiniGame(
+        MiniGameData::default(),
+    ))))
 }
 
 /// Handle pausing mini-game
-pub(in crate::ui::state) fn handle_pause_minigame(state: &mut AppState) -> Result<(), UserError> {
-    if let Some(ref mut session) = state.game.minigame_session {
+pub(in crate::ui::state) fn handle_pause_minigame(
+    ctx: &mut HandlerContext<'_>,
+) -> Result<HandlerOutcome, UserError> {
+    if let Some(ref mut session) = ctx.game.minigame_session {
         session.pause();
     }
-    Ok(())
+    Ok(HandlerOutcome::Stay)
 }
 
 /// Handle resuming mini-game
-pub(in crate::ui::state) fn handle_resume_minigame(state: &mut AppState) -> Result<(), UserError> {
-    if let Some(ref mut session) = state.game.minigame_session {
+pub(in crate::ui::state) fn handle_resume_minigame(
+    ctx: &mut HandlerContext<'_>,
+) -> Result<HandlerOutcome, UserError> {
+    if let Some(ref mut session) = ctx.game.minigame_session {
         session.resume();
     }
-    Ok(())
+    Ok(HandlerOutcome::Stay)
 }
 
 /// Handle mini-game timer tick (100ms)
-///
-/// Checks for timeouts and updates countdown.
-pub(in crate::ui::state) fn handle_minigame_tick(state: &mut AppState) -> Result<(), UserError> {
-    if let Some(ref mut session) = state.game.minigame_session {
-        // Tick countdown if in countdown state
-        if session.state().is_countdown() {
-            session.tick_countdown();
-        }
+pub(in crate::ui::state) fn handle_minigame_tick(
+    ctx: &mut HandlerContext<'_>,
+) -> Result<HandlerOutcome, UserError> {
+    if let Some(ref mut session) = ctx.game.minigame_session
+        && session.state().is_countdown()
+    {
+        session.tick_countdown();
     }
-    Ok(())
+    Ok(HandlerOutcome::Stay)
 }
 
 /// Execute a command in the mini-game session
@@ -181,12 +186,8 @@ pub(in crate::ui::state) fn handle_minigame_timeout(state: &mut AppState) -> Res
     if let Some(ref mut session) = state.game.minigame_session {
         session.handle_timeout();
 
-        // Check if game is over
         if session.state().is_game_over() {
-            // Process game over (calculate XP, save progress)
             handle_minigame_game_over(state)?;
-            // Game over - stay on screen to show final score
-            // User must press a key to return to menu
         }
     }
     Ok(())
@@ -194,29 +195,24 @@ pub(in crate::ui::state) fn handle_minigame_timeout(state: &mut AppState) -> Res
 
 /// Handle scenario completion (user triggered)
 pub(in crate::ui::state) fn handle_minigame_scenario_complete(
-    state: &mut AppState,
-) -> Result<(), UserError> {
-    if let Some(ref mut session) = state.game.minigame_session {
+    ctx: &mut HandlerContext<'_>,
+) -> Result<HandlerOutcome, UserError> {
+    if let Some(ref mut session) = ctx.game.minigame_session {
         session.advance_to_next();
     }
-    Ok(())
+    Ok(HandlerOutcome::Stay)
 }
 
 /// Handle advancing to next scenario (after transition delay)
-///
-/// If scenario loading fails (e.g., empty queue), logs error but continues.
-/// This prevents crash when scenario pool is exhausted.
 pub(in crate::ui::state) fn handle_minigame_next_scenario(
-    state: &mut AppState,
-) -> Result<(), UserError> {
-    if let Some(ref mut session) = state.game.minigame_session
+    ctx: &mut HandlerContext<'_>,
+) -> Result<HandlerOutcome, UserError> {
+    if let Some(ref mut session) = ctx.game.minigame_session
         && let Err(e) = session.complete_transition()
     {
-        // Log error but don't crash - user can still see current state
         tracing::warn!("Failed to load next mini-game scenario: {:?}", e);
-        // The game will continue in its current state
     }
-    Ok(())
+    Ok(HandlerOutcome::Stay)
 }
 
 /// Handle game over - calculate XP, update profile, save progress
@@ -282,23 +278,16 @@ pub(in crate::ui::state) fn handle_minigame_game_over(
 }
 
 /// Handle returning to mode selection from mini-game
-///
-/// Awards XP for current progress before exiting.
 pub(in crate::ui::state) fn handle_minigame_back_to_menu(
     state: &mut AppState,
-) -> Result<(), UserError> {
-    // Award XP for progress before exiting (if session exists)
+) -> Result<HandlerOutcome, UserError> {
     if state.game.minigame_session.is_some() {
         handle_minigame_game_over(state)?;
     }
-
-    // Clear mini-game session
     state.game.minigame_session = None;
-
-    // Navigate to mode selection
-    state.screen = TypedScreen::ModeSelection(ModeSelectionData::default());
-
-    Ok(())
+    Ok(HandlerOutcome::Transition(Box::new(
+        TypedScreen::ModeSelection(ModeSelectionData::default()),
+    )))
 }
 
 #[cfg(test)]
@@ -363,16 +352,25 @@ mod tests {
         }
     }
 
+    fn start_minigame(state: &mut AppState) {
+        let mut ctx = HandlerContext::new(
+            &mut state.ui,
+            &mut state.game,
+            &mut state.progress,
+            &state.config,
+        );
+        let outcome = handle_start_minigame(&mut ctx).unwrap();
+        crate::ui::state::apply_outcome(state, outcome);
+    }
+
     #[test]
     fn test_start_minigame() {
         let mut state = create_test_state();
-
-        handle_start_minigame(&mut state).unwrap();
+        start_minigame(&mut state);
 
         assert!(state.game.minigame_session.is_some());
         assert!(matches!(state.screen, TypedScreen::MiniGame(_)));
 
-        // Session should be in countdown state
         if let Some(ref session) = state.game.minigame_session {
             assert!(session.state().is_countdown());
         }
@@ -383,31 +381,45 @@ mod tests {
         let mut state = create_test_state();
         state.game.scenario_collection = crate::config::ScenarioCollection::new(vec![]);
 
-        handle_start_minigame(&mut state).unwrap();
+        start_minigame(&mut state);
 
-        // Should not create session without scenarios
         assert!(state.game.minigame_session.is_none());
     }
 
     #[test]
     fn test_pause_resume_minigame() {
         let mut state = create_test_state();
-        handle_start_minigame(&mut state).unwrap();
+        start_minigame(&mut state);
 
-        // Transition to playing state
         if let Some(ref mut session) = state.game.minigame_session {
             session.tick_countdown();
             session.tick_countdown();
             session.tick_countdown();
         }
 
-        handle_pause_minigame(&mut state).unwrap();
+        {
+            let mut ctx = HandlerContext::new(
+                &mut state.ui,
+                &mut state.game,
+                &mut state.progress,
+                &state.config,
+            );
+            handle_pause_minigame(&mut ctx).unwrap();
+        }
 
         if let Some(ref session) = state.game.minigame_session {
             assert!(session.state().is_paused());
         }
 
-        handle_resume_minigame(&mut state).unwrap();
+        {
+            let mut ctx = HandlerContext::new(
+                &mut state.ui,
+                &mut state.game,
+                &mut state.progress,
+                &state.config,
+            );
+            handle_resume_minigame(&mut ctx).unwrap();
+        }
 
         if let Some(ref session) = state.game.minigame_session {
             assert!(session.state().is_playing());
@@ -417,11 +429,12 @@ mod tests {
     #[test]
     fn test_minigame_back_to_menu() {
         let mut state = create_test_state();
-        handle_start_minigame(&mut state).unwrap();
+        start_minigame(&mut state);
 
         assert!(state.game.minigame_session.is_some());
 
-        handle_minigame_back_to_menu(&mut state).unwrap();
+        let outcome = handle_minigame_back_to_menu(&mut state).unwrap();
+        crate::ui::state::apply_outcome(&mut state, outcome);
 
         assert!(state.game.minigame_session.is_none());
         assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
@@ -430,14 +443,21 @@ mod tests {
     #[test]
     fn test_minigame_tick_countdown() {
         let mut state = create_test_state();
-        handle_start_minigame(&mut state).unwrap();
+        start_minigame(&mut state);
 
-        // Should be in countdown with 3 remaining
         if let Some(ref session) = state.game.minigame_session {
             assert_eq!(session.state().countdown_remaining(), Some(3));
         }
 
-        handle_minigame_tick(&mut state).unwrap();
+        {
+            let mut ctx = HandlerContext::new(
+                &mut state.ui,
+                &mut state.game,
+                &mut state.progress,
+                &state.config,
+            );
+            handle_minigame_tick(&mut ctx).unwrap();
+        }
 
         if let Some(ref session) = state.game.minigame_session {
             assert_eq!(session.state().countdown_remaining(), Some(2));
@@ -449,7 +469,7 @@ mod tests {
         use crate::gamification::XPCalculator;
 
         let mut state = create_test_state();
-        handle_start_minigame(&mut state).unwrap();
+        start_minigame(&mut state);
 
         // Transition to playing state
         if let Some(ref mut session) = state.game.minigame_session {
@@ -481,7 +501,7 @@ mod tests {
     #[test]
     fn test_minigame_updates_high_score() {
         let mut state = create_test_state();
-        handle_start_minigame(&mut state).unwrap();
+        start_minigame(&mut state);
 
         // Set initial high score
         state.progress.profile.minigame_high_score = 1000;
@@ -569,7 +589,7 @@ mod tests {
     #[test]
     fn test_minigame_timeout_to_game_over() {
         let mut state = create_test_state();
-        handle_start_minigame(&mut state).unwrap();
+        start_minigame(&mut state);
 
         // Transition to playing state
         if let Some(ref mut session) = state.game.minigame_session {
@@ -618,7 +638,7 @@ mod tests {
         use ratatui::{Terminal, backend::TestBackend};
 
         let mut state = create_test_state();
-        handle_start_minigame(&mut state).unwrap();
+        start_minigame(&mut state);
 
         // Progress to playing
         if let Some(ref mut session) = state.game.minigame_session {
@@ -654,7 +674,7 @@ mod tests {
         // Test that game over handler doesn't return error even if save fails
         // (uses test storage that doesn't actually persist, so save succeeds)
         let mut state = create_test_state();
-        handle_start_minigame(&mut state).unwrap();
+        start_minigame(&mut state);
 
         // Progress to playing
         if let Some(ref mut session) = state.game.minigame_session {

--- a/src/ui/state/handlers/profile.rs
+++ b/src/ui/state/handlers/profile.rs
@@ -128,6 +128,17 @@ mod tests {
         }
     }
 
+    fn start_minigame(state: &mut AppState) {
+        let mut ctx = HandlerContext::new(
+            &mut state.ui,
+            &mut state.game,
+            &mut state.progress,
+            &state.config,
+        );
+        let outcome = handle_start_minigame(&mut ctx).unwrap();
+        crate::ui::state::apply_outcome(state, outcome);
+    }
+
     #[test]
     fn test_show_profile_from_menu() {
         let mut state = create_test_state();
@@ -179,7 +190,7 @@ mod tests {
         let mut state = create_test_state();
 
         // Start minigame properly
-        handle_start_minigame(&mut state).unwrap();
+        start_minigame(&mut state);
 
         // Transition to playing then pause
         if let Some(ref mut session) = state.game.minigame_session {
@@ -215,7 +226,7 @@ mod tests {
         let mut state = create_test_state();
 
         // Start minigame properly
-        handle_start_minigame(&mut state).unwrap();
+        start_minigame(&mut state);
 
         // Transition to playing then pause
         if let Some(ref mut session) = state.game.minigame_session {
@@ -248,7 +259,7 @@ mod tests {
         let mut state = create_test_state();
 
         // Start minigame properly
-        handle_start_minigame(&mut state).unwrap();
+        start_minigame(&mut state);
 
         // Transition to playing but don't pause
         if let Some(ref mut session) = state.game.minigame_session {

--- a/src/ui/state/mod.rs
+++ b/src/ui/state/mod.rs
@@ -14,7 +14,7 @@
 //!
 //! This ensures:
 //! - All state changes go through the update function
-//! - No hixen side effects in state changes
+//! - No hidden side effects in state changes
 //! - State transitions are testable and reproducible
 //! - UI rendering is pure (no side effects)
 
@@ -536,17 +536,81 @@ pub fn update(state: &mut AppState, msg: Message) -> Result<(), UserError> {
             apply_outcome(state, outcome);
             Ok(())
         }
-        Message::StartMiniGame => handlers::handle_start_minigame(state),
+        Message::StartMiniGame => {
+            let mut ctx = HandlerContext::new(
+                &mut state.ui,
+                &mut state.game,
+                &mut state.progress,
+                &state.config,
+            );
+            let outcome = handlers::handle_start_minigame(&mut ctx)?;
+            apply_outcome(state, outcome);
+            Ok(())
+        }
 
-        // Mini-game messages (not refactored yet)
-        Message::PauseMiniGame => handlers::handle_pause_minigame(state),
-        Message::ResumeMiniGame => handlers::handle_resume_minigame(state),
-        Message::MiniGameTick => handlers::handle_minigame_tick(state),
+        // Mini-game messages
+        Message::PauseMiniGame => {
+            let mut ctx = HandlerContext::new(
+                &mut state.ui,
+                &mut state.game,
+                &mut state.progress,
+                &state.config,
+            );
+            let outcome = handlers::handle_pause_minigame(&mut ctx)?;
+            apply_outcome(state, outcome);
+            Ok(())
+        }
+        Message::ResumeMiniGame => {
+            let mut ctx = HandlerContext::new(
+                &mut state.ui,
+                &mut state.game,
+                &mut state.progress,
+                &state.config,
+            );
+            let outcome = handlers::handle_resume_minigame(&mut ctx)?;
+            apply_outcome(state, outcome);
+            Ok(())
+        }
+        Message::MiniGameTick => {
+            let mut ctx = HandlerContext::new(
+                &mut state.ui,
+                &mut state.game,
+                &mut state.progress,
+                &state.config,
+            );
+            let outcome = handlers::handle_minigame_tick(&mut ctx)?;
+            apply_outcome(state, outcome);
+            Ok(())
+        }
         Message::MiniGameCommand(command) => handlers::handle_minigame_command(state, command),
         Message::MiniGameTimeout => handlers::handle_minigame_timeout(state),
-        Message::MiniGameScenarioComplete => handlers::handle_minigame_scenario_complete(state),
-        Message::MiniGameNextScenario => handlers::handle_minigame_next_scenario(state),
-        Message::MiniGameBackToMenu => handlers::handle_minigame_back_to_menu(state),
+        Message::MiniGameScenarioComplete => {
+            let mut ctx = HandlerContext::new(
+                &mut state.ui,
+                &mut state.game,
+                &mut state.progress,
+                &state.config,
+            );
+            let outcome = handlers::handle_minigame_scenario_complete(&mut ctx)?;
+            apply_outcome(state, outcome);
+            Ok(())
+        }
+        Message::MiniGameNextScenario => {
+            let mut ctx = HandlerContext::new(
+                &mut state.ui,
+                &mut state.game,
+                &mut state.progress,
+                &state.config,
+            );
+            let outcome = handlers::handle_minigame_next_scenario(&mut ctx)?;
+            apply_outcome(state, outcome);
+            Ok(())
+        }
+        Message::MiniGameBackToMenu => {
+            let outcome = handlers::handle_minigame_back_to_menu(state)?;
+            apply_outcome(state, outcome);
+            Ok(())
+        }
 
         // Menu messages
         Message::MenuUp => {


### PR DESCRIPTION
## Summary

- Migrate minigame handlers to HandlerContext + HandlerOutcome pattern (ADR-007)
- Refactor 7 handlers: start, pause, resume, tick, scenario_complete, next_scenario, back_to_menu
- Update dispatch code in mod.rs with new handler signatures
- Add test helper function in profile.rs
- Fix typo in mod.rs documentation

## Changes

### Migrated Handlers (minigame.rs)
- `handle_start_minigame` - now returns `Result<HandlerOutcome, UserError>`
- `handle_pause_minigame` - now returns `Result<HandlerOutcome, UserError>`
- `handle_resume_minigame` - now returns `Result<HandlerOutcome, UserError>`
- `handle_minigame_tick` - now returns `Result<HandlerOutcome, UserError>`
- `handle_minigame_scenario_complete` - now returns `Result<HandlerOutcome, UserError>`
- `handle_minigame_next_scenario` - now returns `Result<HandlerOutcome, UserError>`
- `handle_minigame_back_to_menu` - now returns `Result<HandlerOutcome, UserError>`

### Retained AppState Access
Handlers with complex cross-cutting concerns retain direct AppState access:
- `handle_minigame_command` - requires quest tracking via update()
- `handle_minigame_timeout` - requires quest tracking via update()
- `handle_minigame_game_over` - requires profile save and XP calculations

## Test plan

- [x] All 751 tests pass
- [x] Clippy passes with no warnings
- [x] Code formatted with nightly rustfmt
- [x] Performance review: EXCELLENT
- [x] Security review: APPROVED
- [x] Testing review: B- (coverage gaps noted but not blocking)
- [x] Code review: APPROVED