### PR TITLE
feat(match-mode): implement surround commands (ms, md, mr)

### DIFF
--- a/src/helix/commands.rs
+++ b/src/helix/commands.rs
@@ -83,6 +83,11 @@ pub const CMD_FLIP_SELECTIONS: &str = "Alt-;";
 pub const CMD_MATCH_MODE: &str = "m";
 pub const CMD_MATCH_BRACKETS: &str = "mm";
 
+// Match mode surround commands (ms{char}, mr{from}{to}, md{char})
+pub const CMD_SURROUND_ADD_PREFIX: &str = "ms";
+pub const CMD_SURROUND_REPLACE_PREFIX: &str = "mr";
+pub const CMD_SURROUND_DELETE_PREFIX: &str = "md";
+
 // Goto mode (prefix for goto commands)
 pub const CMD_GOTO_MODE: &str = "g";
 pub const CMD_GOTO_LINE_START: &str = "gh";

--- a/src/helix/simulator/commands/editing.rs
+++ b/src/helix/simulator/commands/editing.rs
@@ -254,6 +254,204 @@ pub fn replace_with_yanked<M: EditorMode>(sim: &mut HelixSimulator<M>) -> Result
     Ok(())
 }
 
+/// Surround selection with character pair (Helix 'ms{char}' command)
+///
+/// Wraps the current selection with the specified character and its pair.
+/// For brackets, the opening/closing pairs are: (), [], {}, <>.
+/// For quotes, the same character is used on both sides.
+pub fn surround_selection<M: EditorMode>(
+    sim: &mut HelixSimulator<M>,
+    surround_char: char,
+) -> Result<(), UserError> {
+    let (open, close) = get_surround_pair(surround_char);
+
+    let range = sim.selection.primary();
+    let start = range.from();
+    let end = range.to();
+
+    // Insert closing bracket first (at higher position) to preserve start position
+    let close_str: String = close.into();
+    let open_str: String = open.into();
+
+    // Build the changes: insert open at start, close at end
+    let transaction = Transaction::change(
+        &sim.doc,
+        [(start, start, Some(open_str.into()))].into_iter(),
+    );
+    sim.apply_transaction(transaction);
+
+    // After inserting open char, positions shift by 1
+    let new_end = end + 1;
+    let transaction = Transaction::change(
+        &sim.doc,
+        [(new_end, new_end, Some(close_str.into()))].into_iter(),
+    );
+    sim.apply_transaction(transaction);
+
+    // Update selection to include the surrounded text (excluding delimiters)
+    sim.selection = Selection::single(start + 1, new_end);
+
+    Ok(())
+}
+
+/// Delete surrounding pair (Helix 'md{char}' command)
+///
+/// Removes the innermost pair of the specified character around the cursor.
+pub fn delete_surround<M: EditorMode>(
+    sim: &mut HelixSimulator<M>,
+    surround_char: char,
+) -> Result<(), UserError> {
+    let (open, close) = get_surround_pair(surround_char);
+    let head = sim.selection.primary().head;
+
+    // Find the surrounding pair around cursor
+    let Some((open_pos, close_pos)) = find_surrounding_pair(sim, head, open, close) else {
+        return Ok(()); // No surrounding pair found
+    };
+
+    // Delete close first (higher position) to preserve open position
+    let transaction = Transaction::change(&sim.doc, [(close_pos, close_pos + 1, None)].into_iter());
+    sim.apply_transaction(transaction);
+
+    // Delete open
+    let transaction = Transaction::change(&sim.doc, [(open_pos, open_pos + 1, None)].into_iter());
+    sim.apply_transaction(transaction);
+
+    // Adjust cursor position
+    let new_head = if head > close_pos {
+        head.saturating_sub(2)
+    } else if head > open_pos {
+        head.saturating_sub(1)
+    } else {
+        head
+    };
+    sim.selection = Selection::point(new_head.min(sim.doc.len_chars().saturating_sub(1)));
+
+    Ok(())
+}
+
+/// Replace surrounding pair (Helix 'mr{from}{to}' command)
+///
+/// Replaces the innermost pair of `from_char` with `to_char`.
+pub fn replace_surround<M: EditorMode>(
+    sim: &mut HelixSimulator<M>,
+    from_char: char,
+    to_char: char,
+) -> Result<(), UserError> {
+    let (from_open, from_close) = get_surround_pair(from_char);
+    let (to_open, to_close) = get_surround_pair(to_char);
+    let head = sim.selection.primary().head;
+
+    // Find the surrounding pair around cursor
+    let Some((open_pos, close_pos)) = find_surrounding_pair(sim, head, from_open, from_close)
+    else {
+        return Ok(()); // No surrounding pair found
+    };
+
+    // Replace close first to preserve open position
+    let close_str: String = to_close.into();
+    let transaction = Transaction::change(
+        &sim.doc,
+        [(close_pos, close_pos + 1, Some(close_str.into()))].into_iter(),
+    );
+    sim.apply_transaction(transaction);
+
+    // Replace open
+    let open_str: String = to_open.into();
+    let transaction = Transaction::change(
+        &sim.doc,
+        [(open_pos, open_pos + 1, Some(open_str.into()))].into_iter(),
+    );
+    sim.apply_transaction(transaction);
+
+    Ok(())
+}
+
+/// Get the opening and closing characters for a surround pair
+fn get_surround_pair(ch: char) -> (char, char) {
+    match ch {
+        '(' | ')' => ('(', ')'),
+        '[' | ']' => ('[', ']'),
+        '{' | '}' => ('{', '}'),
+        '<' | '>' => ('<', '>'),
+        // For quotes and other characters, use the same char on both sides
+        _ => (ch, ch),
+    }
+}
+
+/// Find the innermost surrounding pair around a position
+fn find_surrounding_pair<M: EditorMode>(
+    sim: &HelixSimulator<M>,
+    pos: usize,
+    open: char,
+    close: char,
+) -> Option<(usize, usize)> {
+    let slice = sim.doc.slice(..);
+    let len = sim.doc.len_chars();
+
+    // For same-char pairs (quotes), find nearest on each side
+    if open == close {
+        // Search backwards for opening quote
+        let mut open_pos = None;
+        for i in (0..pos).rev() {
+            if slice.char(i) == open {
+                open_pos = Some(i);
+                break;
+            }
+        }
+
+        // Search forwards for closing quote
+        let mut close_pos = None;
+        for i in pos..len {
+            if slice.char(i) == close && Some(i) != open_pos {
+                close_pos = Some(i);
+                break;
+            }
+        }
+
+        open_pos.and_then(|o| close_pos.map(|c| (o, c)))
+    } else {
+        // For bracket pairs, need to track nesting
+        let mut open_pos = None;
+        let mut depth = 0;
+
+        // Search backwards for matching open bracket
+        for i in (0..=pos).rev() {
+            let ch = slice.char(i);
+            if ch == close {
+                depth += 1;
+            } else if ch == open {
+                if depth == 0 {
+                    open_pos = Some(i);
+                    break;
+                }
+                depth -= 1;
+            }
+        }
+
+        let open_idx = open_pos?;
+
+        // Search forwards for matching close bracket
+        let mut close_pos = None;
+        depth = 0;
+
+        for i in open_idx + 1..len {
+            let ch = slice.char(i);
+            if ch == open {
+                depth += 1;
+            } else if ch == close {
+                if depth == 0 {
+                    close_pos = Some(i);
+                    break;
+                }
+                depth -= 1;
+            }
+        }
+
+        close_pos.map(|c| (open_idx, c))
+    }
+}
+
 /// Join lines in selection with space (Helix 'Alt-J' command)
 ///
 /// Like J but joins all selected lines and selects the inserted space.
