### PR TITLE
fix(search): * command stays on current word instead of jumping (Issue #149)

### DIFF
--- a/scenarios/en/search/basic-search.toml
+++ b/scenarios/en/search/basic-search.toml
@@ -33,11 +33,11 @@ cursor_position = [3, 8]
 selection = [3, 8, 3, 13]
 
 [scenarios.solution]
-commands = ["*"]
-description = "Press '*' to jump to next occurrence of 'count'"
+commands = ["*", "n"]
+description = "Press '*' to search for 'count', then 'n' to jump to next occurrence"
 
 [scenarios.scoring]
-optimal_count = 1
+optimal_count = 2
 max_points = 100
 tolerance = 0
 
@@ -74,11 +74,11 @@ cursor_position = [1, 19]
 selection = [1, 15, 1, 19]
 
 [scenarios.solution]
-commands = ["*", "n"]
-description = "Press '*' then 'n' to reach the third 'data'"
+commands = ["*", "n", "n"]
+description = "Press '*' to search for 'data', then 'n' twice to reach the third 'data'"
 
 [scenarios.scoring]
-optimal_count = 2
+optimal_count = 3
 max_points = 100
 tolerance = 0
 
@@ -119,11 +119,11 @@ cursor_position = [1, 5]
 selection = [1, 4, 1, 5]
 
 [scenarios.solution]
-commands = ["*"]
-description = "Press '*' to find next 'a'"
+commands = ["*", "n"]
+description = "Press '*' to search for 'a', then 'n' to find next match"
 
 [scenarios.scoring]
-optimal_count = 1
+optimal_count = 2
 max_points = 100
 tolerance = 0
 
@@ -166,11 +166,11 @@ cursor_position = [5, 24]
 selection = [5, 19, 5, 24]
 
 [scenarios.solution]
-commands = ["*", "N", "N"]
-description = "Press '*' to search for 'count', then 'N' twice to reach the last occurrence"
+commands = ["*", "N"]
+description = "Press '*' to search for 'count', then 'N' to go backward to last occurrence"
 
 [scenarios.scoring]
-optimal_count = 3
+optimal_count = 2
 max_points = 100
 tolerance = 0
 

--- a/src/helix/simulator/commands/search.rs
+++ b/src/helix/simulator/commands/search.rs
@@ -160,6 +160,9 @@ pub fn goto_prev_match<M: crate::helix::simulator::EditorMode>(
 }
 
 /// Search word under cursor (* command)
+///
+/// Sets the word under cursor as search pattern and selects it,
+/// but does NOT jump to next match. Use `n` to navigate to next occurrence.
 pub fn search_word_under_cursor<M: crate::helix::simulator::EditorMode>(
     sim: &mut HelixSimulator<M>,
 ) -> Result<(), UserError> {
@@ -177,13 +180,16 @@ pub fn search_word_under_cursor<M: crate::helix::simulator::EditorMode>(
         .set_word_pattern(&word, SearchDirection::Forward)
         .is_ok()
     {
-        search_next_match(sim)?;
+        sim.selection = Selection::single(start, end);
     }
 
     Ok(())
 }
 
 /// Search selection text (Alt-* command)
+///
+/// Sets the current selection as search pattern. If selection is empty,
+/// falls back to word under cursor. Does NOT jump to next match.
 pub fn search_selection<M: crate::helix::simulator::EditorMode>(
     sim: &mut HelixSimulator<M>,
 ) -> Result<(), UserError> {
@@ -198,13 +204,9 @@ pub fn search_selection<M: crate::helix::simulator::EditorMode>(
     let slice = sim.doc.slice(..);
     let selection_text: String = slice.slice(start..end).chars().collect();
 
-    if sim
-        .search_state
+    sim.search_state
         .set_selection_pattern(&selection_text, SearchDirection::Forward)
-        .is_ok()
-    {
-        search_next_match(sim)?;
-    }
+        .ok();
 
     Ok(())
 }
@@ -228,10 +230,10 @@ mod tests {
         // Should have found the word pattern
         assert!(sim.search_state.has_pattern());
 
-        // Should have selected the next match (second "hello")
+        // Should have selected the CURRENT word (first "hello"), not jumped
         let range = sim.selection.primary();
-        assert_eq!(range.from(), 12);
-        assert_eq!(range.to(), 17);
+        assert_eq!(range.from(), 0);
+        assert_eq!(range.to(), 5);
     }
 
     #[test]
@@ -244,8 +246,13 @@ mod tests {
 
         search_word_under_cursor(&mut sim).unwrap();
 
-        // Should still find the word and jump to next occurrence
+        // Should find the word and select it (stay on current word)
         assert!(sim.search_state.has_pattern());
+
+        // Verify cursor stays on current word
+        let range = sim.selection.primary();
+        assert_eq!(range.from(), 0);
+        assert_eq!(range.to(), 5);
     }
 
     #[test]
@@ -261,10 +268,10 @@ mod tests {
         // Should have pattern set
         assert!(sim.search_state.has_pattern());
 
-        // Should have found next match
+        // Selection should remain unchanged (already set at 0..3)
         let range = sim.selection.primary();
-        assert_eq!(range.from(), 8);
-        assert_eq!(range.to(), 11);
+        assert_eq!(range.from(), 0);
+        assert_eq!(range.to(), 3);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fix `*` command to select current word without jumping to next occurrence
- Fix `Alt-*` command to keep current selection unchanged
- Update 4 search scenarios with correct command sequences
- Update test assertions for new behavior

## Problem

The `*` command (`search_word_under_cursor`) was incorrectly calling `search_next_match()` after setting the search pattern, causing it to immediately jump to the next occurrence.

In real Helix, `*` should:
1. Select the word under cursor
2. Set it as the search pattern
3. **Stay on the current word** (not jump)
4. Wait for `n` (next) or `N` (previous) to navigate

## Solution

- Replace `search_next_match(sim)?` with `sim.selection = Selection::single(start, end)` in `search_word_under_cursor`
- Remove `search_next_match(sim)?` call from `search_selection`

## Test plan

- [x] `cargo nextest run` - 1842 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - zero warnings
- [x] `cargo +nightly fmt --check` - pass
- [x] Security review - passed
- [x] Performance review - passed (performance-positive)
- [x] Testing review - adequate coverage

Closes #149