### PR TITLE
release: v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-01-07
+
+### Changed
+
+- **Refactored to helix-core primitives** (#110)
+  - Migrated text objects (`miw`, `maw`, `mip`, `map`) to `helix_core::textobject`
+  - Migrated character search (`f`, `F`, `t`, `T`) to `helix_core::search`
+  - Migrated surround helpers to `helix_core::surround::find_nth_pairs_pos`
+  - Migrated bracket matching (`mm`) to `helix_core::match_brackets`
+  - Migrated paragraph movement (`{`, `}`) to `helix_core::movement`
+  - Migrated toggle comments (`Ctrl-c`) to `helix_core::comment`
+  - Migrated split selection on newlines (`Alt-s`) to `helix_core::selection`
+
+- **Code cleanup and deduplication** (#111)
+  - Extracted `extract_word_at_cursor` helper for search commands
+  - Removed ~400 lines of excessive comments and documentation
+  - Added 14 new unit tests for helper functions
+
+### Fixed
+
+- `join_selections_space` (`Alt-J`) now correctly selects inserted space (#110)
+
 ## [0.5.0] - 2026-01-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "helix-trainer"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helix-trainer"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Andrei G <andrei.g@my.com>"]


### PR DESCRIPTION
## Summary

Patch release with helix-core integration and code cleanup.

### Changed

- **Refactored to helix-core primitives** (#110)
  - Migrated text objects (`miw`, `maw`, `mip`, `map`) to `helix_core::textobject`
  - Migrated character search (`f`, `F`, `t`, `T`) to `helix_core::search`
  - Migrated surround helpers to `helix_core::surround::find_nth_pairs_pos`
  - Migrated bracket matching (`mm`) to `helix_core::match_brackets`
  - Migrated paragraph movement (`{`, `}`) to `helix_core::movement`
  - Migrated toggle comments (`Ctrl-c`) to `helix_core::comment`
  - Migrated split selection on newlines (`Alt-s`) to `helix_core::selection`

- **Code cleanup and deduplication** (#111)
  - Extracted `extract_word_at_cursor` helper for search commands
  - Removed ~400 lines of excessive comments and documentation
  - Added 14 new unit tests for helper functions

### Fixed

- `join_selections_space` (`Alt-J`) now correctly selects inserted space (#110)

## Test Plan

- [x] All 1145 tests pass
- [x] Clippy zero warnings
- [x] Formatted with `cargo +nightly fmt`