@@ -369,5 +567,123 @@ mod tests {
 
         // No change for single line
         assert_eq!(sim.doc.to_string(), "single line");
+    }
+
+    // Surround command tests
+    #[test]
+    fn test_surround_selection_parens() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("hello world".to_string());
+        sim.selection = Selection::single(0, 5); // Select "hello"
+
+        surround_selection(&mut sim, '(').unwrap();
+
+        assert_eq!(sim.doc.to_string(), "(hello) world");
+    }
+
+    #[test]
+    fn test_surround_selection_brackets() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("hello world".to_string());
+        sim.selection = Selection::single(0, 5);
+
+        surround_selection(&mut sim, '[').unwrap();
+
+        assert_eq!(sim.doc.to_string(), "[hello] world");
+    }
+
+    #[test]
+    fn test_surround_selection_quotes() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("hello world".to_string());
+        sim.selection = Selection::single(0, 5);
+
+        surround_selection(&mut sim, '"').unwrap();
+
+        assert_eq!(sim.doc.to_string(), "\"hello\" world");
+    }
+
+    #[test]
+    fn test_delete_surround_parens() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("(hello) world".to_string());
+        sim.selection = Selection::point(3); // Cursor inside parens
+
+        delete_surround(&mut sim, '(').unwrap();
+
+        assert_eq!(sim.doc.to_string(), "hello world");
+    }
+
+    #[test]
+    fn test_delete_surround_brackets() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("[hello] world".to_string());
+        sim.selection = Selection::point(3);
+
+        delete_surround(&mut sim, '[').unwrap();
+
+        assert_eq!(sim.doc.to_string(), "hello world");
+    }
+
+    #[test]
+    fn test_delete_surround_quotes() {
+        let mut sim: HelixSimulator<NormalMode> =
+            HelixSimulator::new("\"hello\" world".to_string());
+        sim.selection = Selection::point(3);
+
+        delete_surround(&mut sim, '"').unwrap();
+
+        assert_eq!(sim.doc.to_string(), "hello world");
+    }
+
+    #[test]
+    fn test_delete_surround_nested() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("((inner))".to_string());
+        sim.selection = Selection::point(3); // Cursor on 'n'
+
+        delete_surround(&mut sim, '(').unwrap();
+
+        assert_eq!(sim.doc.to_string(), "(inner)");
+    }
+
+    #[test]
+    fn test_replace_surround_parens_to_brackets() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("(hello) world".to_string());
+        sim.selection = Selection::point(3);
+
+        replace_surround(&mut sim, '(', '[').unwrap();
+
+        assert_eq!(sim.doc.to_string(), "[hello] world");
+    }
+
+    #[test]
+    fn test_replace_surround_quotes_to_single() {
+        let mut sim: HelixSimulator<NormalMode> =
+            HelixSimulator::new("\"hello\" world".to_string());
+        sim.selection = Selection::point(3);
+
+        replace_surround(&mut sim, '"', '\'').unwrap();
+
+        assert_eq!(sim.doc.to_string(), "'hello' world");
+    }
+
+    #[test]
+    fn test_surround_pair_mapping() {
+        assert_eq!(get_surround_pair('('), ('(', ')'));
+        assert_eq!(get_surround_pair(')'), ('(', ')'));
+        assert_eq!(get_surround_pair('['), ('[', ']'));
+        assert_eq!(get_surround_pair(']'), ('[', ']'));
+        assert_eq!(get_surround_pair('{'), ('{', '}'));
+        assert_eq!(get_surround_pair('}'), ('{', '}'));
+        assert_eq!(get_surround_pair('<'), ('<', '>'));
+        assert_eq!(get_surround_pair('>'), ('<', '>'));
+        assert_eq!(get_surround_pair('"'), ('"', '"'));
+        assert_eq!(get_surround_pair('\''), ('\'', '\''));
+    }
+
+    #[test]
+    fn test_delete_surround_no_pair_found() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("hello world".to_string());
+        sim.selection = Selection::point(3);
+
+        // Should not error, just do nothing
+        delete_surround(&mut sim, '(').unwrap();
+
+        assert_eq!(sim.doc.to_string(), "hello world");
     }
 }

