### PR TITLE
feat: implement text object selection (ma/mi)

### DIFF
--- a/src/helix/simulator/commands/editing.rs
+++ b/src/helix/simulator/commands/editing.rs
@@ -389,6 +389,11 @@ fn find_surrounding_pair<M: EditorMode>(
     let slice = sim.doc.slice(..);
     let len = sim.doc.len_chars();
 
+    // Handle empty document
+    if len == 0 {
+        return None;
+    }
+
     // For same-char pairs (quotes), find nearest on each side
     if open == close {
         // Search backwards for opening quote
@@ -450,6 +455,329 @@ fn find_surrounding_pair<M: EditorMode>(
 
         close_pos.map(|c| (open_idx, c))
     }
+}
+
+// ============================================================================
+// Text Object Selection Functions
+// ============================================================================
+
+/// Select around text object (Helix 'ma{obj}' command)
+///
+/// Selects text around the specified text object, including delimiters.
+pub fn select_around_textobject<M: EditorMode>(
+    sim: &mut HelixSimulator<M>,
+    obj: char,
+) -> Result<(), UserError> {
+    match obj {
+        'w' => select_around_word(sim, false),
+        'W' => select_around_word(sim, true),
+        '(' | ')' => select_around_bracket(sim, '(', ')'),
+        '[' | ']' => select_around_bracket(sim, '[', ']'),
+        '{' | '}' => select_around_bracket(sim, '{', '}'),
+        '<' | '>' => select_around_bracket(sim, '<', '>'),
+        '"' => select_around_quote(sim, '"'),
+        '\'' => select_around_quote(sim, '\''),
+        '`' => select_around_quote(sim, '`'),
+        'p' => select_around_paragraph(sim),
+        _ => Ok(()), // Unknown text object - no-op
+    }
+}
+
+/// Select inside text object (Helix 'mi{obj}' command)
+///
+/// Selects text inside the specified text object, excluding delimiters.
+pub fn select_inside_textobject<M: EditorMode>(
+    sim: &mut HelixSimulator<M>,
+    obj: char,
+) -> Result<(), UserError> {
+    match obj {
+        'w' => select_inside_word(sim, false),
+        'W' => select_inside_word(sim, true),
+        '(' | ')' => select_inside_bracket(sim, '(', ')'),
+        '[' | ']' => select_inside_bracket(sim, '[', ']'),
+        '{' | '}' => select_inside_bracket(sim, '{', '}'),
+        '<' | '>' => select_inside_bracket(sim, '<', '>'),
+        '"' => select_inside_quote(sim, '"'),
+        '\'' => select_inside_quote(sim, '\''),
+        '`' => select_inside_quote(sim, '`'),
+        'p' => select_inside_paragraph(sim),
+        _ => Ok(()), // Unknown text object - no-op
+    }
+}
+
+/// Select around word (small word or WORD)
+fn select_around_word<M: EditorMode>(
+    sim: &mut HelixSimulator<M>,
+    big_word: bool,
+) -> Result<(), UserError> {
+    let head = sim.selection.primary().head;
+    let slice = sim.doc.slice(..);
+    let len = sim.doc.len_chars();
+
+    if len == 0 {
+        return Ok(());
+    }
+
+    let head = head.min(len.saturating_sub(1));
+
+    // Find word boundaries
+    let is_word_char = |c: char| {
+        if big_word {
+            !c.is_whitespace()
+        } else {
+            c.is_alphanumeric() || c == '_'
+        }
+    };
+
+    let current_char = slice.char(head);
+    let in_word = is_word_char(current_char);
+
+    if !in_word {
+        // Cursor on whitespace - select the whitespace
+        let mut start = head;
+        let mut end = head;
+
+        // Expand backwards through whitespace
+        while start > 0 && slice.char(start.saturating_sub(1)).is_whitespace() {
+            start -= 1;
+        }
+
+        // Expand forwards through whitespace
+        while end < len && slice.char(end).is_whitespace() {
+            end += 1;
+        }
+
+        sim.selection = Selection::single(start, end);
+    } else {
+        // Cursor in word - select word plus trailing whitespace
+        let mut start = head;
+        let mut end = head;
+
+        // Expand backwards to word start
+        while start > 0 && is_word_char(slice.char(start.saturating_sub(1))) {
+            start -= 1;
+        }
+
+        // Expand forwards to word end
+        while end < len && is_word_char(slice.char(end)) {
+            end += 1;
+        }
+
+        // Include trailing whitespace for "around"
+        while end < len && slice.char(end).is_whitespace() && slice.char(end) != '\n' {
+            end += 1;
+        }
+
+        sim.selection = Selection::single(start, end);
+    }
+
+    Ok(())
+}
+
+/// Select inside word (small word or WORD)
+fn select_inside_word<M: EditorMode>(
+    sim: &mut HelixSimulator<M>,
+    big_word: bool,
+) -> Result<(), UserError> {
+    let head = sim.selection.primary().head;
+    let slice = sim.doc.slice(..);
+    let len = sim.doc.len_chars();
+
+    if len == 0 {
+        return Ok(());
+    }
+
+    let head = head.min(len.saturating_sub(1));
+
+    let is_word_char = |c: char| {
+        if big_word {
+            !c.is_whitespace()
+        } else {
+            c.is_alphanumeric() || c == '_'
+        }
+    };
+
+    let current_char = slice.char(head);
+    if !is_word_char(current_char) {
+        // Not on a word - no selection
+        return Ok(());
+    }
+
+    let mut start = head;
+    let mut end = head;
+
+    // Expand backwards to word start
+    while start > 0 && is_word_char(slice.char(start.saturating_sub(1))) {
+        start -= 1;
+    }
+
+    // Expand forwards to word end
+    while end < len && is_word_char(slice.char(end)) {
+        end += 1;
+    }
+
+    sim.selection = Selection::single(start, end);
+    Ok(())
+}
+
+/// Select around bracket pair
+fn select_around_bracket<M: EditorMode>(
+    sim: &mut HelixSimulator<M>,
+    open: char,
+    close: char,
+) -> Result<(), UserError> {
+    let head = sim.selection.primary().head;
+
+    let Some((open_pos, close_pos)) = find_surrounding_pair(sim, head, open, close) else {
+        return Ok(());
+    };
+
+    // Include the brackets
+    sim.selection = Selection::single(open_pos, close_pos + 1);
+    Ok(())
+}
+
+/// Select inside bracket pair
+fn select_inside_bracket<M: EditorMode>(
+    sim: &mut HelixSimulator<M>,
+    open: char,
+    close: char,
+) -> Result<(), UserError> {
+    let head = sim.selection.primary().head;
+
+    let Some((open_pos, close_pos)) = find_surrounding_pair(sim, head, open, close) else {
+        return Ok(());
+    };
+
+    // Exclude the brackets
+    if open_pos + 1 < close_pos {
+        sim.selection = Selection::single(open_pos + 1, close_pos);
+    } else {
+        // Empty inside - select nothing (point at opening bracket)
+        sim.selection = Selection::point(open_pos + 1);
+    }
+    Ok(())
+}
+
+/// Select around quote pair
+fn select_around_quote<M: EditorMode>(
+    sim: &mut HelixSimulator<M>,
+    quote: char,
+) -> Result<(), UserError> {
+    let head = sim.selection.primary().head;
+
+    let Some((open_pos, close_pos)) = find_surrounding_pair(sim, head, quote, quote) else {
+        return Ok(());
+    };
+
+    // Include the quotes
+    sim.selection = Selection::single(open_pos, close_pos + 1);
+    Ok(())
+}
+
+/// Select inside quote pair
+fn select_inside_quote<M: EditorMode>(
+    sim: &mut HelixSimulator<M>,
+    quote: char,
+) -> Result<(), UserError> {
+    let head = sim.selection.primary().head;
+
+    let Some((open_pos, close_pos)) = find_surrounding_pair(sim, head, quote, quote) else {
+        return Ok(());
+    };
+
+    // Exclude the quotes
+    if open_pos + 1 < close_pos {
+        sim.selection = Selection::single(open_pos + 1, close_pos);
+    } else {
+        // Empty inside - select nothing (point after opening quote)
+        sim.selection = Selection::point(open_pos + 1);
+    }
+    Ok(())
+}
+
+/// Select around paragraph
+fn select_around_paragraph<M: EditorMode>(sim: &mut HelixSimulator<M>) -> Result<(), UserError> {
+    // Handle empty document
+    if sim.doc.len_chars() == 0 {
+        return Ok(());
+    }
+
+    let head = sim.selection.primary().head;
+    let current_line = sim.doc.char_to_line(head);
+    let total_lines = sim.doc.len_lines();
+
+    // Find paragraph start (first non-empty line going backwards)
+    let mut para_start_line = current_line;
+    while para_start_line > 0 {
+        let line = sim.doc.line(para_start_line.saturating_sub(1));
+        if line.len_chars() == 0 || (line.len_chars() == 1 && line.char(0) == '\n') {
+            break;
+        }
+        para_start_line -= 1;
+    }
+
+    // Find paragraph end (first empty line going forwards)
+    let mut para_end_line = current_line;
+    while para_end_line < total_lines {
+        let line = sim.doc.line(para_end_line);
+        if line.len_chars() == 0 || (line.len_chars() == 1 && line.char(0) == '\n') {
+            para_end_line += 1; // Include the empty line for "around"
+            break;
+        }
+        para_end_line += 1;
+    }
+
+    let start = sim.doc.line_to_char(para_start_line);
+    let end = if para_end_line < total_lines {
+        sim.doc.line_to_char(para_end_line)
+    } else {
+        sim.doc.len_chars()
+    };
+
+    sim.selection = Selection::single(start, end);
+    Ok(())
+}
+
+/// Select inside paragraph
+fn select_inside_paragraph<M: EditorMode>(sim: &mut HelixSimulator<M>) -> Result<(), UserError> {
+    // Handle empty document
+    if sim.doc.len_chars() == 0 {
+        return Ok(());
+    }
+
+    let head = sim.selection.primary().head;
+    let current_line = sim.doc.char_to_line(head);
+    let total_lines = sim.doc.len_lines();
+
+    // Find paragraph start (first non-empty line going backwards)
+    let mut para_start_line = current_line;
+    while para_start_line > 0 {
+        let line = sim.doc.line(para_start_line.saturating_sub(1));
+        if line.len_chars() == 0 || (line.len_chars() == 1 && line.char(0) == '\n') {
+            break;
+        }
+        para_start_line -= 1;
+    }
+
+    // Find paragraph end (last non-empty line going forwards)
+    let mut para_end_line = current_line;
+    while para_end_line + 1 < total_lines {
+        let line = sim.doc.line(para_end_line + 1);
+        if line.len_chars() == 0 || (line.len_chars() == 1 && line.char(0) == '\n') {
+            break;
+        }
+        para_end_line += 1;
+    }
+
+    let start = sim.doc.line_to_char(para_start_line);
+    // End at the end of the last line (not including trailing newline for "inside")
+    let end_line_start = sim.doc.line_to_char(para_end_line);
+    let end_line_len = sim.doc.line(para_end_line).len_chars();
+    let end = end_line_start + end_line_len;
+
+    sim.selection = Selection::single(start, end);
+    Ok(())
 }
 
 /// Join lines in selection with space (Helix 'Alt-J' command)
@@ -685,5 +1013,594 @@ mod tests {
         delete_surround(&mut sim, '(').unwrap();
 
         assert_eq!(sim.doc.to_string(), "hello world");
+    }
+
+    // Text object tests
+    #[test]
+    fn test_select_around_word() {
+        let mut sim: HelixSimulator<NormalMode> =
+            HelixSimulator::new("hello world test".to_string());
+        sim.selection = Selection::point(7); // Cursor on 'o' in "world"
+
+        select_around_textobject(&mut sim, 'w').unwrap();
+
+        let range = sim.selection.primary();
+        // Should select "world " (including trailing space)
+        assert_eq!(range.from(), 6);
+        assert_eq!(range.to(), 12);
+    }
+
+    #[test]
+    fn test_select_inside_word() {
+        let mut sim: HelixSimulator<NormalMode> =
+            HelixSimulator::new("hello world test".to_string());
+        sim.selection = Selection::point(7); // Cursor on 'o' in "world"
+
+        select_inside_textobject(&mut sim, 'w').unwrap();
+
+        let range = sim.selection.primary();
+        // Should select "world" (excluding trailing space)
+        assert_eq!(range.from(), 6);
+        assert_eq!(range.to(), 11);
+    }
+
+    #[test]
+    fn test_select_around_big_word() {
+        let mut sim: HelixSimulator<NormalMode> =
+            HelixSimulator::new("hello-world test".to_string());
+        sim.selection = Selection::point(7); // Cursor on 'w' in "hello-world"
+
+        select_around_textobject(&mut sim, 'W').unwrap();
+
+        let range = sim.selection.primary();
+        // WORD includes hyphen
+        assert_eq!(range.from(), 0);
+        assert_eq!(range.to(), 12); // "hello-world "
+    }
+
+    #[test]
+    fn test_select_inside_big_word() {
+        let mut sim: HelixSimulator<NormalMode> =
+            HelixSimulator::new("hello-world test".to_string());
+        sim.selection = Selection::point(7);
+
+        select_inside_textobject(&mut sim, 'W').unwrap();
+
+        let range = sim.selection.primary();
+        // WORD includes hyphen
+        assert_eq!(range.from(), 0);
+        assert_eq!(range.to(), 11); // "hello-world"
+    }
+
+    #[test]
+    fn test_select_around_parens() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("fn(arg1, arg2)".to_string());
+        sim.selection = Selection::point(5); // Cursor on 'g' in "arg1"
+
+        select_around_textobject(&mut sim, '(').unwrap();
+
+        let range = sim.selection.primary();
+        // Should select "(arg1, arg2)" including parens
+        assert_eq!(range.from(), 2);
+        assert_eq!(range.to(), 14);
+    }
+
+    #[test]
+    fn test_select_inside_parens() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("fn(arg1, arg2)".to_string());
+        sim.selection = Selection::point(5);
+
+        select_inside_textobject(&mut sim, '(').unwrap();
+
+        let range = sim.selection.primary();
+        // Should select "arg1, arg2" excluding parens
+        assert_eq!(range.from(), 3);
+        assert_eq!(range.to(), 13);
+    }
+
+    #[test]
+    fn test_select_around_brackets() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("[1, 2, 3]".to_string());
+        sim.selection = Selection::point(4); // Cursor on '2'
+
+        select_around_textobject(&mut sim, '[').unwrap();
+
+        let range = sim.selection.primary();
+        assert_eq!(range.from(), 0);
+        assert_eq!(range.to(), 9);
+    }
+
+    #[test]
+    fn test_select_inside_brackets() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("[1, 2, 3]".to_string());
+        sim.selection = Selection::point(4);
+
+        select_inside_textobject(&mut sim, '[').unwrap();
+
+        let range = sim.selection.primary();
+        assert_eq!(range.from(), 1);
+        assert_eq!(range.to(), 8);
+    }
+
+    #[test]
+    fn test_select_around_braces() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("{ x: 1, y: 2 }".to_string());
+        sim.selection = Selection::point(5); // Cursor on '1'
+
+        select_around_textobject(&mut sim, '{').unwrap();
+
+        let range = sim.selection.primary();
+        assert_eq!(range.from(), 0);
+        assert_eq!(range.to(), 14);
+    }
+
+    #[test]
+    fn test_select_inside_braces() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("{ x: 1, y: 2 }".to_string());
+        sim.selection = Selection::point(5);
+
+        select_inside_textobject(&mut sim, '{').unwrap();
+
+        let range = sim.selection.primary();
+        assert_eq!(range.from(), 1);
+        assert_eq!(range.to(), 13);
+    }
+
+    #[test]
+    fn test_select_around_angle_brackets() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("Vec<T>".to_string());
+        sim.selection = Selection::point(4); // Cursor on 'T'
+
+        select_around_textobject(&mut sim, '<').unwrap();
+
+        let range = sim.selection.primary();
+        assert_eq!(range.from(), 3);
+        assert_eq!(range.to(), 6);
+    }
+
+    #[test]
+    fn test_select_inside_angle_brackets() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("Vec<T>".to_string());
+        sim.selection = Selection::point(4);
+
+        select_inside_textobject(&mut sim, '<').unwrap();
+
+        let range = sim.selection.primary();
+        assert_eq!(range.from(), 4);
+        assert_eq!(range.to(), 5);
+    }
+
+    #[test]
+    fn test_select_around_double_quotes() {
+        let mut sim: HelixSimulator<NormalMode> =
+            HelixSimulator::new("let s = \"hello\";".to_string());
+        sim.selection = Selection::point(10); // Cursor on 'e' in "hello"
+
+        select_around_textobject(&mut sim, '"').unwrap();
+
+        let range = sim.selection.primary();
+        // Should select "\"hello\"" including quotes
+        assert_eq!(range.from(), 8);
+        assert_eq!(range.to(), 15);
+    }
+
+    #[test]
+    fn test_select_inside_double_quotes() {
+        let mut sim: HelixSimulator<NormalMode> =
+            HelixSimulator::new("let s = \"hello\";".to_string());
+        sim.selection = Selection::point(10);
+
+        select_inside_textobject(&mut sim, '"').unwrap();
+
+        let range = sim.selection.primary();
+        // Should select "hello" excluding quotes
+        assert_eq!(range.from(), 9);
+        assert_eq!(range.to(), 14);
+    }
+
+    #[test]
+    fn test_select_around_single_quotes() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("let c = 'x';".to_string());
+        sim.selection = Selection::point(9); // Cursor on 'x'
+
+        select_around_textobject(&mut sim, '\'').unwrap();
+
+        let range = sim.selection.primary();
+        assert_eq!(range.from(), 8);
+        assert_eq!(range.to(), 11);
+    }
+
+    #[test]
+    fn test_select_inside_single_quotes() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("let c = 'x';".to_string());
+        sim.selection = Selection::point(9);
+
+        select_inside_textobject(&mut sim, '\'').unwrap();
+
+        let range = sim.selection.primary();
+        assert_eq!(range.from(), 9);
+        assert_eq!(range.to(), 10);
+    }
+
+    #[test]
+    fn test_select_around_backticks() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("run `ls -la`".to_string());
+        sim.selection = Selection::point(6); // Cursor on 's'
+
+        select_around_textobject(&mut sim, '`').unwrap();
+
+        let range = sim.selection.primary();
+        assert_eq!(range.from(), 4);
+        assert_eq!(range.to(), 12);
+    }
+
+    #[test]
+    fn test_select_inside_backticks() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("run `ls -la`".to_string());
+        sim.selection = Selection::point(6);
+
+        select_inside_textobject(&mut sim, '`').unwrap();
+
+        let range = sim.selection.primary();
+        assert_eq!(range.from(), 5);
+        assert_eq!(range.to(), 11);
+    }
+
+    #[test]
+    fn test_select_around_paragraph() {
+        let mut sim: HelixSimulator<NormalMode> =
+            HelixSimulator::new("line 1\nline 2\n\nline 3".to_string());
+        sim.selection = Selection::point(8); // Cursor on line 2
+
+        select_around_textobject(&mut sim, 'p').unwrap();
+
+        let range = sim.selection.primary();
+        // Should select first paragraph including the blank line separator
+        // "line 1\nline 2\n\n" = positions 0-14 (Selection end is exclusive)
+        assert_eq!(range.from(), 0);
+        assert_eq!(range.to(), 15);
+    }
+
+    #[test]
+    fn test_select_inside_paragraph() {
+        let mut sim: HelixSimulator<NormalMode> =
+            HelixSimulator::new("line 1\nline 2\n\nline 3".to_string());
+        sim.selection = Selection::point(8); // Cursor on line 2
+
+        select_inside_textobject(&mut sim, 'p').unwrap();
+
+        let range = sim.selection.primary();
+        // Should select first paragraph content including line newlines
+        // "line 1\nline 2\n" = positions 0-13 (Selection end is exclusive)
+        assert_eq!(range.from(), 0);
+        assert_eq!(range.to(), 14);
+    }
+
+    #[test]
+    fn test_select_inside_word_on_whitespace() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("hello   world".to_string());
+        sim.selection = Selection::point(6); // Cursor on whitespace
+
+        select_inside_textobject(&mut sim, 'w').unwrap();
+
+        // When on whitespace, inside word does nothing
+        let range = sim.selection.primary();
+        assert_eq!(range.from(), 6);
+        assert_eq!(range.to(), 6);
+    }
+
+    #[test]
+    fn test_select_around_word_on_whitespace() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("hello   world".to_string());
+        sim.selection = Selection::point(6); // Cursor on whitespace
+
+        select_around_textobject(&mut sim, 'w').unwrap();
+
+        let range = sim.selection.primary();
+        // Around on whitespace selects the whitespace
+        assert_eq!(range.from(), 5);
+        assert_eq!(range.to(), 8);
+    }
+
+    #[test]
+    fn test_select_textobject_unknown() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("hello".to_string());
+        sim.selection = Selection::point(2);
+
+        // Unknown text object should do nothing
+        select_around_textobject(&mut sim, 'z').unwrap();
+        assert_eq!(sim.selection.primary().head, 2);
+
+        select_inside_textobject(&mut sim, 'z').unwrap();
+        assert_eq!(sim.selection.primary().head, 2);
+    }
+
+    #[test]
+    fn test_select_inside_empty_brackets() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("foo()".to_string());
+        sim.selection = Selection::point(4); // Cursor after '('
+
+        select_inside_textobject(&mut sim, '(').unwrap();
+
+        // Empty inside - should be a point selection
+        let range = sim.selection.primary();
+        assert_eq!(range.from(), 4);
+        assert_eq!(range.to(), 4);
+    }
+
+    #[test]
+    fn test_select_around_nested_parens() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("fn(a, (b, c))".to_string());
+        sim.selection = Selection::point(8); // Cursor on 'b'
+
+        select_around_textobject(&mut sim, '(').unwrap();
+
+        let range = sim.selection.primary();
+        // Should select innermost "(b, c)"
+        assert_eq!(range.from(), 6);
+        assert_eq!(range.to(), 12);
+    }
+
+    // Critical: Empty document tests
+    #[test]
+    fn test_select_textobject_empty_document() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new(String::new());
+        sim.selection = Selection::point(0);
+
+        // Should not panic on any text object
+        select_around_textobject(&mut sim, 'w').unwrap();
+        select_inside_textobject(&mut sim, 'w').unwrap();
+        select_around_textobject(&mut sim, '(').unwrap();
+        select_inside_textobject(&mut sim, '"').unwrap();
+        select_around_textobject(&mut sim, 'p').unwrap();
+    }
+
+    // Critical: Boundary position tests
+    #[test]
+    fn test_select_around_word_at_document_start() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("hello world".to_string());
+        sim.selection = Selection::point(0);
+
+        select_around_textobject(&mut sim, 'w').unwrap();
+
+        let range = sim.selection.primary();
+        assert_eq!(range.from(), 0);
+        assert_eq!(range.to(), 6); // "hello "
+    }
+
+    #[test]
+    fn test_select_around_word_at_document_end() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("hello world".to_string());
+        sim.selection = Selection::point(10); // On 'd' in "world"
+
+        select_around_textobject(&mut sim, 'w').unwrap();
+
+        let range = sim.selection.primary();
+        // "world" at end has no trailing space
+        assert_eq!(range.from(), 6);
+        assert_eq!(range.to(), 11);
+    }
+
+    // High: Closing bracket variants
+    #[test]
+    fn test_select_around_closing_paren() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("fn(arg)".to_string());
+        sim.selection = Selection::point(4);
+
+        // Use closing paren ')' instead of opening '('
+        select_around_textobject(&mut sim, ')').unwrap();
+
+        let range = sim.selection.primary();
+        assert_eq!(range.from(), 2);
+        assert_eq!(range.to(), 7);
+    }
+
+    #[test]
+    fn test_select_inside_closing_bracket() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("[1, 2]".to_string());
+        sim.selection = Selection::point(2);
+
+        // Use closing bracket ']'
+        select_inside_textobject(&mut sim, ']').unwrap();
+
+        let range = sim.selection.primary();
+        assert_eq!(range.from(), 1);
+        assert_eq!(range.to(), 5);
+    }
+
+    #[test]
+    fn test_select_around_closing_brace() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("{x}".to_string());
+        sim.selection = Selection::point(1);
+
+        select_around_textobject(&mut sim, '}').unwrap();
+
+        let range = sim.selection.primary();
+        assert_eq!(range.from(), 0);
+        assert_eq!(range.to(), 3);
+    }
+
+    #[test]
+    fn test_select_inside_closing_angle() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("<T>".to_string());
+        sim.selection = Selection::point(1);
+
+        select_inside_textobject(&mut sim, '>').unwrap();
+
+        let range = sim.selection.primary();
+        assert_eq!(range.from(), 1);
+        assert_eq!(range.to(), 2);
+    }
+
+    // High: Unmatched brackets
+    #[test]
+    fn test_select_inside_unmatched_bracket() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("(hello world".to_string());
+        sim.selection = Selection::point(3);
+
+        // No matching closing bracket - should do nothing
+        select_inside_textobject(&mut sim, '(').unwrap();
+
+        // Selection should remain unchanged
+        let range = sim.selection.primary();
+        assert_eq!(range.head, 3);
+    }
+
+    #[test]
+    fn test_select_around_unmatched_quote() {
+        let mut sim: HelixSimulator<NormalMode> =
+            HelixSimulator::new("let s = \"hello".to_string());
+        sim.selection = Selection::point(10);
+
+        // No matching closing quote - should do nothing
+        select_around_textobject(&mut sim, '"').unwrap();
+
+        let range = sim.selection.primary();
+        assert_eq!(range.head, 10);
+    }
+
+    // High: Deeply nested brackets
+    #[test]
+    fn test_select_around_deeply_nested() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("(((deep)))".to_string());
+        sim.selection = Selection::point(4); // On 'e'
+
+        select_around_textobject(&mut sim, '(').unwrap();
+
+        let range = sim.selection.primary();
+        // Should select innermost "(deep)"
+        assert_eq!(range.from(), 2);
+        assert_eq!(range.to(), 8);
+    }
+
+    #[test]
+    fn test_select_inside_triple_nested() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("[[[inner]]]".to_string());
+        sim.selection = Selection::point(4); // On 'n'
+
+        select_inside_textobject(&mut sim, '[').unwrap();
+
+        let range = sim.selection.primary();
+        // Should select "inner" from innermost brackets
+        assert_eq!(range.from(), 3);
+        assert_eq!(range.to(), 8);
+    }
+
+    // High: Paragraph on blank line
+    #[test]
+    fn test_select_paragraph_cursor_on_blank_line() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("para1\n\npara2".to_string());
+        sim.selection = Selection::point(6); // On blank line (the \n)
+
+        select_around_textobject(&mut sim, 'p').unwrap();
+
+        // Should select something (the blank line itself or adjacent paragraph)
+        let range = sim.selection.primary();
+        // Exact behavior may vary; ensure no panic
+        assert!(range.to() > range.from());
+    }
+
+    #[test]
+    fn test_select_paragraph_single_line_document() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("single line".to_string());
+        sim.selection = Selection::point(5);
+
+        select_around_textobject(&mut sim, 'p').unwrap();
+
+        let range = sim.selection.primary();
+        // Should select entire document
+        assert_eq!(range.from(), 0);
+        assert_eq!(range.to(), 11);
+    }
+
+    // Medium: Empty quotes
+    #[test]
+    fn test_select_inside_empty_double_quotes() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("x = \"\"".to_string());
+        sim.selection = Selection::point(5); // Between the quotes
+
+        select_inside_textobject(&mut sim, '"').unwrap();
+
+        // Empty inside - should be point selection
+        let range = sim.selection.primary();
+        assert_eq!(range.from(), range.to());
+    }
+
+    #[test]
+    fn test_select_inside_empty_single_quotes() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("c = ''".to_string());
+        sim.selection = Selection::point(5);
+
+        select_inside_textobject(&mut sim, '\'').unwrap();
+
+        let range = sim.selection.primary();
+        assert_eq!(range.from(), range.to());
+    }
+
+    // Medium: Single character word
+    #[test]
+    fn test_select_around_single_char_word() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("a b c".to_string());
+        sim.selection = Selection::point(2); // On 'b'
+
+        select_around_textobject(&mut sim, 'w').unwrap();
+
+        let range = sim.selection.primary();
+        // "b " including trailing space
+        assert_eq!(range.from(), 2);
+        assert_eq!(range.to(), 4);
+    }
+
+    #[test]
+    fn test_select_inside_single_char_word() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("a b c".to_string());
+        sim.selection = Selection::point(2);
+
+        select_inside_textobject(&mut sim, 'w').unwrap();
+
+        let range = sim.selection.primary();
+        // Just "b"
+        assert_eq!(range.from(), 2);
+        assert_eq!(range.to(), 3);
+    }
+
+    // Medium: WORD with special characters
+    #[test]
+    fn test_select_around_big_word_with_symbols() {
+        let mut sim: HelixSimulator<NormalMode> =
+            HelixSimulator::new("foo@bar.com test".to_string());
+        sim.selection = Selection::point(5); // On 'a' in bar
+
+        select_around_textobject(&mut sim, 'W').unwrap();
+
+        let range = sim.selection.primary();
+        // "foo@bar.com " is one WORD
+        assert_eq!(range.from(), 0);
+        assert_eq!(range.to(), 12);
+    }
+
+    // Medium: Multiline brackets
+    #[test]
+    fn test_select_around_multiline_brackets() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("{\n  x: 1\n}".to_string());
+        sim.selection = Selection::point(5); // On 'x'
+
+        select_around_textobject(&mut sim, '{').unwrap();
+
+        let range = sim.selection.primary();
+        assert_eq!(range.from(), 0);
+        assert_eq!(range.to(), 10);
+    }
+
+    #[test]
+    fn test_select_inside_multiline_parens() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("(\n  arg\n)".to_string());
+        sim.selection = Selection::point(4); // On 'a'
+
+        select_inside_textobject(&mut sim, '(').unwrap();
+
+        let range = sim.selection.primary();
+        assert_eq!(range.from(), 1);
+        assert_eq!(range.to(), 8);
     }
 }

