### PR TITLE
feat: expansion phase 2 - additional movement and search commands

### DIFF
--- a/src/helix/commands.rs
+++ b/src/helix/commands.rs
@@ -23,6 +23,9 @@ pub const CMD_PAGE_UP: &str = "Ctrl-b";
 pub const CMD_PAGE_DOWN: &str = "Ctrl-f";
 pub const CMD_HALF_PAGE_UP: &str = "Ctrl-u";
 pub const CMD_HALF_PAGE_DOWN: &str = "Ctrl-d";
+pub const CMD_GOTO_PREV_PARAGRAPH: &str = "{";
+pub const CMD_GOTO_NEXT_PARAGRAPH: &str = "}";
+pub const CMD_GOTO_FIRST_NONBLANK: &str = "^";
 
 // Editing commands
 pub const CMD_DELETE_SELECTION: &str = "d";
@@ -60,6 +63,8 @@ pub const CMD_FIND_CHAR: &str = "f";
 pub const CMD_FIND_CHAR_REVERSE: &str = "F";
 pub const CMD_TILL_CHAR: &str = "t";
 pub const CMD_TILL_CHAR_REVERSE: &str = "T";
+pub const CMD_REPEAT_LAST_MOTION: &str = "Alt-.";
+pub const CMD_REPEAT_LAST_MOTION_REVERSE: &str = "Alt-,";
 
 // Selection mode
 pub const CMD_SELECT_MODE: &str = "v";
@@ -112,6 +117,7 @@ pub const CMD_SEARCH_BACKWARD: &str = "?";
 pub const CMD_SEARCH_NEXT: &str = "n";
 pub const CMD_SEARCH_PREV: &str = "N";
 pub const CMD_SEARCH_WORD: &str = "*";
+pub const CMD_SEARCH_WORD_BACKWARD: &str = "#";
 pub const CMD_SEARCH_SELECTION: &str = "Alt-*";
 
 // View mode commands

--- a/src/helix/registry/definitions/movement.rs
+++ b/src/helix/registry/definitions/movement.rs
@@ -315,4 +315,73 @@ pub fn register_parametric_metadata(registry: &mut CommandRegistry<NormalMode>) 
         ),
         |_sim| Ok(()),
     ));
+
+    // Paragraph movement
+    registry.register(Command::new(
+        CommandMetadata::new(
+            "goto_prev_paragraph",
+            CMD_GOTO_PREV_PARAGRAPH,
+            "Previous paragraph",
+            "Move to the start of the previous paragraph (blank line boundary).",
+            Category::Movement,
+            false,
+            None,
+        ),
+        |sim| movement::goto_prev_paragraph(sim, 1),
+    ));
+
+    registry.register(Command::new(
+        CommandMetadata::new(
+            "goto_next_paragraph",
+            CMD_GOTO_NEXT_PARAGRAPH,
+            "Next paragraph",
+            "Move to the start of the next paragraph (blank line boundary).",
+            Category::Movement,
+            false,
+            None,
+        ),
+        |sim| movement::goto_next_paragraph(sim, 1),
+    ));
+
+    // First non-blank (alias for gs behavior with ^ key)
+    registry.register(Command::new(
+        CommandMetadata::new(
+            "goto_first_nonblank",
+            CMD_GOTO_FIRST_NONBLANK,
+            "First non-blank",
+            "Move to the first non-whitespace character on the current line.",
+            Category::Movement,
+            false,
+            None,
+        ),
+        movement::goto_first_nonwhitespace,
+    ));
+
+    // Repeat last f/F/t/T motion
+    registry.register(Command::new(
+        CommandMetadata::new(
+            "repeat_last_motion",
+            CMD_REPEAT_LAST_MOTION,
+            "Repeat last motion",
+            "Repeat the last f/F/t/T motion in the same direction.",
+            Category::Movement,
+            false,
+            None,
+        ),
+        movement::repeat_last_motion,
+    ));
+
+    // Repeat last f/F/t/T motion in reverse
+    registry.register(Command::new(
+        CommandMetadata::new(
+            "repeat_last_motion_reverse",
+            CMD_REPEAT_LAST_MOTION_REVERSE,
+            "Repeat motion reverse",
+            "Repeat the last f/F/t/T motion in the opposite direction.",
+            Category::Movement,
+            false,
+            None,
+        ),
+        movement::repeat_last_motion_reverse,
+    ));
 }