--- a/src/helix/simulator/commands/mod.rs
+++ b/src/helix/simulator/commands/mod.rs
@@ -79,6 +79,45 @@ fn cmd_to_key_events(cmd: &str) -> Vec<KeyEvent> {
         ];
     }
 
+    // Match mode surround commands (e.g., "ms(" -> m + s + '(', "md(" -> m + d + '(')
+    if cmd.starts_with("ms") && cmd.len() == 3 {
+        let ch = cmd.chars().nth(2).unwrap();
+        return vec![
+            KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE),
+        ];
+    }
+
+    if cmd.starts_with("md") && cmd.len() == 3 {
+        let ch = cmd.chars().nth(2).unwrap();
+        return vec![
+            KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE),
+        ];
+    }
+
+    // Match mode surround replace (e.g., "mr()" -> m + r + '(' + ')')
+    if cmd.starts_with("mr") && cmd.len() == 4 {
+        let from_ch = cmd.chars().nth(2).unwrap();
+        let to_ch = cmd.chars().nth(3).unwrap();
+        return vec![
+            KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char(from_ch), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char(to_ch), KeyModifiers::NONE),
+        ];
+    }
+
+    // Match mode match brackets (e.g., "mm" -> m + m)
+    if cmd == CMD_MATCH_BRACKETS {
+        return vec![
+            KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE),
+        ];
+    }
+
     // Alt-; for flip selections
     if cmd == CMD_FLIP_SELECTIONS {
         return vec![KeyEvent::new(KeyCode::Char(';'), KeyModifiers::ALT)];
@@ -221,6 +260,27 @@ pub(super) fn execute_normal_mode_command_internal(
                 // Not a parametric command, try registry below
             }
         }
+    }
+
+    // Special handling for surround commands (ms{char}, md{char})
+    if cmd.len() == 3 && cmd.starts_with("ms") {
+        let surround_char = cmd.chars().nth(2).unwrap();
+        editing::surround_selection(sim, surround_char)?;
+        return Ok(());
+    }
+
+    if cmd.len() == 3 && cmd.starts_with("md") {
+        let surround_char = cmd.chars().nth(2).unwrap();
+        editing::delete_surround(sim, surround_char)?;
+        return Ok(());
+    }
+
+    // Special handling for surround replace (mr{from}{to})
+    if cmd.len() == 4 && cmd.starts_with("mr") {
+        let from_char = cmd.chars().nth(2).unwrap();
+        let to_char = cmd.chars().nth(3).unwrap();
+        editing::replace_surround(sim, from_char, to_char)?;
+        return Ok(());
     }
 
     // Special cases that need manual handling

--- a/src/input/typestate.rs
+++ b/src/input/typestate.rs
@@ -75,6 +75,25 @@ pub struct ViewPending;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MatchPending;
 
+/// Waiting for character after 'ms' (surround add)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SurroundAddPending;
+
+/// Waiting for character after 'md' (surround delete)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SurroundDeletePending;
+
+/// Waiting for first character after 'mr' (surround replace from char)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SurroundReplaceFromPending;
+
+/// Waiting for second character after 'mr{from}' (surround replace to char)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SurroundReplaceToPending {
+    /// The character to replace from
+    pub from_char: char,
+}
+
 /// Waiting for character after 'f'/'F'/'t'/'T' (find/till commands)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FindCharPending {
