### PR TITLE
fix(keybindings): use Helix paragraph commands [p/]p instead of Vim {/}

### DIFF
--- a/quests/en/daily.toml
+++ b/quests/en/daily.toml
@@ -722,25 +722,25 @@ target = 3
 # --- Paragraph Movement ---
 
 [[quests]]
-id = "cmd_brace_open_medium"
+id = "cmd_prev_paragraph_medium"
 name = "Previous Paragraph"
-description = "Jump to previous paragraph 5 times using '{'"
+description = "Jump to previous paragraph 5 times using '[p'"
 type = "command_practice"
 difficulty = "medium"
 
 [quests.params]
-command = "{"
+command = "[p"
 target = 5
 
 [[quests]]
-id = "cmd_brace_close_medium"
+id = "cmd_next_paragraph_medium"
 name = "Next Paragraph"
-description = "Jump to next paragraph 5 times using '}'"
+description = "Jump to next paragraph 5 times using ']p'"
 type = "command_practice"
 difficulty = "medium"
 
 [quests.params]
-command = "}"
+command = "]p"
 target = 5
 
 # --- Advanced Selection ---

--- a/scenarios/en/movement/paragraph.toml
+++ b/scenarios/en/movement/paragraph.toml
@@ -1,17 +1,17 @@
 # Paragraph Movement Commands
-# Scenarios for { and } paragraph navigation
+# Scenarios for [p and ]p paragraph navigation
 
 # ============================================================================
-# NEXT PARAGRAPH (})
+# NEXT PARAGRAPH (]p)
 # ============================================================================
 
 [[scenarios]]
 id = "paragraph_next_001"
 name = "Jump to next paragraph"
-description = "Use '}' to move to the start of the next paragraph"
+description = "Use ']p' to move to the start of the next paragraph"
 
 hints = [
-    "'}' jumps to the start of the next paragraph",
+    "']p' jumps to the start of the next paragraph",
     "Skips over blank lines to the next content",
 ]
 
@@ -24,8 +24,8 @@ file_content = "First paragraph.\nMore text here.\n\nSecond paragraph.\nAnother 
 cursor_position = [3, 0]
 
 [scenarios.solution]
-commands = ["}"]
-description = "Press '}' to jump to next paragraph start"
+commands = ["]p"]
+description = "Press ']p' to jump to next paragraph start"
 
 [scenarios.scoring]
 optimal_count = 1
@@ -36,17 +36,17 @@ tolerance = 0
 category = "movement"
 difficulty = "intermediate"
 tags = ["paragraph", "navigation"]
-commands_taught = ["}"]
+commands_taught = ["]p"]
 estimated_time_seconds = 10
 
 [[scenarios]]
 id = "paragraph_next_002"
 name = "Navigate code blocks"
-description = "Use '}' to navigate between code blocks separated by blank lines"
+description = "Use ']p' to navigate between code blocks separated by blank lines"
 
 hints = [
     "In code, paragraphs are often functions or blocks",
-    "'}' efficiently jumps between logical sections",
+    "']p' efficiently jumps between logical sections",
 ]
 
 [scenarios.setup]
@@ -58,8 +58,8 @@ file_content = "fn first() {\n    // code\n}\n\nfn second() {\n    // more\n}"
 cursor_position = [4, 0]
 
 [scenarios.solution]
-commands = ["}"]
-description = "Press '}' to jump to the next function"
+commands = ["]p"]
+description = "Press ']p' to jump to the next function"
 
 [scenarios.scoring]
 optimal_count = 1
@@ -70,20 +70,20 @@ tolerance = 0
 category = "movement"
 difficulty = "intermediate"
 tags = ["paragraph", "navigation", "code"]
-commands_taught = ["}"]
+commands_taught = ["]p"]
 estimated_time_seconds = 10
 
 # ============================================================================
-# PREVIOUS PARAGRAPH ({)
+# PREVIOUS PARAGRAPH ([p)
 # ============================================================================
 
 [[scenarios]]
 id = "paragraph_prev_001"
 name = "Jump to previous paragraph"
-description = "Use '{' to move backward to the previous paragraph start"
+description = "Use '[p' to move backward to the previous paragraph start"
 
 hints = [
-    "'{' moves backward to the start of the previous paragraph",
+    "'[p' moves backward to the start of the previous paragraph",
     "Useful for navigating back through documents",
 ]
 