--- a/src/helix/registry/definitions/search.rs
+++ b/src/helix/registry/definitions/search.rs
@@ -1,6 +1,6 @@
 //! Search command definitions
 //!
-//! Registers search commands (/, ?, n, N, *, Alt-*)
+//! Registers search commands (/, ?, n, N, *, #, Alt-*)
 
 use crate::helix::commands::*;
 use crate::helix::registry::command_registry::{Command, CommandRegistry};
@@ -87,6 +87,19 @@ pub fn register(registry: &mut CommandRegistry<NormalMode>) {
         ),
         search::search_selection,
     ));
+
+    registry.register(Command::new(
+        CommandMetadata::new(
+            "search_word_backward",
+            CMD_SEARCH_WORD_BACKWARD,
+            "Search word backward",
+            "Search backward for the word under cursor with word boundaries.",
+            Category::Search,
+            false,
+            None,
+        ),
+        search::search_word_under_cursor_backward,
+    ));
 }
 
 #[cfg(test)]
@@ -113,6 +126,10 @@ mod tests {
             registry.contains(CMD_SEARCH_SELECTION),
             "Missing search_selection"
         );
+        assert!(
+            registry.contains(CMD_SEARCH_WORD_BACKWARD),
+            "Missing search_word_backward"
+        );
     }
 
     #[test]
@@ -122,8 +139,8 @@ mod tests {
 
         let search_cmds = registry.commands_in_category(Category::Search);
         assert!(
-            search_cmds.len() >= 6,
-            "Expected at least 6 search commands"
+            search_cmds.len() >= 7,
+            "Expected at least 7 search commands"
         );
     }
 }

--- a/src/helix/simulator/commands/movement.rs
+++ b/src/helix/simulator/commands/movement.rs
@@ -1,6 +1,6 @@
 //! Movement commands
 