@@ -130,6 +149,10 @@ impl private::Sealed for BaseState {}
 impl private::Sealed for GotoPending {}
 impl private::Sealed for ViewPending {}
 impl private::Sealed for MatchPending {}
+impl private::Sealed for SurroundAddPending {}
+impl private::Sealed for SurroundDeletePending {}
+impl private::Sealed for SurroundReplaceFromPending {}
+impl private::Sealed for SurroundReplaceToPending {}
 impl private::Sealed for FindCharPending {}
 impl private::Sealed for ReplaceCharPending {}
 impl private::Sealed for CountPending {}
@@ -163,6 +186,30 @@ impl HandlerState for ViewPending {
 impl HandlerState for MatchPending {
     fn state_name() -> &'static str {
         "MATCH_PENDING"
+    }
+}
+
+impl HandlerState for SurroundAddPending {
+    fn state_name() -> &'static str {
+        "SURROUND_ADD_PENDING"
+    }
+}
+
+impl HandlerState for SurroundDeletePending {
+    fn state_name() -> &'static str {
+        "SURROUND_DELETE_PENDING"
+    }
+}
+
+impl HandlerState for SurroundReplaceFromPending {
+    fn state_name() -> &'static str {
+        "SURROUND_REPLACE_FROM_PENDING"
+    }
+}
+
+impl HandlerState for SurroundReplaceToPending {
+    fn state_name() -> &'static str {
+        "SURROUND_REPLACE_TO_PENDING"
     }
 }
 
