### PR TITLE
fix(search): remove invalid # search_word_backward command (Issue #144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,13 +217,12 @@ This release significantly expands command coverage with a complete typestate-ba
   - <kbd>Alt</kbd>-<kbd>K</kbd> remove_selections_matching: Remove matching
   - <kbd>Ctrl</kbd>-<kbd>c</kbd> toggle_comments: Toggle line comments
 
-- **Search Commands (7 new)** (#100)
+- **Search Commands (6 new)** (#100)
   - <kbd>/</kbd> search_forward: Search forward with regex
   - <kbd>?</kbd> search_backward: Search backward with regex
   - <kbd>n</kbd> search_next: Jump to next match
   - <kbd>N</kbd> search_prev: Jump to previous match
   - <kbd>*</kbd> search_word_under_cursor: Search word forward
-  - <kbd>#</kbd> search_word_backward: Search word backward (#105)
   - <kbd>Alt</kbd>-<kbd>*</kbd> search_selection: Search selection text
 
 - **View Commands (6 new)** (#100)

--- a/docs/HELIX_KEYBINDINGS.md
+++ b/docs/HELIX_KEYBINDINGS.md
@@ -632,7 +632,6 @@ Track which commands have been implemented in the simulator:
 | ✅ | <kbd>n</kbd> | Jump to next match |
 | ✅ | <kbd>N</kbd> | Jump to previous match |
 | ✅ | <kbd>*</kbd> | Search word under cursor forward |
-| ✅ | <kbd>#</kbd> | Search word under cursor backward |
 | ✅ | <kbd>Alt</kbd>+<kbd>*</kbd> | Search selection text |
 
 ### View Commands
@@ -674,7 +673,7 @@ Track which commands have been implemented in the simulator:
 | **Page** | 4 | <kbd>Ctrl+b</kbd> <kbd>Ctrl+f</kbd> <kbd>Ctrl+u</kbd> <kbd>Ctrl+d</kbd> |
 | **Editing** | 17 | <kbd>i</kbd> <kbd>a</kbd> <kbd>I</kbd> <kbd>A</kbd> <kbd>o</kbd> <kbd>O</kbd> <kbd>d</kbd> <kbd>c</kbd> <kbd>r</kbd> <kbd>R</kbd> <kbd>~</kbd> <kbd>`</kbd> <kbd>Alt+`</kbd> <kbd>.</kbd> <kbd>u</kbd> <kbd>U</kbd> |
 | **Selection** | 20 | <kbd>x</kbd> <kbd>X</kbd> <kbd>v</kbd> <kbd>;</kbd> <kbd>,</kbd> <kbd>%</kbd> <kbd>s</kbd> <kbd>S</kbd> <kbd>C</kbd> <kbd>K</kbd> <kbd>Alt+C</kbd> <kbd>Alt+K</kbd> <kbd>Alt+s</kbd> <kbd>Alt+x</kbd> <kbd>_</kbd> <kbd>&</kbd> <kbd>Alt+-</kbd> <kbd>Alt+_</kbd> <kbd>Alt+,</kbd> |
-| **Search** | 7 | <kbd>/</kbd> <kbd>?</kbd> <kbd>n</kbd> <kbd>N</kbd> <kbd>*</kbd> <kbd>#</kbd> <kbd>Alt+*</kbd> |
+| **Search** | 6 | <kbd>/</kbd> <kbd>?</kbd> <kbd>n</kbd> <kbd>N</kbd> <kbd>*</kbd> <kbd>Alt+*</kbd> |
 | **View** | 6 | <kbd>z</kbd> <kbd>zz</kbd> <kbd>zt</kbd> <kbd>zb</kbd> <kbd>zm</kbd> <kbd>zj</kbd> <kbd>zk</kbd> |
 | **Match Mode** | 6 | <kbd>mm</kbd> <kbd>ms</kbd> <kbd>md</kbd> <kbd>mr</kbd> <kbd>ma</kbd> <kbd>mi</kbd> |
 | **Indentation** | 2 | <kbd>></kbd> <kbd><</kbd> |

--- a/scenarios/en/search/basic-search.toml
+++ b/scenarios/en/search/basic-search.toml
@@ -1,5 +1,5 @@
 # Basic Search Commands
-# Scenarios for *, #, n, N search commands
+# Scenarios for *, n, N search commands
 
 [[scenarios]]
 id = "search_word_001"
@@ -90,45 +90,6 @@ commands_taught = ["*", "n"]
 estimated_time_seconds = 15
 
 [[scenarios]]
-id = "search_word_backward_001"
-name = "Search word backward"
-description = "Use '#' to search backward for word under cursor"
-
-hints = [
-    "'#' searches backward for word under cursor",
-    "Like '*' but in reverse direction",
-]
-
-[scenarios.setup]
-file_content = """let value = 10;
-let other = 20;
-let result = value + other;"""
-cursor_position = [2, 13]
-
-[scenarios.target]
-file_content = """let value = 10;
-let other = 20;
-let result = value + other;"""
-cursor_position = [0, 4]
-selection = [0, 4, 0, 9]
-
-[scenarios.solution]
-commands = ["#"]
-description = "Press '#' to jump to previous occurrence of 'value'"
-
-[scenarios.scoring]
-optimal_count = 1
-max_points = 100
-tolerance = 0
-
-[scenarios.metadata]
-category = "search"
-difficulty = "beginner"
-tags = ["search", "word", "backward"]
-commands_taught = ["#"]
-estimated_time_seconds = 10
-
-[[scenarios]]
 id = "search_next_001"
 name = "Go to next match"
 description = "Use '*' to search for word under cursor"
@@ -173,39 +134,4 @@ tags = ["search", "next", "match"]
 commands_taught = ["*"]
 estimated_time_seconds = 10
 
-[[scenarios]]
-id = "search_prev_001"
-name = "Go to previous match"
-description = "Use 'N' to navigate to previous search match"
 
-hints = [
-    "'N' goes to the previous match (opposite of 'n')",
-    "Useful for reversing search direction",
-]
-
-[scenarios.setup]
-file_content = """struct Point { x: i32, y: i32 }
-struct Rect { x: i32, y: i32, w: i32, h: i32 }"""
-cursor_position = [1, 14]
-
-[scenarios.target]
-file_content = """struct Point { x: i32, y: i32 }
-struct Rect { x: i32, y: i32, w: i32, h: i32 }"""
-cursor_position = [0, 15]
-selection = [0, 15, 0, 16]
-
-[scenarios.solution]
-commands = ["#"]
-description = "Press '#' to search backward for 'x'"
-
-[scenarios.scoring]
-optimal_count = 1
-max_points = 100
-tolerance = 0
-
-[scenarios.metadata]
-category = "search"
-difficulty = "intermediate"
-tags = ["search", "previous", "match"]
-commands_taught = ["#"]
-estimated_time_seconds = 10

--- a/src/config/quests/tests.rs
+++ b/src/config/quests/tests.rs
@@ -598,7 +598,7 @@ fn test_validate_all_quest_templates() {
         ".", // Replace (r + char is handled specially)
         "r", // Selection
         "_", "C", // Search
-        "*", "n", "N", "#", // Text objects (match mode prefix + object)
+        "*", "n", "N", // Text objects (match mode prefix + object)
         "miw", "maw", "mip", "map", // Surround (match mode prefix + surround command)
         "ms", "md", "mr",
     ]

--- a/src/helix/commands.rs
+++ b/src/helix/commands.rs
@@ -130,7 +130,6 @@ pub const CMD_SEARCH_BACKWARD: &str = "?";
 pub const CMD_SEARCH_NEXT: &str = "n";
 pub const CMD_SEARCH_PREV: &str = "N";
 pub const CMD_SEARCH_WORD: &str = "*";
-pub const CMD_SEARCH_WORD_BACKWARD: &str = "#";
 pub const CMD_SEARCH_SELECTION: &str = "Alt-*";
 
 // View mode commands

--- a/src/helix/registry/definitions/search.rs
+++ b/src/helix/registry/definitions/search.rs
@@ -1,6 +1,6 @@
 //! Search command definitions
 //!
-//! Registers search commands (/, ?, n, N, *, #, Alt-*)
+//! Registers search commands (/, ?, n, N, *, Alt-*)
 
 use crate::helix::commands::*;
 use crate::helix::registry::command_registry::{Command, CommandRegistry};
@@ -87,19 +87,6 @@ pub fn register(registry: &mut CommandRegistry<NormalMode>) {
         ),
         search::search_selection,
     ));
-
-    registry.register(Command::new(
-        CommandMetadata::new(
-            "search_word_backward",
-            CMD_SEARCH_WORD_BACKWARD,
-            "Search word backward",
-            "Search backward for the word under cursor with word boundaries.",
-            Category::Search,
-            false,
-            None,
-        ),
-        search::search_word_under_cursor_backward,
-    ));
 }
 
 #[cfg(test)]