--- a/src/helix/simulator/commands/mod.rs
+++ b/src/helix/simulator/commands/mod.rs
@@ -118,6 +118,25 @@ fn cmd_to_key_events(cmd: &str) -> Vec<KeyEvent> {
         ];
     }
 
+    // Text object commands (e.g., "maw" -> m + a + w, "mi(" -> m + i + '(')
+    if cmd.starts_with("ma") && cmd.len() == 3 {
+        let obj = cmd.chars().nth(2).unwrap();
+        return vec![
+            KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char(obj), KeyModifiers::NONE),
+        ];
+    }
+
+    if cmd.starts_with("mi") && cmd.len() == 3 {
+        let obj = cmd.chars().nth(2).unwrap();
+        return vec![
+            KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char(obj), KeyModifiers::NONE),
+        ];
+    }
+
     // Alt-; for flip selections
     if cmd == CMD_FLIP_SELECTIONS {
         return vec![KeyEvent::new(KeyCode::Char(';'), KeyModifiers::ALT)];
@@ -280,6 +299,19 @@ pub(super) fn execute_normal_mode_command_internal(
         let from_char = cmd.chars().nth(2).unwrap();
         let to_char = cmd.chars().nth(3).unwrap();
         editing::replace_surround(sim, from_char, to_char)?;
+        return Ok(());
+    }
+
+    // Special handling for text object commands (ma{obj}, mi{obj})
+    if cmd.len() == 3 && cmd.starts_with("ma") {
+        let obj = cmd.chars().nth(2).unwrap();
+        editing::select_around_textobject(sim, obj)?;
+        return Ok(());
+    }
+
+    if cmd.len() == 3 && cmd.starts_with("mi") {
+        let obj = cmd.chars().nth(2).unwrap();
+        editing::select_inside_textobject(sim, obj)?;
         return Ok(());
     }
 
@@ -567,6 +599,69 @@ mod tests {
             let events = cmd_to_key_events("a");
             assert_eq!(events.len(), 1);
             assert_eq!(events[0].modifiers, KeyModifiers::NONE);
+        }
+
+        #[test]
+        fn test_cmd_to_key_events_text_object_around_word() {
+            let events = cmd_to_key_events("maw");
+            assert_eq!(events.len(), 3);
+            assert_eq!(events[0].code, KeyCode::Char('m'));
+            assert_eq!(events[1].code, KeyCode::Char('a'));
+            assert_eq!(events[2].code, KeyCode::Char('w'));
+        }
+
+        #[test]
+        fn test_cmd_to_key_events_text_object_inside_word() {
+            let events = cmd_to_key_events("miw");
+            assert_eq!(events.len(), 3);
+            assert_eq!(events[0].code, KeyCode::Char('m'));
+            assert_eq!(events[1].code, KeyCode::Char('i'));
+            assert_eq!(events[2].code, KeyCode::Char('w'));
+        }
+
+        #[test]
+        fn test_cmd_to_key_events_text_object_around_big_word() {
+            let events = cmd_to_key_events("maW");
+            assert_eq!(events.len(), 3);
+            assert_eq!(events[0].code, KeyCode::Char('m'));
+            assert_eq!(events[1].code, KeyCode::Char('a'));
+            assert_eq!(events[2].code, KeyCode::Char('W'));
+        }
+
+        #[test]
+        fn test_cmd_to_key_events_text_object_around_paren() {
+            let events = cmd_to_key_events("ma(");
+            assert_eq!(events.len(), 3);
+            assert_eq!(events[0].code, KeyCode::Char('m'));
+            assert_eq!(events[1].code, KeyCode::Char('a'));
+            assert_eq!(events[2].code, KeyCode::Char('('));
+        }
+
+        #[test]
+        fn test_cmd_to_key_events_text_object_inside_bracket() {
+            let events = cmd_to_key_events("mi[");
+            assert_eq!(events.len(), 3);
+            assert_eq!(events[0].code, KeyCode::Char('m'));
+            assert_eq!(events[1].code, KeyCode::Char('i'));
+            assert_eq!(events[2].code, KeyCode::Char('['));
+        }
+
+        #[test]
+        fn test_cmd_to_key_events_text_object_around_quote() {
+            let events = cmd_to_key_events("ma\"");
+            assert_eq!(events.len(), 3);
+            assert_eq!(events[0].code, KeyCode::Char('m'));
+            assert_eq!(events[1].code, KeyCode::Char('a'));
+            assert_eq!(events[2].code, KeyCode::Char('"'));
+        }
+
+        #[test]
+        fn test_cmd_to_key_events_text_object_inside_paragraph() {
+            let events = cmd_to_key_events("mip");
+            assert_eq!(events.len(), 3);
+            assert_eq!(events[0].code, KeyCode::Char('m'));
+            assert_eq!(events[1].code, KeyCode::Char('i'));
+            assert_eq!(events[2].code, KeyCode::Char('p'));
         }
     }
 }