@@ -253,6 +300,14 @@ pub enum InputState {
     ViewPending,
     /// After 'm' - waiting for match command second key
     MatchPending,
+    /// After 'ms' - waiting for surround add character
+    SurroundAddPending,
+    /// After 'md' - waiting for surround delete character
+    SurroundDeletePending,
+    /// After 'mr' - waiting for surround replace from character
+    SurroundReplaceFromPending,
+    /// After 'mr{char}' - waiting for surround replace to character
+    SurroundReplaceToPending { from_char: char },
     /// After 'f'/'F'/'t'/'T' - waiting for character
     FindCharPending { find_type: FindType },
     /// After 'r' - waiting for replacement character
@@ -301,13 +356,29 @@ impl InputState {
     pub fn is_waiting_for_char(&self) -> bool {
         matches!(
             self,
-            Self::FindCharPending { .. } | Self::ReplaceCharPending
+            Self::FindCharPending { .. }
+                | Self::ReplaceCharPending
+                | Self::SurroundAddPending
+                | Self::SurroundDeletePending
+                | Self::SurroundReplaceFromPending
+                | Self::SurroundReplaceToPending { .. }
         )
     }
 
     /// Check if this state is a prefix state (waiting for more input)
     pub fn is_prefix_state(&self) -> bool {
         !matches!(self, Self::Base)
+    }
+
+    /// Check if this is a surround pending state
+    pub fn is_surround_pending(&self) -> bool {
+        matches!(
+            self,
+            Self::SurroundAddPending
+                | Self::SurroundDeletePending
+                | Self::SurroundReplaceFromPending
+                | Self::SurroundReplaceToPending { .. }
+        )
     }
 
     /// Get the state name for display
@@ -317,6 +388,10 @@ impl InputState {
             Self::GotoPending => "GOTO_PENDING",
             Self::ViewPending => "VIEW_PENDING",
             Self::MatchPending => "MATCH_PENDING",
+            Self::SurroundAddPending => "SURROUND_ADD_PENDING",
+            Self::SurroundDeletePending => "SURROUND_DELETE_PENDING",
+            Self::SurroundReplaceFromPending => "SURROUND_REPLACE_FROM_PENDING",
+            Self::SurroundReplaceToPending { .. } => "SURROUND_REPLACE_TO_PENDING",
             Self::FindCharPending { .. } => "FIND_CHAR_PENDING",
             Self::ReplaceCharPending => "REPLACE_CHAR_PENDING",
             Self::CountPending { .. } => "COUNT_PENDING",
@@ -480,9 +555,94 @@ impl InputHandler<MatchPending> for KeyHandler {
         match key.code {
             // 'mm' - match brackets
             KeyCode::Char('m') => HandlerResult::Execute(Cow::Borrowed(CMD_MATCH_BRACKETS)),
+            // 'ms' - surround add (transition to SurroundAddPending)
+            KeyCode::Char('s') => HandlerResult::Transition(InputState::SurroundAddPending),
+            // 'md' - surround delete (transition to SurroundDeletePending)
+            KeyCode::Char('d') => HandlerResult::Transition(InputState::SurroundDeletePending),
+            // 'mr' - surround replace (transition to SurroundReplaceFromPending)
+            KeyCode::Char('r') => HandlerResult::Transition(InputState::SurroundReplaceFromPending),
             // Escape - cancel
             KeyCode::Esc => HandlerResult::Cancel,
             // Invalid second key - cancel
+            _ => HandlerResult::Cancel,
+        }
+    }
+}
+
+// ============================================================================
+// Surround add pending state handler (after 'ms')
+// ============================================================================
+
+impl InputHandler<SurroundAddPending> for KeyHandler {
+    fn handle_key(_state: &SurroundAddPending, key: KeyEvent) -> HandlerResult {
+        match key.code {
+            // Accept any printable character for surrounding
+            KeyCode::Char(c) => {
+                let cmd = format!("ms{}", c);
+                HandlerResult::Execute(Cow::Owned(cmd))
+            }
+            // Escape - cancel
+            KeyCode::Esc => HandlerResult::Cancel,
+            // Other keys - cancel
+            _ => HandlerResult::Cancel,
+        }
+    }
+}
+
+// ============================================================================
+// Surround delete pending state handler (after 'md')
+// ============================================================================
+
+impl InputHandler<SurroundDeletePending> for KeyHandler {
+    fn handle_key(_state: &SurroundDeletePending, key: KeyEvent) -> HandlerResult {
+        match key.code {
+            // Accept any printable character for deletion target
+            KeyCode::Char(c) => {
+                let cmd = format!("md{}", c);
+                HandlerResult::Execute(Cow::Owned(cmd))
+            }
+            // Escape - cancel
+            KeyCode::Esc => HandlerResult::Cancel,
+            // Other keys - cancel
+            _ => HandlerResult::Cancel,
+        }
+    }
+}
+
+// ============================================================================
+// Surround replace from pending state handler (after 'mr')
+// ============================================================================
+
+impl InputHandler<SurroundReplaceFromPending> for KeyHandler {
+    fn handle_key(_state: &SurroundReplaceFromPending, key: KeyEvent) -> HandlerResult {
+        match key.code {
+            // Accept any printable character as "from" character
+            KeyCode::Char(c) => {
+                HandlerResult::Transition(InputState::SurroundReplaceToPending { from_char: c })
+            }
+            // Escape - cancel
+            KeyCode::Esc => HandlerResult::Cancel,
+            // Other keys - cancel
+            _ => HandlerResult::Cancel,
+        }
+    }
+}
+
+// ============================================================================
+// Surround replace to pending state handler (after 'mr{from}')
+// ============================================================================
+
+impl InputHandler<SurroundReplaceToPending> for KeyHandler {
+    fn handle_key(state: &SurroundReplaceToPending, key: KeyEvent) -> HandlerResult {
+        match key.code {
+            // Accept any printable character as "to" character
+            KeyCode::Char(c) => {
+                let cmd = format!("mr{}{}", state.from_char, c);
+                HandlerResult::Execute(Cow::Owned(cmd))
+            }
+            // Escape - cancel
+            KeyCode::Esc => HandlerResult::Cancel,
+            // Other keys - cancel
             _ => HandlerResult::Cancel,
         }
     }
@@ -620,6 +780,19 @@ impl InputStateMachine {
             InputState::GotoPending => KeyHandler::handle_key(&GotoPending, key),
             InputState::ViewPending => KeyHandler::handle_key(&ViewPending, key),
             InputState::MatchPending => KeyHandler::handle_key(&MatchPending, key),
+            InputState::SurroundAddPending => KeyHandler::handle_key(&SurroundAddPending, key),
+            InputState::SurroundDeletePending => {
+                KeyHandler::handle_key(&SurroundDeletePending, key)
+            }
+            InputState::SurroundReplaceFromPending => {
+                KeyHandler::handle_key(&SurroundReplaceFromPending, key)
+            }
+            InputState::SurroundReplaceToPending { from_char } => KeyHandler::handle_key(
+                &SurroundReplaceToPending {
+                    from_char: *from_char,
+                },
+                key,
+            ),
             InputState::FindCharPending { find_type } => KeyHandler::handle_key(
                 &FindCharPending {
                     find_type: *find_type,
@@ -879,6 +1052,18 @@ impl TypestateHandler<BaseState> {
             HandlerResult::Transition(InputState::MatchPending) => {
                 TypestateHandlerState::MatchPending(TypestateHandler::new())
             }
+            HandlerResult::Transition(InputState::SurroundAddPending) => {
+                TypestateHandlerState::SurroundAddPending(TypestateHandler::new())
+            }
+            HandlerResult::Transition(InputState::SurroundDeletePending) => {
+                TypestateHandlerState::SurroundDeletePending(TypestateHandler::new())
+            }
+            HandlerResult::Transition(InputState::SurroundReplaceFromPending) => {
+                TypestateHandlerState::SurroundReplaceFromPending(TypestateHandler::new())
+            }
+            HandlerResult::Transition(InputState::SurroundReplaceToPending { from_char }) => {
+                TypestateHandlerState::SurroundReplaceToPending(TypestateHandler::new(), *from_char)
+            }
             HandlerResult::Transition(InputState::FindCharPending { find_type }) => {
                 TypestateHandlerState::FindCharPending(TypestateHandler::new(), *find_type)
             }
@@ -903,6 +1088,10 @@ pub enum TypestateHandlerState {
     GotoPending(TypestateHandler<GotoPending>),
     ViewPending(TypestateHandler<ViewPending>),
     MatchPending(TypestateHandler<MatchPending>),
+    SurroundAddPending(TypestateHandler<SurroundAddPending>),
+    SurroundDeletePending(TypestateHandler<SurroundDeletePending>),
+    SurroundReplaceFromPending(TypestateHandler<SurroundReplaceFromPending>),
+    SurroundReplaceToPending(TypestateHandler<SurroundReplaceToPending>, char),
     FindCharPending(TypestateHandler<FindCharPending>, FindType),
     ReplaceCharPending(TypestateHandler<ReplaceCharPending>),
     CountPending(TypestateHandler<CountPending>, usize),
@@ -944,6 +1133,54 @@ impl TypestateHandlerState {
                 let result = KeyHandler::handle_key(&MatchPending, key);
                 let next = match &result {
                     HandlerResult::Stay => Self::MatchPending(TypestateHandler::new()),
+                    HandlerResult::Transition(InputState::SurroundAddPending) => {
+                        Self::SurroundAddPending(TypestateHandler::new())
+                    }
+                    HandlerResult::Transition(InputState::SurroundDeletePending) => {
+                        Self::SurroundDeletePending(TypestateHandler::new())
+                    }
+                    HandlerResult::Transition(InputState::SurroundReplaceFromPending) => {
+                        Self::SurroundReplaceFromPending(TypestateHandler::new())
+                    }
+                    _ => Self::Base(TypestateHandler::new()),
+                };
+                (result, next)
+            }
+            Self::SurroundAddPending(_) => {
+                let result = KeyHandler::handle_key(&SurroundAddPending, key);
+                let next = match &result {
+                    HandlerResult::Stay => Self::SurroundAddPending(TypestateHandler::new()),
+                    _ => Self::Base(TypestateHandler::new()),
+                };
+                (result, next)
+            }
+            Self::SurroundDeletePending(_) => {
+                let result = KeyHandler::handle_key(&SurroundDeletePending, key);
+                let next = match &result {
+                    HandlerResult::Stay => Self::SurroundDeletePending(TypestateHandler::new()),
+                    _ => Self::Base(TypestateHandler::new()),
+                };
+                (result, next)
+            }
+            Self::SurroundReplaceFromPending(_) => {
+                let result = KeyHandler::handle_key(&SurroundReplaceFromPending, key);
+                let next = match &result {
+                    HandlerResult::Stay => {
+                        Self::SurroundReplaceFromPending(TypestateHandler::new())
+                    }
+                    HandlerResult::Transition(InputState::SurroundReplaceToPending {
+                        from_char,
+                    }) => Self::SurroundReplaceToPending(TypestateHandler::new(), *from_char),
+                    _ => Self::Base(TypestateHandler::new()),
+                };
+                (result, next)
+            }
+            Self::SurroundReplaceToPending(_, from_char) => {
+                let result = KeyHandler::handle_key(&SurroundReplaceToPending { from_char }, key);
+                let next = match &result {
+                    HandlerResult::Stay => {
+                        Self::SurroundReplaceToPending(TypestateHandler::new(), from_char)
+                    }
                     _ => Self::Base(TypestateHandler::new()),
                 };
                 (result, next)
@@ -992,6 +1229,10 @@ impl TypestateHandlerState {
             Self::GotoPending(_) => GotoPending::state_name(),
             Self::ViewPending(_) => ViewPending::state_name(),
             Self::MatchPending(_) => MatchPending::state_name(),
+            Self::SurroundAddPending(_) => SurroundAddPending::state_name(),
+            Self::SurroundDeletePending(_) => SurroundDeletePending::state_name(),
+            Self::SurroundReplaceFromPending(_) => SurroundReplaceFromPending::state_name(),
+            Self::SurroundReplaceToPending(_, _) => SurroundReplaceToPending::state_name(),
             Self::FindCharPending(_, _) => FindCharPending::state_name(),
             Self::ReplaceCharPending(_) => ReplaceCharPending::state_name(),
             Self::CountPending(_, _) => CountPending::state_name(),
@@ -1416,11 +1657,171 @@ mod tests {
         }
 
         #[test]
+        fn test_match_pending_ms_transitions_to_surround_add() {
+            let result = KeyHandler::handle_key(
+                &MatchPending,
+                KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE),
+            );
+            assert!(matches!(
+                result,
+                HandlerResult::Transition(InputState::SurroundAddPending)
+            ));
+        }
+
+        #[test]
+        fn test_match_pending_md_transitions_to_surround_delete() {
+            let result = KeyHandler::handle_key(
+                &MatchPending,
+                KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE),
+            );
+            assert!(matches!(
+                result,
+                HandlerResult::Transition(InputState::SurroundDeletePending)
+            ));
+        }
+
+        #[test]
+        fn test_match_pending_mr_transitions_to_surround_replace() {
+            let result = KeyHandler::handle_key(
+                &MatchPending,
+                KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE),
+            );
+            assert!(matches!(
+                result,
+                HandlerResult::Transition(InputState::SurroundReplaceFromPending)
+            ));
+        }
+
+        #[test]
         fn test_match_pending_invalid_cancels() {
             let result = KeyHandler::handle_key(
                 &MatchPending,
                 KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
             );
+            assert!(matches!(result, HandlerResult::Cancel));
+        }
+    }
+
+    mod surround_add_pending_handler_tests {
+        use super::*;
+
+        #[test]
+        fn test_surround_add_pending_accept_char() {
+            let result = KeyHandler::handle_key(
+                &SurroundAddPending,
+                KeyEvent::new(KeyCode::Char('('), KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "ms("));
+        }
+
+        #[test]
+        fn test_surround_add_pending_accept_bracket() {
+            let result = KeyHandler::handle_key(
+                &SurroundAddPending,
+                KeyEvent::new(KeyCode::Char('['), KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "ms["));
+        }
+
+        #[test]
+        fn test_surround_add_pending_accept_quote() {
+            let result = KeyHandler::handle_key(
+                &SurroundAddPending,
+                KeyEvent::new(KeyCode::Char('"'), KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "ms\""));
+        }
+
+        #[test]
+        fn test_surround_add_pending_escape_cancels() {
+            let result = KeyHandler::handle_key(
+                &SurroundAddPending,
+                KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Cancel));
+        }
+    }
+
+    mod surround_delete_pending_handler_tests {
+        use super::*;
+
+        #[test]
+        fn test_surround_delete_pending_accept_char() {
+            let result = KeyHandler::handle_key(
+                &SurroundDeletePending,
+                KeyEvent::new(KeyCode::Char('('), KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "md("));
+        }
+
+        #[test]
+        fn test_surround_delete_pending_accept_bracket() {
+            let result = KeyHandler::handle_key(
+                &SurroundDeletePending,
+                KeyEvent::new(KeyCode::Char('{'), KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "md{"));
+        }
+
+        #[test]
+        fn test_surround_delete_pending_escape_cancels() {
+            let result = KeyHandler::handle_key(
+                &SurroundDeletePending,
+                KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Cancel));
+        }
+    }
+
+    mod surround_replace_pending_handler_tests {
+        use super::*;
+
+        #[test]
+        fn test_surround_replace_from_transitions_to_to() {
+            let result = KeyHandler::handle_key(
+                &SurroundReplaceFromPending,
+                KeyEvent::new(KeyCode::Char('('), KeyModifiers::NONE),
+            );
+            assert!(matches!(
+                result,
+                HandlerResult::Transition(InputState::SurroundReplaceToPending { from_char: '(' })
+            ));
+        }
+
+        #[test]
+        fn test_surround_replace_from_escape_cancels() {
+            let result = KeyHandler::handle_key(
+                &SurroundReplaceFromPending,
+                KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Cancel));
+        }
+
+        #[test]
+        fn test_surround_replace_to_completes() {
+            let state = SurroundReplaceToPending { from_char: '(' };
+            let result = KeyHandler::handle_key(
+                &state,
+                KeyEvent::new(KeyCode::Char('['), KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "mr(["));
+        }
+
+        #[test]
+        fn test_surround_replace_to_quotes() {
+            let state = SurroundReplaceToPending { from_char: '"' };
+            let result = KeyHandler::handle_key(
+                &state,
+                KeyEvent::new(KeyCode::Char('\''), KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "mr\"'"));
+        }
+
+        #[test]
+        fn test_surround_replace_to_escape_cancels() {
+            let state = SurroundReplaceToPending { from_char: '(' };
+            let result =
+                KeyHandler::handle_key(&state, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
             assert!(matches!(result, HandlerResult::Cancel));
         }
     }
@@ -1681,6 +2082,100 @@ mod tests {
 
             sm.reset();
             assert!(sm.state().is_base());
+        }
+
+        #[test]
+        fn test_state_machine_surround_add_sequence() {
+            let mut sm = InputStateMachine::new();
+
+            // Press 'm' - transition to MatchPending
+            let result = sm.process_key(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE));
+            assert!(result.is_transition());
+            assert!(sm.state().is_match_pending());
+
+            // Press 's' - transition to SurroundAddPending
+            let result = sm.process_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
+            assert!(result.is_transition());
+            assert!(matches!(sm.state(), InputState::SurroundAddPending));
+
+            // Press '(' - execute "ms("
+            let result = sm.process_key(KeyEvent::new(KeyCode::Char('('), KeyModifiers::NONE));
+            assert!(result.is_execute());
+            assert_eq!(result.command(), Some("ms("));
+            assert!(sm.state().is_base());
+        }
+
+        #[test]
+        fn test_state_machine_surround_delete_sequence() {
+            let mut sm = InputStateMachine::new();
+
+            // Press 'm' - transition to MatchPending
+            sm.process_key(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE));
+            assert!(sm.state().is_match_pending());
+
+            // Press 'd' - transition to SurroundDeletePending
+            let result = sm.process_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
+            assert!(result.is_transition());
+            assert!(matches!(sm.state(), InputState::SurroundDeletePending));
+
+            // Press '{' - execute "md{"
+            let result = sm.process_key(KeyEvent::new(KeyCode::Char('{'), KeyModifiers::NONE));
+            assert!(result.is_execute());
+            assert_eq!(result.command(), Some("md{"));
+            assert!(sm.state().is_base());
+        }
+
+        #[test]
+        fn test_state_machine_surround_replace_sequence() {
+            let mut sm = InputStateMachine::new();
+
+            // Press 'm' - transition to MatchPending
+            sm.process_key(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE));
+            assert!(sm.state().is_match_pending());
+
+            // Press 'r' - transition to SurroundReplaceFromPending
+            let result = sm.process_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE));
+            assert!(result.is_transition());
+            assert!(matches!(sm.state(), InputState::SurroundReplaceFromPending));
+
+            // Press '(' - transition to SurroundReplaceToPending
+            let result = sm.process_key(KeyEvent::new(KeyCode::Char('('), KeyModifiers::NONE));
+            assert!(result.is_transition());
+            assert!(matches!(
+                sm.state(),
+                InputState::SurroundReplaceToPending { from_char: '(' }
+            ));
+
+            // Press '[' - execute "mr(["
+            let result = sm.process_key(KeyEvent::new(KeyCode::Char('['), KeyModifiers::NONE));
+            assert!(result.is_execute());
+            assert_eq!(result.command(), Some("mr(["));
+            assert!(sm.state().is_base());
+        }
+
+        #[test]
+        fn test_state_machine_surround_escape_cancels() {
+            let mut sm = InputStateMachine::new();
+
+            // Go to SurroundAddPending
+            sm.process_key(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE));
+            sm.process_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
+            assert!(matches!(sm.state(), InputState::SurroundAddPending));
+
+            // Press Escape - should cancel
+            let result = sm.process_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+            assert!(result.is_cancel());
+            assert!(sm.state().is_base());
+        }
+
+        #[test]
+        fn test_surround_pending_predicates() {
+            assert!(InputState::SurroundAddPending.is_surround_pending());
+            assert!(InputState::SurroundDeletePending.is_surround_pending());
+            assert!(InputState::SurroundReplaceFromPending.is_surround_pending());
+            assert!(InputState::SurroundReplaceToPending { from_char: '(' }.is_surround_pending());
+            assert!(!InputState::Base.is_surround_pending());
+            assert!(!InputState::MatchPending.is_surround_pending());
         }
     }
 