@@ -96,8 +96,8 @@ file_content = "First para.\n\nSecond para.\n\nThird para."
 cursor_position = [4, 0]
 
 [scenarios.solution]
-commands = ["{"]
-description = "Press '{' to move to paragraph start"
+commands = ["[p"]
+description = "Press '[p' to move to paragraph start"
 
 [scenarios.scoring]
 optimal_count = 1
@@ -108,17 +108,17 @@ tolerance = 0
 category = "movement"
 difficulty = "intermediate"
 tags = ["paragraph", "navigation"]
-commands_taught = ["{"]
+commands_taught = ["[p"]
 estimated_time_seconds = 10
 
 [[scenarios]]
 id = "paragraph_prev_002"
 name = "Navigate back across paragraphs"
-description = "Use '{' from a blank line to go to previous paragraph"
+description = "Use '[p' from a blank line to go to previous paragraph"
 
 hints = [
-    "'{' from a blank line goes to the previous paragraph",
-    "Combined with '}' for efficient bidirectional navigation",
+    "'[p' from a blank line goes to the previous paragraph",
+    "Combined with ']p' for efficient bidirectional navigation",
 ]
 
 [scenarios.setup]
@@ -130,8 +130,8 @@ file_content = "Para 1.\n\nPara 2."
 cursor_position = [0, 0]
 
 [scenarios.solution]
-commands = ["{"]
-description = "Press '{' to go back to previous paragraph"
+commands = ["[p"]
+description = "Press '[p' to go back to previous paragraph"
 
 [scenarios.scoring]
 optimal_count = 1
@@ -142,5 +142,5 @@ tolerance = 0
 category = "movement"
 difficulty = "intermediate"
 tags = ["paragraph", "navigation"]
-commands_taught = ["{"]
+commands_taught = ["[p"]
 estimated_time_seconds = 10