--- a/src/input/typestate.rs
+++ b/src/input/typestate.rs
@@ -94,6 +94,14 @@ pub struct SurroundReplaceToPending {
     pub from_char: char,
 }
 
+/// Waiting for text object after 'ma' (select around)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TextObjectAroundPending;
+
+/// Waiting for text object after 'mi' (select inside)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TextObjectInsidePending;
+
 /// Waiting for character after 'f'/'F'/'t'/'T' (find/till commands)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FindCharPending {
@@ -153,6 +161,8 @@ impl private::Sealed for SurroundAddPending {}
 impl private::Sealed for SurroundDeletePending {}
 impl private::Sealed for SurroundReplaceFromPending {}
 impl private::Sealed for SurroundReplaceToPending {}
+impl private::Sealed for TextObjectAroundPending {}
+impl private::Sealed for TextObjectInsidePending {}
 impl private::Sealed for FindCharPending {}
 impl private::Sealed for ReplaceCharPending {}
 impl private::Sealed for CountPending {}
@@ -210,6 +220,18 @@ impl HandlerState for SurroundReplaceFromPending {
 impl HandlerState for SurroundReplaceToPending {
     fn state_name() -> &'static str {
         "SURROUND_REPLACE_TO_PENDING"
+    }
+}
+
+impl HandlerState for TextObjectAroundPending {
+    fn state_name() -> &'static str {
+        "TEXT_OBJECT_AROUND_PENDING"
+    }
+}
+
+impl HandlerState for TextObjectInsidePending {
+    fn state_name() -> &'static str {
+        "TEXT_OBJECT_INSIDE_PENDING"
     }
 }
 