### PR DESCRIPTION
## Summary

Implement Match Mode surround commands for Phase 4 of the expansion plan (#104):

- <kbd>m</kbd><kbd>s</kbd><kbd>{char}</kbd> - Surround selection with character pair
- <kbd>m</kbd><kbd>d</kbd><kbd>{char}</kbd> - Delete surrounding pair
- <kbd>m</kbd><kbd>r</kbd><kbd>{from}</kbd><kbd>{to}</kbd> - Replace surrounding pair

## Changes

### Typestate Input Handling (`src/input/typestate.rs`)
- Add `SurroundAddPending`, `SurroundDeletePending`, `SurroundReplaceFromPending`, `SurroundReplaceToPending` state types
- Implement `InputHandler` for all surround states
- Update `MatchPending` handler to transition to surround states on `s`, `d`, `r`
- Update `InputStateMachine` and `TypestateHandlerState` for runtime dispatch
- Add comprehensive tests for state transitions

### Surround Command Handlers (`src/helix/simulator/commands/editing.rs`)
- `surround_selection()` - Wrap selection with character pair
- `delete_surround()` - Remove innermost surrounding pair
- `replace_surround()` - Replace one pair with another
- `find_surrounding_pair()` - Search for brackets/quotes with nesting support
- `get_surround_pair()` - Map characters to open/close pairs

### Command Dispatching (`src/helix/simulator/commands/mod.rs`)
- Add dispatch logic for `ms{char}`, `md{char}`, `mr{from}{to}` commands
- Add `cmd_to_key_events` conversion for surround sequences

## Supported Surround Characters
| Character | Pair |
|-----------|------|
| `(` `)` | Parentheses |
| `[` `]` | Square brackets |
| `{` `}` | Curly braces |
| `<` `>` | Angle brackets |
| `"` | Double quotes |
| `'` | Single quotes |
| Other | Same char on both sides |

## Test Plan

- [x] All 1044 tests pass
- [x] Clippy passes with zero warnings
- [x] Release build succeeds
- [x] Performance review passed
- [x] Security review passed
- [x] Test coverage review completed

Resolves part of #104 (Phase 4 - Match Mode)