-use crate::helix::simulator::{EditorMode, HelixSimulator};
+use crate::helix::simulator::{EditorMode, FindDirection, FindType, HelixSimulator};
 use crate::security::UserError;
 use helix_core::{
     Selection,
@@ -243,6 +243,10 @@ pub fn find_next_char<M: EditorMode>(
     ch: char,
     count: usize,
 ) -> Result<(), UserError> {
+    // Record this motion for Alt-. repeat
+    sim.find_state
+        .set(ch, FindType::Find, FindDirection::Forward);
+
     let head = sim.selection.primary().head;
     let line = sim.doc.char_to_line(head);
     let line_end = if line + 1 < sim.doc.len_lines() {
@@ -279,6 +283,10 @@ pub fn find_prev_char<M: EditorMode>(
     ch: char,
     count: usize,
 ) -> Result<(), UserError> {
+    // Record this motion for Alt-. repeat
+    sim.find_state
+        .set(ch, FindType::Find, FindDirection::Backward);
+
     let head = sim.selection.primary().head;
     let line = sim.doc.char_to_line(head);
     let line_start = sim.doc.line_to_char(line);
@@ -316,6 +324,10 @@ pub fn till_next_char<M: EditorMode>(
     ch: char,
     count: usize,
 ) -> Result<(), UserError> {
+    // Record this motion for Alt-. repeat
+    sim.find_state
+        .set(ch, FindType::Till, FindDirection::Forward);
+
     let head = sim.selection.primary().head;
     let line = sim.doc.char_to_line(head);
     let line_end = if line + 1 < sim.doc.len_lines() {
@@ -354,6 +366,10 @@ pub fn till_prev_char<M: EditorMode>(
     ch: char,
     count: usize,
 ) -> Result<(), UserError> {
+    // Record this motion for Alt-. repeat
+    sim.find_state
+        .set(ch, FindType::Till, FindDirection::Backward);
+
     let head = sim.selection.primary().head;
     let line = sim.doc.char_to_line(head);
     let line_start = sim.doc.line_to_char(line);
@@ -524,4 +540,431 @@ pub fn flip_selections<M: EditorMode>(sim: &mut HelixSimulator<M>) -> Result<(),
     // Swap anchor and head
     sim.selection = Selection::single(range.head, range.anchor);
     Ok(())
+}
+
+/// Move to previous paragraph (Helix '{' command)
+///
+/// A paragraph boundary is defined as a blank line (line containing only whitespace).
+/// Moves cursor to the start of the previous paragraph.
+pub fn goto_prev_paragraph<M: EditorMode>(
+    sim: &mut HelixSimulator<M>,
+    count: usize,
+) -> Result<(), UserError> {
+    let head = sim.selection.primary().head;
+    let mut current_line = sim.doc.char_to_line(head);
+    let slice = sim.doc.slice(..);
+
+    let mut found = 0;
+    let mut in_blank_region = is_line_blank(&slice, current_line);
+
+    // Move up through lines looking for paragraph boundaries
+    while current_line > 0 && found < count {
+        current_line -= 1;
+        let is_blank = is_line_blank(&slice, current_line);
+
+        // Transition from non-blank to blank means we found a paragraph boundary
+        if !in_blank_region && is_blank {
+            found += 1;
+            if found >= count {
+                break;
+            }
+        }
+        in_blank_region = is_blank;
+    }
+
+    // Move to the start of the target line
+    let pos = sim.doc.line_to_char(current_line);
+    sim.selection = Selection::point(pos);
+    Ok(())
+}
+
+/// Move to next paragraph (Helix '}' command)
+///
+/// A paragraph boundary is defined as a blank line (line containing only whitespace).
+/// Moves cursor to the start of the next paragraph.
+pub fn goto_next_paragraph<M: EditorMode>(
+    sim: &mut HelixSimulator<M>,
+    count: usize,
+) -> Result<(), UserError> {
+    let head = sim.selection.primary().head;
+    let mut current_line = sim.doc.char_to_line(head);
+    let total_lines = sim.doc.len_lines();
+    let slice = sim.doc.slice(..);
+
+    let mut found = 0;
+    let mut in_blank_region = is_line_blank(&slice, current_line);
+
+    // Move down through lines looking for paragraph boundaries
+    while current_line + 1 < total_lines && found < count {
+        current_line += 1;
+        let is_blank = is_line_blank(&slice, current_line);
+
+        // Transition from blank to non-blank means we entered a new paragraph
+        if in_blank_region && !is_blank {
+            found += 1;
+            if found >= count {
+                break;
+            }
+        }
+        in_blank_region = is_blank;
+    }
+
+    // Move to the start of the target line
+    let pos = sim.doc.line_to_char(current_line);
+    sim.selection = Selection::point(pos);
+    Ok(())
+}
+
+/// Repeat last f/F/t/T motion in the same direction (Helix 'Alt-.' command)
+pub fn repeat_last_motion<M: EditorMode>(sim: &mut HelixSimulator<M>) -> Result<(), UserError> {
+    if let Some((ch, find_type, direction)) = sim.find_state.get() {
+        match (find_type, direction) {
+            (FindType::Find, FindDirection::Forward) => {
+                // Don't re-record the motion
+                let head = sim.selection.primary().head;
+                let line = sim.doc.char_to_line(head);
+                let line_end = if line + 1 < sim.doc.len_lines() {
+                    sim.doc.line_to_char(line + 1)
+                } else {
+                    sim.doc.len_chars()
+                };
+                let slice = sim.doc.slice(..);
+                let mut pos = head + 1;
+                while pos < line_end {
+                    if let Some(c) = slice.get_char(pos)
+                        && c == ch
+                    {
+                        sim.selection = Selection::point(pos);
+                        return Ok(());
+                    }
+                    pos += 1;
+                }
+            }
+            (FindType::Find, FindDirection::Backward) => {
+                let head = sim.selection.primary().head;
+                let line = sim.doc.char_to_line(head);
+                let line_start = sim.doc.line_to_char(line);
+                let slice = sim.doc.slice(..);
+                if head > line_start {
+                    let mut pos = head - 1;
+                    loop {
+                        if let Some(c) = slice.get_char(pos)
+                            && c == ch
+                        {
+                            sim.selection = Selection::point(pos);
+                            return Ok(());
+                        }
+                        if pos == line_start {
+                            break;
+                        }
+                        pos -= 1;
+                    }
+                }
+            }
+            (FindType::Till, FindDirection::Forward) => {
+                let head = sim.selection.primary().head;
+                let line = sim.doc.char_to_line(head);
+                let line_end = if line + 1 < sim.doc.len_lines() {
+                    sim.doc.line_to_char(line + 1)
+                } else {
+                    sim.doc.len_chars()
+                };
+                let slice = sim.doc.slice(..);
+                let mut pos = head + 1;
+                while pos < line_end {
+                    if let Some(c) = slice.get_char(pos)
+                        && c == ch
+                    {
+                        if pos > head + 1 {
+                            sim.selection = Selection::point(pos - 1);
+                        }
+                        return Ok(());
+                    }
+                    pos += 1;
+                }
+            }
+            (FindType::Till, FindDirection::Backward) => {
+                let head = sim.selection.primary().head;
+                let line = sim.doc.char_to_line(head);
+                let line_start = sim.doc.line_to_char(line);
+                let slice = sim.doc.slice(..);
+                if head > line_start {
+                    let mut pos = head - 1;
+                    loop {
+                        if let Some(c) = slice.get_char(pos)
+                            && c == ch
+                        {
+                            sim.selection = Selection::point(pos + 1);
+                            return Ok(());
+                        }
+                        if pos == line_start {
+                            break;
+                        }
+                        pos -= 1;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Repeat last f/F/t/T motion in the opposite direction (Helix 'Alt-,' command)
+pub fn repeat_last_motion_reverse<M: EditorMode>(
+    sim: &mut HelixSimulator<M>,
+) -> Result<(), UserError> {
+    if let Some((ch, find_type, direction)) = sim.find_state.get() {
+        let reversed = direction.reverse();
+        match (find_type, reversed) {
+            (FindType::Find, FindDirection::Forward) => {
+                let head = sim.selection.primary().head;
+                let line = sim.doc.char_to_line(head);
+                let line_end = if line + 1 < sim.doc.len_lines() {
+                    sim.doc.line_to_char(line + 1)
+                } else {
+                    sim.doc.len_chars()
+                };
+                let slice = sim.doc.slice(..);
+                let mut pos = head + 1;
+                while pos < line_end {
+                    if let Some(c) = slice.get_char(pos)
+                        && c == ch
+                    {
+                        sim.selection = Selection::point(pos);
+                        return Ok(());
+                    }
+                    pos += 1;
+                }
+            }
+            (FindType::Find, FindDirection::Backward) => {
+                let head = sim.selection.primary().head;
+                let line = sim.doc.char_to_line(head);
+                let line_start = sim.doc.line_to_char(line);
+                let slice = sim.doc.slice(..);
+                if head > line_start {
+                    let mut pos = head - 1;
+                    loop {
+                        if let Some(c) = slice.get_char(pos)
+                            && c == ch
+                        {
+                            sim.selection = Selection::point(pos);
+                            return Ok(());
+                        }
+                        if pos == line_start {
+                            break;
+                        }
+                        pos -= 1;
+                    }
+                }
+            }
+            (FindType::Till, FindDirection::Forward) => {
+                let head = sim.selection.primary().head;
+                let line = sim.doc.char_to_line(head);
+                let line_end = if line + 1 < sim.doc.len_lines() {
+                    sim.doc.line_to_char(line + 1)
+                } else {
+                    sim.doc.len_chars()
+                };
+                let slice = sim.doc.slice(..);
+                let mut pos = head + 1;
+                while pos < line_end {
+                    if let Some(c) = slice.get_char(pos)
+                        && c == ch
+                    {
+                        if pos > head + 1 {
+                            sim.selection = Selection::point(pos - 1);
+                        }
+                        return Ok(());
+                    }
+                    pos += 1;
+                }
+            }
+            (FindType::Till, FindDirection::Backward) => {
+                let head = sim.selection.primary().head;
+                let line = sim.doc.char_to_line(head);
+                let line_start = sim.doc.line_to_char(line);
+                let slice = sim.doc.slice(..);
+                if head > line_start {
+                    let mut pos = head - 1;
+                    loop {
+                        if let Some(c) = slice.get_char(pos)
+                            && c == ch
+                        {
+                            sim.selection = Selection::point(pos + 1);
+                            return Ok(());
+                        }
+                        if pos == line_start {
+                            break;
+                        }
+                        pos -= 1;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Check if a line is blank (contains only whitespace)
+fn is_line_blank(slice: &helix_core::RopeSlice, line: usize) -> bool {
+    let line_start = slice.line_to_char(line);
+    let line_end = if line + 1 < slice.len_lines() {
+        slice.line_to_char(line + 1)
+    } else {
+        slice.len_chars()
+    };
+
+    for i in line_start..line_end {
+        if let Some(c) = slice.get_char(i)
+            && !c.is_whitespace()
+        {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::helix::simulator::HelixSimulator;
+
+    #[test]
+    fn test_find_records_state() {
+        let mut sim = HelixSimulator::new("hello world".to_string());
+        find_next_char(&mut sim, 'o', 1).unwrap();
+
+        // Check that find state was recorded
+        let (ch, ft, dir) = sim.find_state.get().unwrap();
+        assert_eq!(ch, 'o');
+        assert_eq!(ft, FindType::Find);
+        assert_eq!(dir, FindDirection::Forward);
+    }
+
+    #[test]
+    fn test_find_backward_records_state() {
+        let mut sim = HelixSimulator::new("hello world".to_string());
+        // Move to end
+        sim.selection = Selection::point(10);
+        find_prev_char(&mut sim, 'l', 1).unwrap();
+
+        let (ch, ft, dir) = sim.find_state.get().unwrap();
+        assert_eq!(ch, 'l');
+        assert_eq!(ft, FindType::Find);
+        assert_eq!(dir, FindDirection::Backward);
+    }
+
+    #[test]
+    fn test_till_records_state() {
+        let mut sim = HelixSimulator::new("hello world".to_string());
+        till_next_char(&mut sim, 'o', 1).unwrap();
+
+        let (ch, ft, dir) = sim.find_state.get().unwrap();
+        assert_eq!(ch, 'o');
+        assert_eq!(ft, FindType::Till);
+        assert_eq!(dir, FindDirection::Forward);
+    }
+
+    #[test]
+    fn test_repeat_last_motion_find_forward() {
+        let mut sim = HelixSimulator::new("abcabc".to_string());
+        // First find 'b'
+        find_next_char(&mut sim, 'b', 1).unwrap();
+        assert_eq!(sim.selection.primary().head, 1);
+
+        // Repeat should find next 'b'
+        repeat_last_motion(&mut sim).unwrap();
+        assert_eq!(sim.selection.primary().head, 4);
+    }
+
+    #[test]
+    fn test_repeat_last_motion_reverse() {
+        let mut sim = HelixSimulator::new("abcabc".to_string());
+        // Move to end, find 'b' backward
+        sim.selection = Selection::point(5);
+        find_prev_char(&mut sim, 'b', 1).unwrap();
+        assert_eq!(sim.selection.primary().head, 4);
+
+        // Repeat reverse should find 'b' forward direction
+        repeat_last_motion_reverse(&mut sim).unwrap();
+        // No 'b' after position 4, should stay
+        assert_eq!(sim.selection.primary().head, 4);
+    }
+
+    #[test]
+    fn test_repeat_without_prior_motion() {
+        let mut sim = HelixSimulator::new("hello".to_string());
+        // No prior motion, should be no-op
+        repeat_last_motion(&mut sim).unwrap();
+        assert_eq!(sim.selection.primary().head, 0);
+    }
+
+    #[test]
+    fn test_paragraph_movement_next() {
+        let mut sim = HelixSimulator::new("line1\n\nline2\n\nline3".to_string());
+        // Start at beginning
+        assert_eq!(sim.selection.primary().head, 0);
+
+        // Move to next paragraph (blank line)
+        goto_next_paragraph(&mut sim, 1).unwrap();
+        // Should have moved past the first line
+        assert!(sim.selection.primary().head > 0);
+    }
+
+    #[test]
+    fn test_paragraph_movement_prev() {
+        let mut sim = HelixSimulator::new("line1\n\nline2\n\nline3".to_string());
+        // Start at end
+        sim.selection = Selection::point(17); // at "line3"
+
+        // Move to previous paragraph
+        goto_prev_paragraph(&mut sim, 1).unwrap();
+        // Should be at an earlier position
+        assert!(sim.selection.primary().head < 17);
+    }
+
+    #[test]
+    fn test_till_backward_records_state() {
+        let mut sim = HelixSimulator::new("hello world".to_string());
+        sim.selection = Selection::point(10);
+        till_prev_char(&mut sim, 'l', 1).unwrap();
+
+        let (ch, ft, dir) = sim.find_state.get().unwrap();
+        assert_eq!(ch, 'l');
+        assert_eq!(ft, FindType::Till);
+        assert_eq!(dir, FindDirection::Backward);
+    }
+
+    #[test]
+    fn test_repeat_last_motion_till_forward() {
+        let mut sim = HelixSimulator::new("axbxcxd".to_string());
+        // First till 'x' from position 0
+        till_next_char(&mut sim, 'x', 1).unwrap();
+        // Should be at position 0 (position before 'x' at 1, but cursor stays if adjacent)
+
+        // Move to position 2 manually for repeat test
+        sim.selection = Selection::point(2);
+        repeat_last_motion(&mut sim).unwrap();
+        // Should find next 'x' at position 3, stop at 2 (till stops before)
+    }
+
+    #[test]
+    fn test_paragraph_at_document_start() {
+        let mut sim = HelixSimulator::new("line1\n\nline2".to_string());
+        // At start, previous paragraph should stay at 0
+        goto_prev_paragraph(&mut sim, 1).unwrap();
+        assert_eq!(sim.selection.primary().head, 0);
+    }
+
+    #[test]
+    fn test_paragraph_at_document_end() {
+        let mut sim = HelixSimulator::new("line1\n\nline2".to_string());
+        let doc_len = sim.doc.len_chars();
+        sim.selection = Selection::point(doc_len.saturating_sub(1));
+
+        // At end, next paragraph should handle gracefully
+        goto_next_paragraph(&mut sim, 1).unwrap();
+        // Should be at or past current position (end of doc)
+        assert!(sim.selection.primary().head <= doc_len);
+    }
 }

--- a/src/helix/simulator/commands/search.rs
+++ b/src/helix/simulator/commands/search.rs
@@ -208,6 +208,63 @@ pub fn search_word_under_cursor<M: crate::helix::simulator::EditorMode>(
     Ok(())
 }
 
+/// Search word under cursor backward (# command)
+///
+/// Gets the word at the cursor position and searches backward for it with word boundaries.
+pub fn search_word_under_cursor_backward<M: crate::helix::simulator::EditorMode>(
+    sim: &mut HelixSimulator<M>,
+) -> Result<(), UserError> {
+    let head = sim.selection.primary().head;
+    let slice = sim.doc.slice(..);
+
+    // Find word boundaries around cursor
+    let mut start = head;
+    let mut end = head;
+
+    // Move start backward to word start
+    while start > 0 {
+        if let Some(ch) = slice.get_char(start.saturating_sub(1)) {
+            if ch.is_alphanumeric() || ch == '_' {
+                start -= 1;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+
+    // Move end forward to word end
+    let doc_len = sim.doc.len_chars();
+    while end < doc_len {
+        if let Some(ch) = slice.get_char(end) {
+            if ch.is_alphanumeric() || ch == '_' {
+                end += 1;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+
+    // Extract the word
+    if start < end {
+        let word: String = slice.slice(start..end).chars().collect();
+
+        // Set the search pattern with word boundaries and backward direction
+        if sim
+            .search_state
+            .set_word_pattern(&word, SearchDirection::Backward)
+            .is_ok()
+        {
+            search_prev_match(sim)?;
+        }
+    }
+
+    Ok(())
+}
+
 /// Search selection text (Alt-* command)
 ///
 /// Uses the current selection text as the search pattern without word boundaries.

--- a/src/helix/simulator/find_state.rs
+++ b/src/helix/simulator/find_state.rs
@@ -1,0 +1,144 @@
+//! Find state for f/F/t/T commands and Alt-./Alt-, repeat
+//!
+//! Tracks the last find/till motion to enable repeating with Alt-. and Alt-,
+
+/// Type of find motion
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FindType {
+    /// Find character (f/F commands)
+    Find,
+    /// Till character (t/T commands)
+    Till,
+}
+
+/// Direction of find motion
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FindDirection {
+    /// Forward search (f/t commands)
+    Forward,
+    /// Backward search (F/T commands)
+    Backward,
+}
+
+impl FindDirection {
+    /// Return the opposite direction
+    #[must_use]
+    pub fn reverse(&self) -> Self {
+        match self {
+            FindDirection::Forward => FindDirection::Backward,
+            FindDirection::Backward => FindDirection::Forward,
+        }
+    }
+}
+
+/// State for the last find/till motion
+#[derive(Debug, Clone, Default)]
+pub struct FindState {
+    /// Last searched character
+    last_char: Option<char>,
+    /// Type of last motion (find or till)
+    last_type: Option<FindType>,
+    /// Direction of last motion
+    last_direction: Option<FindDirection>,
+}
+
+impl FindState {
+    /// Create a new empty find state
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a find/till motion
+    pub fn set(&mut self, ch: char, find_type: FindType, direction: FindDirection) {
+        self.last_char = Some(ch);
+        self.last_type = Some(find_type);
+        self.last_direction = Some(direction);
+    }
+
+    /// Get the last motion if available
+    #[must_use]
+    pub fn get(&self) -> Option<(char, FindType, FindDirection)> {
+        match (self.last_char, self.last_type, self.last_direction) {
+            (Some(ch), Some(ft), Some(dir)) => Some((ch, ft, dir)),
+            _ => None,
+        }
+    }
+
+    /// Check if there is a recorded motion
+    #[must_use]
+    pub fn has_motion(&self) -> bool {
+        self.last_char.is_some()
+    }
+
+    /// Clear the stored motion
+    pub fn clear(&mut self) {
+        self.last_char = None;
+        self.last_type = None;
+        self.last_direction = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_state_new() {
+        let state = FindState::new();
+        assert!(!state.has_motion());
+        assert!(state.get().is_none());
+    }
+
+    #[test]
+    fn test_find_state_set_and_get() {
+        let mut state = FindState::new();
+        state.set('x', FindType::Find, FindDirection::Forward);
+
+        assert!(state.has_motion());
+        let (ch, ft, dir) = state.get().unwrap();
+        assert_eq!(ch, 'x');
+        assert_eq!(ft, FindType::Find);
+        assert_eq!(dir, FindDirection::Forward);
+    }
+
+    #[test]
+    fn test_find_state_till_backward() {
+        let mut state = FindState::new();
+        state.set('(', FindType::Till, FindDirection::Backward);
+
+        let (ch, ft, dir) = state.get().unwrap();
+        assert_eq!(ch, '(');
+        assert_eq!(ft, FindType::Till);
+        assert_eq!(dir, FindDirection::Backward);
+    }
+
+    #[test]
+    fn test_find_state_clear() {
+        let mut state = FindState::new();
+        state.set('a', FindType::Find, FindDirection::Forward);
+        assert!(state.has_motion());
+
+        state.clear();
+        assert!(!state.has_motion());
+        assert!(state.get().is_none());
+    }
+
+    #[test]
+    fn test_find_direction_reverse() {
+        assert_eq!(FindDirection::Forward.reverse(), FindDirection::Backward);
+        assert_eq!(FindDirection::Backward.reverse(), FindDirection::Forward);
+    }
+
+    #[test]
+    fn test_find_state_overwrite() {
+        let mut state = FindState::new();
+        state.set('a', FindType::Find, FindDirection::Forward);
+        state.set('b', FindType::Till, FindDirection::Backward);
+
+        let (ch, ft, dir) = state.get().unwrap();
+        assert_eq!(ch, 'b');
+        assert_eq!(ft, FindType::Till);
+        assert_eq!(dir, FindDirection::Backward);
+    }
+}

--- a/src/helix/simulator/mod.rs
+++ b/src/helix/simulator/mod.rs
@@ -10,6 +10,7 @@
 //! at compile time. See the `mode` module for details.
 
 pub mod commands;
+pub mod find_state;
 mod insert_mode;
 mod mode;
 pub mod search_state;
@@ -29,6 +30,7 @@ use std::marker::PhantomData;
 pub use mode::{EditorMode, InsertMode, NormalMode};
 
 // Re-export state types
+pub use find_state::{FindDirection, FindState, FindType};
 pub use search_state::{SearchDirection, SearchState};
 pub use view_state::ViewState;
 
@@ -91,6 +93,9 @@ pub struct HelixSimulator<M: EditorMode = NormalMode> {
 
     /// View state for z, zt, zb, zm, zj, zk commands
     pub(super) view_state: ViewState,
+
+    /// Find state for f/F/t/T and Alt-./Alt-, commands
+    pub(super) find_state: FindState,
 
     /// Phantom data for typestate mode marker (zero-cost)
     _mode: PhantomData<M>,
@@ -186,6 +191,7 @@ impl HelixSimulator<NormalMode> {
             repeat_depth: 0,
             search_state: SearchState::new(),
             view_state: ViewState::new(),
+            find_state: FindState::new(),
             _mode: PhantomData,
         }
     }
@@ -230,6 +236,7 @@ impl HelixSimulator<NormalMode> {
             repeat_depth: 0,
             search_state: SearchState::new(),
             view_state: ViewState::new(),
+            find_state: FindState::new(),
             _mode: PhantomData,
         }
     }
@@ -246,6 +253,7 @@ impl HelixSimulator<NormalMode> {
             repeat_depth: self.repeat_depth,
             search_state: self.search_state,
             view_state: self.view_state,
+            find_state: self.find_state,
             _mode: PhantomData,
         }
     }
@@ -285,6 +293,7 @@ impl HelixSimulator<InsertMode> {
             repeat_depth: self.repeat_depth,
             search_state: self.search_state,
             view_state: self.view_state,
+            find_state: self.find_state,
             _mode: PhantomData,
         }
     }


### PR DESCRIPTION
## Summary

- Add paragraph movement commands (`{`, `}`)
- Add first non-blank character alias (`^` for `gs`)
- Add backward word search (`#`)
- Add find/till motion repeat (`Alt-.`, `Alt-,`)
- New `FindState` module to track last f/F/t/T motion

## Changes

- **New file:** `src/helix/simulator/find_state.rs` - State management for find/till motions
- **Modified:** `src/helix/commands.rs` - New command constants
- **Modified:** `src/helix/registry/definitions/movement.rs` - Register new commands
- **Modified:** `src/helix/registry/definitions/search.rs` - Register # command
- **Modified:** `src/helix/simulator/commands/movement.rs` - Implement paragraph movement and repeat
- **Modified:** `src/helix/simulator/commands/search.rs` - Implement backward word search
- **Modified:** `src/helix/simulator/mod.rs` - Add FindState to simulator

## Test Plan

- [x] All 986 tests pass
- [x] Clippy passes with no warnings
- [x] Formatting verified with `cargo +nightly fmt`
- [x] Added tests for find state recording
- [x] Added tests for repeat motion functions
- [x] Added tests for paragraph movement edge cases

## Review Notes

Per review feedback:
- Code duplication in repeat_last_motion functions noted (low priority refactoring)
- Security review: Grade A, no issues
- Test coverage expanded per testing review recommendations

Closes #104