@@ -308,6 +330,10 @@ pub enum InputState {
     SurroundReplaceFromPending,
     /// After 'mr{char}' - waiting for surround replace to character
     SurroundReplaceToPending { from_char: char },
+    /// After 'ma' - waiting for text object (around)
+    TextObjectAroundPending,
+    /// After 'mi' - waiting for text object (inside)
+    TextObjectInsidePending,
     /// After 'f'/'F'/'t'/'T' - waiting for character
     FindCharPending { find_type: FindType },
     /// After 'r' - waiting for replacement character
@@ -381,6 +407,14 @@ impl InputState {
         )
     }
 
+    /// Check if this is a text object pending state (waiting for text object type)
+    pub fn is_text_object_pending(&self) -> bool {
+        matches!(
+            self,
+            Self::TextObjectAroundPending | Self::TextObjectInsidePending
+        )
+    }
+
     /// Get the state name for display
     pub fn name(&self) -> &'static str {
         match self {
@@ -392,6 +426,8 @@ impl InputState {
             Self::SurroundDeletePending => "SURROUND_DELETE_PENDING",
             Self::SurroundReplaceFromPending => "SURROUND_REPLACE_FROM_PENDING",
             Self::SurroundReplaceToPending { .. } => "SURROUND_REPLACE_TO_PENDING",
+            Self::TextObjectAroundPending => "TEXT_OBJECT_AROUND_PENDING",
+            Self::TextObjectInsidePending => "TEXT_OBJECT_INSIDE_PENDING",
             Self::FindCharPending { .. } => "FIND_CHAR_PENDING",
             Self::ReplaceCharPending => "REPLACE_CHAR_PENDING",
             Self::CountPending { .. } => "COUNT_PENDING",
@@ -561,6 +597,10 @@ impl InputHandler<MatchPending> for KeyHandler {
             KeyCode::Char('d') => HandlerResult::Transition(InputState::SurroundDeletePending),
             // 'mr' - surround replace (transition to SurroundReplaceFromPending)
             KeyCode::Char('r') => HandlerResult::Transition(InputState::SurroundReplaceFromPending),
+            // 'ma' - text object around (transition to TextObjectAroundPending)
+            KeyCode::Char('a') => HandlerResult::Transition(InputState::TextObjectAroundPending),
+            // 'mi' - text object inside (transition to TextObjectInsidePending)
+            KeyCode::Char('i') => HandlerResult::Transition(InputState::TextObjectInsidePending),
             // Escape - cancel
             KeyCode::Esc => HandlerResult::Cancel,
             // Invalid second key - cancel
@@ -643,6 +683,52 @@ impl InputHandler<SurroundReplaceToPending> for KeyHandler {
             // Escape - cancel
             KeyCode::Esc => HandlerResult::Cancel,
             // Other keys - cancel
+            _ => HandlerResult::Cancel,
+        }
+    }
+}
+
+// ============================================================================
+// Text object around pending state handler (after 'ma')
+// ============================================================================
+
+impl InputHandler<TextObjectAroundPending> for KeyHandler {
+    fn handle_key(_state: &TextObjectAroundPending, key: KeyEvent) -> HandlerResult {
+        match key.code {
+            // Valid text objects: w, W, (, ), [, ], {, }, <, >, ", ', `, p
+            KeyCode::Char(
+                c @ ('w' | 'W' | '(' | ')' | '[' | ']' | '{' | '}' | '<' | '>' | '"' | '\'' | '`'
+                | 'p'),
+            ) => {
+                let cmd = format!("ma{}", c);
+                HandlerResult::Execute(Cow::Owned(cmd))
+            }
+            // Escape - cancel
+            KeyCode::Esc => HandlerResult::Cancel,
+            // Invalid text object - cancel
+            _ => HandlerResult::Cancel,
+        }
+    }
+}
+
+// ============================================================================
+// Text object inside pending state handler (after 'mi')
+// ============================================================================
+
+impl InputHandler<TextObjectInsidePending> for KeyHandler {
+    fn handle_key(_state: &TextObjectInsidePending, key: KeyEvent) -> HandlerResult {
+        match key.code {
+            // Valid text objects: w, W, (, ), [, ], {, }, <, >, ", ', `, p
+            KeyCode::Char(
+                c @ ('w' | 'W' | '(' | ')' | '[' | ']' | '{' | '}' | '<' | '>' | '"' | '\'' | '`'
+                | 'p'),
+            ) => {
+                let cmd = format!("mi{}", c);
+                HandlerResult::Execute(Cow::Owned(cmd))
+            }
+            // Escape - cancel
+            KeyCode::Esc => HandlerResult::Cancel,
+            // Invalid text object - cancel
             _ => HandlerResult::Cancel,
         }
     }
@@ -793,6 +879,12 @@ impl InputStateMachine {
                 },
                 key,
             ),
+            InputState::TextObjectAroundPending => {
+                KeyHandler::handle_key(&TextObjectAroundPending, key)
+            }
+            InputState::TextObjectInsidePending => {
+                KeyHandler::handle_key(&TextObjectInsidePending, key)
+            }
             InputState::FindCharPending { find_type } => KeyHandler::handle_key(
                 &FindCharPending {
                     find_type: *find_type,
@@ -1092,6 +1184,8 @@ pub enum TypestateHandlerState {
     SurroundDeletePending(TypestateHandler<SurroundDeletePending>),
     SurroundReplaceFromPending(TypestateHandler<SurroundReplaceFromPending>),
     SurroundReplaceToPending(TypestateHandler<SurroundReplaceToPending>, char),
+    TextObjectAroundPending(TypestateHandler<TextObjectAroundPending>),
+    TextObjectInsidePending(TypestateHandler<TextObjectInsidePending>),
     FindCharPending(TypestateHandler<FindCharPending>, FindType),
     ReplaceCharPending(TypestateHandler<ReplaceCharPending>),
     CountPending(TypestateHandler<CountPending>, usize),
@@ -1142,6 +1236,12 @@ impl TypestateHandlerState {
                     HandlerResult::Transition(InputState::SurroundReplaceFromPending) => {
                         Self::SurroundReplaceFromPending(TypestateHandler::new())
                     }
+                    HandlerResult::Transition(InputState::TextObjectAroundPending) => {
+                        Self::TextObjectAroundPending(TypestateHandler::new())
+                    }
+                    HandlerResult::Transition(InputState::TextObjectInsidePending) => {
+                        Self::TextObjectInsidePending(TypestateHandler::new())
+                    }
                     _ => Self::Base(TypestateHandler::new()),
                 };
                 (result, next)
@@ -1181,6 +1281,22 @@ impl TypestateHandlerState {
                     HandlerResult::Stay => {
                         Self::SurroundReplaceToPending(TypestateHandler::new(), from_char)
                     }
+                    _ => Self::Base(TypestateHandler::new()),
+                };
+                (result, next)
+            }
+            Self::TextObjectAroundPending(_) => {
+                let result = KeyHandler::handle_key(&TextObjectAroundPending, key);
+                let next = match &result {
+                    HandlerResult::Stay => Self::TextObjectAroundPending(TypestateHandler::new()),
+                    _ => Self::Base(TypestateHandler::new()),
+                };
+                (result, next)
+            }
+            Self::TextObjectInsidePending(_) => {
+                let result = KeyHandler::handle_key(&TextObjectInsidePending, key);
+                let next = match &result {
+                    HandlerResult::Stay => Self::TextObjectInsidePending(TypestateHandler::new()),
                     _ => Self::Base(TypestateHandler::new()),
                 };
                 (result, next)
@@ -1233,6 +1349,8 @@ impl TypestateHandlerState {
             Self::SurroundDeletePending(_) => SurroundDeletePending::state_name(),
             Self::SurroundReplaceFromPending(_) => SurroundReplaceFromPending::state_name(),
             Self::SurroundReplaceToPending(_, _) => SurroundReplaceToPending::state_name(),
+            Self::TextObjectAroundPending(_) => TextObjectAroundPending::state_name(),
+            Self::TextObjectInsidePending(_) => TextObjectInsidePending::state_name(),
             Self::FindCharPending(_, _) => FindCharPending::state_name(),
             Self::ReplaceCharPending(_) => ReplaceCharPending::state_name(),
             Self::CountPending(_, _) => CountPending::state_name(),
@@ -1693,6 +1811,30 @@ mod tests {
         }
 
         #[test]
+        fn test_match_pending_ma_transitions_to_text_object_around() {
+            let result = KeyHandler::handle_key(
+                &MatchPending,
+                KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE),
+            );
+            assert!(matches!(
+                result,
+                HandlerResult::Transition(InputState::TextObjectAroundPending)
+            ));
+        }
+
+        #[test]
+        fn test_match_pending_mi_transitions_to_text_object_inside() {
+            let result = KeyHandler::handle_key(
+                &MatchPending,
+                KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE),
+            );
+            assert!(matches!(
+                result,
+                HandlerResult::Transition(InputState::TextObjectInsidePending)
+            ));
+        }
+
+        #[test]
         fn test_match_pending_invalid_cancels() {
             let result = KeyHandler::handle_key(
                 &MatchPending,
@@ -1822,6 +1964,140 @@ mod tests {
             let state = SurroundReplaceToPending { from_char: '(' };
             let result =
                 KeyHandler::handle_key(&state, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+            assert!(matches!(result, HandlerResult::Cancel));
+        }
+    }
+
+    mod text_object_around_pending_handler_tests {
+        use super::*;
+
+        #[test]
+        fn test_text_object_around_word() {
+            let result = KeyHandler::handle_key(
+                &TextObjectAroundPending,
+                KeyEvent::new(KeyCode::Char('w'), KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "maw"));
+        }
+
+        #[test]
+        fn test_text_object_around_word_big() {
+            let result = KeyHandler::handle_key(
+                &TextObjectAroundPending,
+                KeyEvent::new(KeyCode::Char('W'), KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "maW"));
+        }
+
+        #[test]
+        fn test_text_object_around_parens() {
+            let result = KeyHandler::handle_key(
+                &TextObjectAroundPending,
+                KeyEvent::new(KeyCode::Char('('), KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "ma("));
+        }
+
+        #[test]
+        fn test_text_object_around_quotes() {
+            let result = KeyHandler::handle_key(
+                &TextObjectAroundPending,
+                KeyEvent::new(KeyCode::Char('"'), KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "ma\""));
+        }
+
+        #[test]
+        fn test_text_object_around_paragraph() {
+            let result = KeyHandler::handle_key(
+                &TextObjectAroundPending,
+                KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "map"));
+        }
+
+        #[test]
+        fn test_text_object_around_escape_cancels() {
+            let result = KeyHandler::handle_key(
+                &TextObjectAroundPending,
+                KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Cancel));
+        }
+
+        #[test]
+        fn test_text_object_around_invalid_cancels() {
+            let result = KeyHandler::handle_key(
+                &TextObjectAroundPending,
+                KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Cancel));
+        }
+    }
+
+    mod text_object_inside_pending_handler_tests {
+        use super::*;
+
+        #[test]
+        fn test_text_object_inside_word() {
+            let result = KeyHandler::handle_key(
+                &TextObjectInsidePending,
+                KeyEvent::new(KeyCode::Char('w'), KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "miw"));
+        }
+
+        #[test]
+        fn test_text_object_inside_brackets() {
+            let result = KeyHandler::handle_key(
+                &TextObjectInsidePending,
+                KeyEvent::new(KeyCode::Char('['), KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "mi["));
+        }
+
+        #[test]
+        fn test_text_object_inside_braces() {
+            let result = KeyHandler::handle_key(
+                &TextObjectInsidePending,
+                KeyEvent::new(KeyCode::Char('{'), KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "mi{"));
+        }
+
+        #[test]
+        fn test_text_object_inside_angle_brackets() {
+            let result = KeyHandler::handle_key(
+                &TextObjectInsidePending,
+                KeyEvent::new(KeyCode::Char('<'), KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "mi<"));
+        }
+
+        #[test]
+        fn test_text_object_inside_single_quote() {
+            let result = KeyHandler::handle_key(
+                &TextObjectInsidePending,
+                KeyEvent::new(KeyCode::Char('\''), KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "mi'"));
+        }
+
+        #[test]
+        fn test_text_object_inside_backtick() {
+            let result = KeyHandler::handle_key(
+                &TextObjectInsidePending,
+                KeyEvent::new(KeyCode::Char('`'), KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "mi`"));
+        }
+
+        #[test]
+        fn test_text_object_inside_escape_cancels() {
+            let result = KeyHandler::handle_key(
+                &TextObjectInsidePending,
+                KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+            );
             assert!(matches!(result, HandlerResult::Cancel));
         }
     }
@@ -2176,6 +2452,71 @@ mod tests {
             assert!(InputState::SurroundReplaceToPending { from_char: '(' }.is_surround_pending());
             assert!(!InputState::Base.is_surround_pending());
             assert!(!InputState::MatchPending.is_surround_pending());
+        }
+
+        #[test]
+        fn test_state_machine_text_object_around_sequence() {
+            let mut sm = InputStateMachine::new();
+
+            // Press 'm' - transition to MatchPending
+            let result = sm.process_key(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE));
+            assert!(result.is_transition());
+            assert!(sm.state().is_match_pending());
+
+            // Press 'a' - transition to TextObjectAroundPending
+            let result = sm.process_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE));
+            assert!(result.is_transition());
+            assert!(matches!(sm.state(), InputState::TextObjectAroundPending));
+
+            // Press 'w' - execute "maw"
+            let result = sm.process_key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::NONE));
+            assert!(result.is_execute());
+            assert_eq!(result.command(), Some("maw"));
+            assert!(sm.state().is_base());
+        }
+
+        #[test]
+        fn test_state_machine_text_object_inside_sequence() {
+            let mut sm = InputStateMachine::new();
+
+            // Press 'm' - transition to MatchPending
+            sm.process_key(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE));
+            assert!(sm.state().is_match_pending());
+
+            // Press 'i' - transition to TextObjectInsidePending
+            let result = sm.process_key(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE));
+            assert!(result.is_transition());
+            assert!(matches!(sm.state(), InputState::TextObjectInsidePending));
+
+            // Press '(' - execute "mi("
+            let result = sm.process_key(KeyEvent::new(KeyCode::Char('('), KeyModifiers::NONE));
+            assert!(result.is_execute());
+            assert_eq!(result.command(), Some("mi("));
+            assert!(sm.state().is_base());
+        }
+
+        #[test]
+        fn test_state_machine_text_object_escape_cancels() {
+            let mut sm = InputStateMachine::new();
+
+            // Go to TextObjectAroundPending
+            sm.process_key(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE));
+            sm.process_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE));
+            assert!(matches!(sm.state(), InputState::TextObjectAroundPending));
+
+            // Press Escape - should cancel
+            let result = sm.process_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+            assert!(result.is_cancel());
+            assert!(sm.state().is_base());
+        }
+
+        #[test]
+        fn test_text_object_pending_predicates() {
+            assert!(InputState::TextObjectAroundPending.is_text_object_pending());
+            assert!(InputState::TextObjectInsidePending.is_text_object_pending());
+            assert!(!InputState::Base.is_text_object_pending());
+            assert!(!InputState::MatchPending.is_text_object_pending());
+            assert!(!InputState::SurroundAddPending.is_text_object_pending());
         }
     }
 


