### PR TITLE
release: v0.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.8] - 2026-02-09
+
+### Added
+
+- **Arrow key cursor movement** — Optional user configuration to enable arrow keys for cursor movement (#153)
+
+### Changed
+
+- CI: Added dependabot auto-merge workflow for patch-level dependency updates
+- CI: Fixed codecov upload to not fail workflow on upload errors
+- CI: Fixed labeler workflow to use `pull_request_target` event
+
+### Dependencies
+
+- `rand`: 0.9.2 → 0.10.0 (adapted to `RngExt` trait rename)
+- `anyhow`: 1.0.100 → 1.0.101
+- `proptest`: 1.9.0 → 1.10.0
+- `regex`: 1.12.2 → 1.12.3
+- `criterion`: 0.8.1 → 0.8.2
+- `tui-big-text`: 0.8.1 → 0.8.2
+- `chrono`: 0.4.42 → 0.4.43
+- `thiserror`: 2.0.17 → 2.0.18
+- `time`: bumped to latest compatible
+- `bytes`: bumped to latest compatible
+
+### Quality
+
+- **Tests**: 1857 (up from 1842)
+- **Clippy**: Zero warnings
+
 ## [0.5.7] - 2026-01-15
 
 ### Added
@@ -1199,7 +1229,10 @@ With this release, all Phase 1 components are fully implemented:
 
 ---
 
-[Unreleased]: https://github.com/bug-ops/helix-trainer/compare/v0.5.5...HEAD
+[Unreleased]: https://github.com/bug-ops/helix-trainer/compare/v0.5.8...HEAD
+[0.5.8]: https://github.com/bug-ops/helix-trainer/compare/v0.5.7...v0.5.8
+[0.5.7]: https://github.com/bug-ops/helix-trainer/compare/v0.5.6...v0.5.7
+[0.5.6]: https://github.com/bug-ops/helix-trainer/compare/v0.5.5...v0.5.6
 [0.5.5]: https://github.com/bug-ops/helix-trainer/compare/v0.5.4...v0.5.5
 [0.5.4]: https://github.com/bug-ops/helix-trainer/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/bug-ops/helix-trainer/compare/v0.5.2...v0.5.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "helix-trainer"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helix-trainer"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Andrei G <andrei.g@my.com>"]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ All modes feature:
 - **136 Training Scenarios** — From basics to intermediate workflows with difficulty indicators
 - **55 Daily Quests** — Easy, medium, and hard challenges across all commands
 - **100% Offline** — No cloud, no tracking, all data stays local (`~/.config/helix-trainer/`)
+- **Arrow Key Navigation** — Optional `enable_arrow_keys_in_normal_mode` configuration for cursor movement
 
 ## Installation
 


### PR DESCRIPTION
## Summary

- Bump version 0.5.7 → 0.5.8
- Update CHANGELOG.md with all changes since v0.5.7
- Update README with arrow key navigation feature

## Changes since v0.5.7

- feat: arrow key cursor movement configuration (#153)
- ci: dependabot auto-merge, codecov fix, labeler fix
- deps: rand 0.10, anyhow 1.0.101, proptest 1.10, regex 1.12.3, criterion 0.8.2, tui-big-text 0.8.2, chrono 0.4.43, thiserror 2.0.18

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] 1857/1857 tests pass
- [x] `cargo +nightly fmt` applied