### PR TITLE
fix(search): correct find_prev returning same match at cursor end (Issue #147)

### DIFF
--- a/scenarios/en/search/basic-search.toml
+++ b/scenarios/en/search/basic-search.toml
@@ -134,4 +134,50 @@ tags = ["search", "next", "match"]
 commands_taught = ["*"]
 estimated_time_seconds = 10
 
+[[scenarios]]
+id = "search_prev_001"
+name = "Search word backward"
+description = "Use '*' and 'N' to navigate backward through word occurrences"
+
+hints = [
+    "'*' starts forward search for word under cursor",
+    "'N' jumps to the previous match (opposite direction)",
+]
+
+[scenarios.setup]
+file_content = """fn main() {
+    let count = 0;
+    for i in 0..10 {
+        count += 1;
+    }
+    println!("{}", count);
+}"""
+cursor_position = [1, 8]
+
+[scenarios.target]
+file_content = """fn main() {
+    let count = 0;
+    for i in 0..10 {
+        count += 1;
+    }
+    println!("{}", count);
+}"""
+cursor_position = [5, 24]
+selection = [5, 19, 5, 24]
+
+[scenarios.solution]
+commands = ["*", "N", "N"]
+description = "Press '*' to search for 'count', then 'N' twice to reach the last occurrence"
+
+[scenarios.scoring]
+optimal_count = 3
+max_points = 100
+tolerance = 0
+
+[scenarios.metadata]
+category = "search"
+difficulty = "beginner"
+tags = ["search", "word", "backward", "prev"]
+commands_taught = ["*", "N"]
+estimated_time_seconds = 15
 

--- a/src/helix/simulator/commands/search.rs
+++ b/src/helix/simulator/commands/search.rs
@@ -411,12 +411,13 @@ mod tests {
         // Call search_backward
         search_backward(&mut sim).unwrap();
 
-        // Should find the last match (second "hello") since we're searching backward
-        // from byte position 17, and the match "hello" at 12-17 ends at 17,
-        // so it finds the match ending <= 17
+        // At position 17, the match "hello" at 12..17 ends exactly at 17.
+        // Since position 17 is the exclusive end of the match, find_prev uses
+        // strict inequality (range.end < pos), so 17 < 17 is false.
+        // This means the match at 12..17 is excluded, and we get the previous match.
         let range = sim.selection.primary();
-        assert_eq!(range.from(), 12);
-        assert_eq!(range.to(), 17);
+        assert_eq!(range.from(), 0);
+        assert_eq!(range.to(), 5);
     }
 
     #[test]

--- a/src/helix/simulator/search_state.rs
+++ b/src/helix/simulator/search_state.rs
@@ -199,9 +199,10 @@ impl SearchState {
             return None;
         }
 
-        // Binary search for the last match ending at or before pos
-        // We want the rightmost match where range.end <= pos
-        let idx = self.matches.partition_point(|range| range.end <= pos);
+        // Binary search for the last match ending strictly before pos
+        // We want the rightmost match where range.end < pos
+        // This ensures we skip the current match when cursor is at its end
+        let idx = self.matches.partition_point(|range| range.end < pos);
 
         if idx > 0 {
             let i = idx - 1;
@@ -325,25 +326,33 @@ mod tests {
         state.update_matches("foo bar foo baz foo");
         // Matches are at positions: 0..3, 8..11, 16..19
 
-        // At position 19 (end of doc), last match ends at 19, so find_prev finds match ending <= 19
-        // Match at 16..19 ends at 19, so 19 <= 19 is true, returns that match
+        // At position 19 (end of last match), find_prev returns PREVIOUS match (not current)
+        // Match at 16..19 ends at 19, but 19 < 19 is false, so it's excluded
         let (idx, range) = state.find_prev(19).unwrap();
-        assert_eq!(idx, 2);
-        assert_eq!(range, 16..19);
+        assert_eq!(idx, 1);
+        assert_eq!(range, 8..11);
 
-        // At position 16, we want matches ending <= 16
-        // Match 8..11 ends at 11, 11 <= 16 is true
+        // At position 16 (start of last match), matches ending < 16 are 0..3 and 8..11
         let (idx, range) = state.find_prev(16).unwrap();
         assert_eq!(idx, 1);
         assert_eq!(range, 8..11);
 
-        // At position 8 (start of second match), we want matches ending <= 8
-        // Match 0..3 ends at 3, 3 <= 8 is true
+        // At position 11 (end of second match), find_prev returns first match
+        let (idx, range) = state.find_prev(11).unwrap();
+        assert_eq!(idx, 0);
+        assert_eq!(range, 0..3);
+
+        // At position 8 (start of second match), matches ending < 8 is only 0..3
         let (idx, range) = state.find_prev(8).unwrap();
         assert_eq!(idx, 0);
         assert_eq!(range, 0..3);
 
-        // Wrap around: at position 0, no match ends <= 0, wraps to last match
+        // At position 3 (end of first match), no match ends < 3, wraps to last match
+        let (idx, range) = state.find_prev(3).unwrap();
+        assert_eq!(idx, 2);
+        assert_eq!(range, 16..19);
+
+        // Wrap around: at position 0, no match ends < 0, wraps to last match
         let (idx, range) = state.find_prev(0).unwrap();
         assert_eq!(idx, 2);
         assert_eq!(range, 16..19);
@@ -500,5 +509,55 @@ mod tests {
 
         // No matches
         assert!(state.find_prev(0).is_none());
+    }
+
+    #[test]
+    fn test_find_prev_cursor_at_match_end() {
+        let mut state = SearchState::new();
+        state.set_pattern("abc", SearchDirection::Forward).unwrap();
+        state.update_matches("abc def abc ghi abc");
+        // Matches at: 0..3, 8..11, 16..19
+
+        // When cursor is at END of a match, find_prev should NOT return that match
+        // Position 3 = end of first match, should wrap to last
+        let (idx, range) = state.find_prev(3).unwrap();
+        assert_eq!(idx, 2);
+        assert_eq!(range, 16..19);
+
+        // Position 11 = end of second match, should return first
+        let (idx, range) = state.find_prev(11).unwrap();
+        assert_eq!(idx, 0);
+        assert_eq!(range, 0..3);
+
+        // Position 19 = end of third match, should return second
+        let (idx, range) = state.find_prev(19).unwrap();
+        assert_eq!(idx, 1);
+        assert_eq!(range, 8..11);
+    }
+
+    #[test]
+    fn test_find_next_and_prev_symmetry() {
+        let mut state = SearchState::new();
+        state.set_pattern("x", SearchDirection::Forward).unwrap();
+        state.update_matches("x y x z x");
+        // Matches at: 0..1, 4..5, 8..9
+
+        // Starting at position 4 (start of second match)
+        // find_next should return match at 8..9
+        let (next_idx, _) = state.find_next(4).unwrap();
+        assert_eq!(next_idx, 2);
+
+        // find_prev should return match at 0..1
+        let (prev_idx, _) = state.find_prev(4).unwrap();
+        assert_eq!(prev_idx, 0);
+
+        // At position 5 (end of second match)
+        // find_next should return match at 8..9
+        let (next_idx, _) = state.find_next(5).unwrap();
+        assert_eq!(next_idx, 2);
+
+        // find_prev should return match at 0..1 (NOT 4..5!)
+        let (prev_idx, _) = state.find_prev(5).unwrap();
+        assert_eq!(prev_idx, 0);
     }
 }


### PR DESCRIPTION
## Summary

- Fix `find_prev` binary search predicate to use strict inequality (`range.end < pos` instead of `range.end <= pos`)
- Add edge case tests for cursor at match end
- Add symmetry test validating `find_next` and `find_prev` never return same match
- Add `search_prev_001` scenario demonstrating backward navigation with `* N N`

## Problem

When cursor was positioned at the end of a match (e.g., position 19 for match `16..19`), `find_prev` incorrectly returned the same match instead of the previous one. This caused the `N` command to appear stuck.

## Solution

Changed the predicate from `range.end <= pos` to `range.end < pos` in `find_prev`. This creates proper symmetry with `find_next` which uses `range.start <= pos` to skip current matches.

## Test plan

- [x] `cargo nextest run` - 1842 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - zero warnings
- [x] `cargo +nightly fmt --check` - pass
- [x] New tests verify edge cases: `test_find_prev_cursor_at_match_end`, `test_find_next_and_prev_symmetry`
- [x] New scenario `search_prev_001` validates backward navigation

Closes #147