### PR DESCRIPTION
## Summary
- Implement text object selection commands for match mode (`ma{obj}`, `mi{obj}`)
- Support word, WORD, bracket pairs, quote pairs, and paragraph text objects
- Add comprehensive test coverage including edge cases and boundary conditions

## Changes
- **src/input/typestate.rs**: Add `TextObjectAroundPending` and `TextObjectInsidePending` state handlers
- **src/helix/simulator/commands/editing.rs**: Implement `select_around_textobject`, `select_inside_textobject` and helper functions
- **src/helix/simulator/commands/mod.rs**: Add dispatcher handling and key event conversion

## Text Objects Supported
| Key | Description |
|-----|-------------|
| `w` | word |
| `W` | WORD |
| `()` | parentheses |
| `[]` | brackets |
| `{}` | braces |
| `<>` | angle brackets |
| `"` | double quotes |
| `'` | single quotes |
| `` ` `` | backticks |
| `p` | paragraph |

## Test plan
- [x] All 1116 tests pass
- [x] Clippy passes with no warnings
- [x] Formatting verified with `cargo +nightly fmt`
- [x] Test boundary conditions (empty document, document start/end)
- [x] Test closing bracket variants ()/]/}/>) 
- [x] Test unmatched brackets and quotes
- [x] Test deeply nested brackets
- [x] Test multiline brackets

Closes part of #104: Phase 4 - Text Objects