--- a/src/config/quests/tests.rs
+++ b/src/config/quests/tests.rs
@@ -591,7 +591,7 @@ fn test_validate_all_quest_templates() {
     let valid_commands: HashSet<&str> = [
         // Movement
         "h", "j", "k", "l", "w", "b", "e", "0", "$", "gg", "G", // Paragraph movement
-        "{", "}", // Editing
+        "[p", "]p", // Editing
         "x", "i", "a", "I", "A", "o", "O", "c", "J", ">", "<", "~", // Clipboard
         "y", "yy", "p", "P", // Undo/Redo
         "u", "U", // Repeat

--- a/src/helix/commands.rs
+++ b/src/helix/commands.rs
@@ -23,8 +23,8 @@ pub const CMD_PAGE_UP: &str = "Ctrl-b";
 pub const CMD_PAGE_DOWN: &str = "Ctrl-f";
 pub const CMD_HALF_PAGE_UP: &str = "Ctrl-u";
 pub const CMD_HALF_PAGE_DOWN: &str = "Ctrl-d";
-pub const CMD_GOTO_PREV_PARAGRAPH: &str = "{";
-pub const CMD_GOTO_NEXT_PARAGRAPH: &str = "}";
+pub const CMD_GOTO_PREV_PARAGRAPH: &str = "[p";
+pub const CMD_GOTO_NEXT_PARAGRAPH: &str = "]p";
 pub const CMD_GOTO_FIRST_NONBLANK: &str = "^";
 
 // Editing commands

--- a/src/helix/registry/keytrie.rs
+++ b/src/helix/registry/keytrie.rs
@@ -82,6 +82,10 @@ impl KeyTrie {
         // Register multi-key match mode commands
         trie.multi_key.insert("mm", "mm");
 
+        // Register multi-key bracket navigation commands
+        trie.multi_key.insert("[p", "[p");
+        trie.multi_key.insert("]p", "]p");
+
         // Register character-input prefixes
         trie.char_input_prefixes.insert('f');
         trie.char_input_prefixes.insert('F');
@@ -222,8 +226,8 @@ impl KeyTrie {
                 return KeyMatch::Partial;
             }
 
-            // Check if this is a goto prefix or match mode prefix
-            if first_char == 'g' || first_char == 'm' {
+            // Check if this is a goto prefix, match mode prefix, or bracket prefix
+            if first_char == 'g' || first_char == 'm' || first_char == '[' || first_char == ']' {
                 return KeyMatch::Partial;
             }
 
@@ -247,7 +251,7 @@ impl KeyTrie {
 
     /// Check if a character starts a multi-key sequence
     pub fn is_multi_key_prefix(&self, ch: char) -> bool {
-        ch == 'g' || self.char_input_prefixes.contains(&ch)
+        ch == 'g' || ch == '[' || ch == ']' || self.char_input_prefixes.contains(&ch)
     }
 }
 

--- a/src/helix/simulator/commands/movement.rs
+++ b/src/helix/simulator/commands/movement.rs
@@ -424,7 +424,7 @@ pub fn flip_selections<M: EditorMode>(sim: &mut HelixSimulator<M>) -> Result<(),
     Ok(())
 }
 
-/// Move to previous paragraph (Helix '{' command)
+/// Move to previous paragraph (Helix '[p' command)
 pub fn goto_prev_paragraph<M: EditorMode>(
     sim: &mut HelixSimulator<M>,
     count: usize,
@@ -436,7 +436,7 @@ pub fn goto_prev_paragraph<M: EditorMode>(
     Ok(())
 }
 
-/// Move to next paragraph (Helix '}' command)
+/// Move to next paragraph (Helix ']p' command)
 pub fn goto_next_paragraph<M: EditorMode>(
     sim: &mut HelixSimulator<M>,
     count: usize,

--- a/src/input/typestate.rs
+++ b/src/input/typestate.rs
@@ -145,6 +145,14 @@ pub struct CountPending {
     pub count: usize,
 }
 
+/// Waiting for second key after '[' (unmatched previous commands)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnmatchedPrevPending;
+
+/// Waiting for second key after ']' (unmatched next commands)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnmatchedNextPending;
+
 // ============================================================================
 // Sealed trait for handler states
 // ============================================================================
@@ -166,6 +174,8 @@ impl private::Sealed for TextObjectInsidePending {}
 impl private::Sealed for FindCharPending {}
 impl private::Sealed for ReplaceCharPending {}
 impl private::Sealed for CountPending {}
+impl private::Sealed for UnmatchedPrevPending {}
+impl private::Sealed for UnmatchedNextPending {}
 
 /// Marker trait for handler state types
 ///
@@ -250,6 +260,18 @@ impl HandlerState for ReplaceCharPending {
 impl HandlerState for CountPending {
     fn state_name() -> &'static str {
         "COUNT_PENDING"
+    }
+}
+
+impl HandlerState for UnmatchedPrevPending {
+    fn state_name() -> &'static str {
+        "UNMATCHED_PREV_PENDING"
+    }
+}
+
+impl HandlerState for UnmatchedNextPending {
+    fn state_name() -> &'static str {
+        "UNMATCHED_NEXT_PENDING"
     }
 }
 
@@ -340,6 +362,10 @@ pub enum InputState {
     ReplaceCharPending,
     /// After digit 1-9 - building count prefix
     CountPending { count: usize },
+    /// After '[' - waiting for unmatched previous command second key
+    UnmatchedPrevPending,
+    /// After ']' - waiting for unmatched next command second key
+    UnmatchedNextPending,
 }
 
 impl InputState {
@@ -415,6 +441,16 @@ impl InputState {
         )
     }
 
+    /// Check if this is unmatched prev pending state
+    pub fn is_unmatched_prev_pending(&self) -> bool {
+        matches!(self, Self::UnmatchedPrevPending)
+    }
+
+    /// Check if this is unmatched next pending state
+    pub fn is_unmatched_next_pending(&self) -> bool {
+        matches!(self, Self::UnmatchedNextPending)
+    }
+
     /// Get the state name for display
     pub fn name(&self) -> &'static str {
         match self {
@@ -431,6 +467,8 @@ impl InputState {
             Self::FindCharPending { .. } => "FIND_CHAR_PENDING",
             Self::ReplaceCharPending => "REPLACE_CHAR_PENDING",
             Self::CountPending { .. } => "COUNT_PENDING",
+            Self::UnmatchedPrevPending => "UNMATCHED_PREV_PENDING",
+            Self::UnmatchedNextPending => "UNMATCHED_NEXT_PENDING",
         }
     }
 }
@@ -480,6 +518,12 @@ impl InputHandler<BaseState> for KeyHandler {
             (KeyCode::Char('g'), false) => HandlerResult::Transition(InputState::GotoPending),
             (KeyCode::Char('z'), false) => HandlerResult::Transition(InputState::ViewPending),
             (KeyCode::Char('m'), false) => HandlerResult::Transition(InputState::MatchPending),
+            (KeyCode::Char('['), false) => {
+                HandlerResult::Transition(InputState::UnmatchedPrevPending)
+            }
+            (KeyCode::Char(']'), false) => {
+                HandlerResult::Transition(InputState::UnmatchedNextPending)
+            }
 
             // Find/till commands - transition to find char pending
             (KeyCode::Char('f'), false) => HandlerResult::Transition(InputState::FindCharPending {
@@ -827,6 +871,40 @@ impl InputHandler<CountPending> for KeyHandler {
 }
 
 // ============================================================================
+// Unmatched prev pending state handler (after '[')
+// ============================================================================
+
+impl InputHandler<UnmatchedPrevPending> for KeyHandler {
+    fn handle_key(_state: &UnmatchedPrevPending, key: KeyEvent) -> HandlerResult {
+        match key.code {
+            // '[p' - goto previous paragraph
+            KeyCode::Char('p') => HandlerResult::Execute(Cow::Borrowed(CMD_GOTO_PREV_PARAGRAPH)),
+            // Escape - cancel
+            KeyCode::Esc => HandlerResult::Cancel,
+            // Other keys - cancel (not recognized)
+            _ => HandlerResult::Cancel,
+        }
+    }
+}
+
+// ============================================================================
+// Unmatched next pending state handler (after ']')
+// ============================================================================
+
+impl InputHandler<UnmatchedNextPending> for KeyHandler {
+    fn handle_key(_state: &UnmatchedNextPending, key: KeyEvent) -> HandlerResult {
+        match key.code {
+            // ']p' - goto next paragraph
+            KeyCode::Char('p') => HandlerResult::Execute(Cow::Borrowed(CMD_GOTO_NEXT_PARAGRAPH)),
+            // Escape - cancel
+            KeyCode::Esc => HandlerResult::Cancel,
+            // Other keys - cancel (not recognized)
+            _ => HandlerResult::Cancel,
+        }
+    }
+}
+
+// ============================================================================
 // Input state machine
 // ============================================================================
 
@@ -895,6 +973,8 @@ impl InputStateMachine {
             InputState::CountPending { count } => {
                 KeyHandler::handle_key(&CountPending { count: *count }, key)
             }
+            InputState::UnmatchedPrevPending => KeyHandler::handle_key(&UnmatchedPrevPending, key),
+            InputState::UnmatchedNextPending => KeyHandler::handle_key(&UnmatchedNextPending, key),
         };
 
         // Update state based on result - move values instead of cloning
@@ -1165,6 +1245,12 @@ impl TypestateHandler<BaseState> {
             HandlerResult::Transition(InputState::CountPending { count }) => {
                 TypestateHandlerState::CountPending(TypestateHandler::new(), *count)
             }
+            HandlerResult::Transition(InputState::UnmatchedPrevPending) => {
+                TypestateHandlerState::UnmatchedPrevPending(TypestateHandler::new())
+            }
+            HandlerResult::Transition(InputState::UnmatchedNextPending) => {
+                TypestateHandlerState::UnmatchedNextPending(TypestateHandler::new())
+            }
             _ => TypestateHandlerState::Base(TypestateHandler::new()),
         };
         (result, next_state)
@@ -1189,6 +1275,8 @@ pub enum TypestateHandlerState {
     FindCharPending(TypestateHandler<FindCharPending>, FindType),
     ReplaceCharPending(TypestateHandler<ReplaceCharPending>),
     CountPending(TypestateHandler<CountPending>, usize),
+    UnmatchedPrevPending(TypestateHandler<UnmatchedPrevPending>),
+    UnmatchedNextPending(TypestateHandler<UnmatchedNextPending>),
 }
 
 impl Default for TypestateHandlerState {
@@ -1330,6 +1418,22 @@ impl TypestateHandlerState {
                 };
                 (result, next)
             }
+            Self::UnmatchedPrevPending(_) => {
+                let result = KeyHandler::handle_key(&UnmatchedPrevPending, key);
+                let next = match &result {
+                    HandlerResult::Stay => Self::UnmatchedPrevPending(TypestateHandler::new()),
+                    _ => Self::Base(TypestateHandler::new()),
+                };
+                (result, next)
+            }
+            Self::UnmatchedNextPending(_) => {
+                let result = KeyHandler::handle_key(&UnmatchedNextPending, key);
+                let next = match &result {
+                    HandlerResult::Stay => Self::UnmatchedNextPending(TypestateHandler::new()),
+                    _ => Self::Base(TypestateHandler::new()),
+                };
+                (result, next)
+            }
         }
     }
 
@@ -1354,6 +1458,8 @@ impl TypestateHandlerState {
             Self::FindCharPending(_, _) => FindCharPending::state_name(),
             Self::ReplaceCharPending(_) => ReplaceCharPending::state_name(),
             Self::CountPending(_, _) => CountPending::state_name(),
+            Self::UnmatchedPrevPending(_) => UnmatchedPrevPending::state_name(),
+            Self::UnmatchedNextPending(_) => UnmatchedNextPending::state_name(),
         }
     }
 }
@@ -1757,6 +1863,90 @@ mod tests {
             let result = KeyHandler::handle_key(
                 &ViewPending,
                 KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Cancel));
+        }
+    }
+
+    mod unmatched_prev_pending_handler_tests {
+        use super::*;
+
+        #[test]
+        fn test_unmatched_prev_pending_p_produces_goto_prev_paragraph() {
+            let result = KeyHandler::handle_key(
+                &UnmatchedPrevPending,
+                KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE),
+            );
+            assert!(
+                matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_GOTO_PREV_PARAGRAPH)
+            );
+        }
+
+        #[test]
+        fn test_unmatched_prev_pending_escape_cancels() {
+            let result = KeyHandler::handle_key(
+                &UnmatchedPrevPending,
+                KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Cancel));
+        }
+
+        #[test]
+        fn test_unmatched_prev_pending_other_key_cancels() {
+            let result = KeyHandler::handle_key(
+                &UnmatchedPrevPending,
+                KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Cancel));
+        }
+
+        #[test]
+        fn test_unmatched_prev_pending_digit_cancels() {
+            let result = KeyHandler::handle_key(
+                &UnmatchedPrevPending,
+                KeyEvent::new(KeyCode::Char('5'), KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Cancel));
+        }
+    }
+
+    mod unmatched_next_pending_handler_tests {
+        use super::*;
+
+        #[test]
+        fn test_unmatched_next_pending_p_produces_goto_next_paragraph() {
+            let result = KeyHandler::handle_key(
+                &UnmatchedNextPending,
+                KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE),
+            );
+            assert!(
+                matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_GOTO_NEXT_PARAGRAPH)
+            );
+        }
+
+        #[test]
+        fn test_unmatched_next_pending_escape_cancels() {
+            let result = KeyHandler::handle_key(
+                &UnmatchedNextPending,
+                KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Cancel));
+        }
+
+        #[test]
+        fn test_unmatched_next_pending_other_key_cancels() {
+            let result = KeyHandler::handle_key(
+                &UnmatchedNextPending,
+                KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+            );
+            assert!(matches!(result, HandlerResult::Cancel));
+        }
+
+        #[test]
+        fn test_unmatched_next_pending_digit_cancels() {
+            let result = KeyHandler::handle_key(
+                &UnmatchedNextPending,
+                KeyEvent::new(KeyCode::Char('3'), KeyModifiers::NONE),
             );
             assert!(matches!(result, HandlerResult::Cancel));
         }


### PR DESCRIPTION
## Summary

Fixes #115 - Paragraph navigation commands were incorrectly using Vim syntax (`{`/`}`) instead of Helix Unimpaired mappings (`[p`/`]p`).

- Update command constants and typestate handlers for bracket prefixes
- Update scenarios and quests with correct commands
- Add unit tests for new handlers

## Test plan

- [x] All 1236 tests pass
- [x] Clippy clean
- [x] Paragraph scenarios now use `[p`/`]p` commands