### PR TITLE
feat(ui): add scenario number in title for progress tracking

### DIFF
--- a/src/ui/render/task.rs
+++ b/src/ui/render/task.rs
@@ -42,8 +42,14 @@ pub(super) fn render_task_screen(frame: &mut Frame, state: &AppState) {
             ])
             .split(area);
 
-        // Title
-        let title = Paragraph::new(format!("Scenario: {}", scenario.name))
+        // Title with scenario number for progress tracking
+        let title_text = if let Some(index) = task_data.scenario_index {
+            let total = state.game.scenario_collection.count();
+            format!("Scenario {}/{}: {}", index + 1, total, scenario.name)
+        } else {
+            format!("Scenario: {}", scenario.name)
+        };
+        let title = Paragraph::new(title_text)
             .style(
                 Style::default()
                     .fg(Color::Green)


### PR DESCRIPTION
## Summary
- Display scenario position as "Scenario X/Y: Name" format in training mode
- Helps users track progress through scenarios
- Enables better bug reporting with scenario numbers

## Before
```
Scenario: Delete current line
```

## After
```
Scenario 101/136: Delete current line
```

Fixes #130

## Test plan
- [x] Clippy passes
- [x] All render tests pass
- [x] Visual verification of title format