@@ -126,10 +113,6 @@ mod tests {
             registry.contains(CMD_SEARCH_SELECTION),
             "Missing search_selection"
         );
-        assert!(
-            registry.contains(CMD_SEARCH_WORD_BACKWARD),
-            "Missing search_word_backward"
-        );
     }
 
     #[test]
@@ -139,8 +122,8 @@ mod tests {
 
         let search_cmds = registry.commands_in_category(Category::Search);
         assert!(
-            search_cmds.len() >= 7,
-            "Expected at least 7 search commands"
+            search_cmds.len() >= 6,
+            "Expected at least 6 search commands"
         );
     }
 }

--- a/src/helix/simulator/commands/search.rs
+++ b/src/helix/simulator/commands/search.rs
@@ -1,4 +1,7 @@
 //! Search commands (/, ?, n, N, *, Alt-*)
+//!
+//! Note: Helix provides `*` for word search (forward). To search backward
+//! for word under cursor, use `*` followed by `N` to go to previous match.
 
 use crate::helix::simulator::HelixSimulator;
 use crate::helix::simulator::search_state::SearchDirection;
@@ -175,30 +178,6 @@ pub fn search_word_under_cursor<M: crate::helix::simulator::EditorMode>(
         .is_ok()
     {
         search_next_match(sim)?;
-    }
-
-    Ok(())
-}
-
-/// Search word under cursor backward (# command)
-pub fn search_word_under_cursor_backward<M: crate::helix::simulator::EditorMode>(
-    sim: &mut HelixSimulator<M>,
-) -> Result<(), UserError> {
-    let head = sim.selection.primary().head;
-    let slice = sim.doc.slice(..);
-
-    let Some((start, end)) = extract_word_at_cursor(slice, head) else {
-        return Ok(());
-    };
-
-    let word: String = slice.slice(start..end).chars().collect();
-
-    if sim
-        .search_state
-        .set_word_pattern(&word, SearchDirection::Backward)
-        .is_ok()
-    {
-        search_prev_match(sim)?;
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- Remove the `#` command for "search backward for word under cursor" which is a Vim-ism that does NOT exist in Helix editor
- Helix provides `*` for word search (forward) and `N` to navigate to previous matches
- Update all related code, tests, scenarios, and documentation

## Changes
- Remove `CMD_SEARCH_WORD_BACKWARD` constant from `commands.rs`
- Remove `search_word_under_cursor_backward` function from simulator
- Remove `#` command registration from registry
- Remove scenarios using `#` command
- Update tests to expect 6 search commands instead of 7
- Update documentation

## Test plan
- [x] All 1840 tests pass
- [x] No clippy warnings
- [x] Build succeeds

Fixes #144