### PR TITLE
ci: add gate job as single required status check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,3 +293,28 @@ jobs:
           name: coverage-report
           path: lcov.info
           retention-days: 30
+
+  gate:
+    name: CI Gate
+    if: always()
+    needs: [test, fmt, clippy, security, msrv, build, coverage]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all jobs
+        run: |
+          results=(
+            "${{ needs.test.result }}"
+            "${{ needs.fmt.result }}"
+            "${{ needs.clippy.result }}"
+            "${{ needs.security.result }}"
+            "${{ needs.msrv.result }}"
+            "${{ needs.build.result }}"
+            "${{ needs.coverage.result }}"
+          )
+          for result in "${results[@]}"; do
+            if [[ "$result" != "success" ]]; then
+              echo "::error::One or more CI jobs failed or were cancelled"
+              exit 1
+            fi
+          done
+          echo "All CI jobs passed"


### PR DESCRIPTION
## Summary

- Add `CI Gate` job that depends on all 7 CI jobs: test, fmt, clippy, security, msrv, build, coverage
- Uses `if: always()` + result checking to ensure it runs even if upstream jobs fail or are cancelled
- Enables setting a single required status check (`CI Gate`) in branch protection instead of listing each job individually

## Test plan

- [ ] CI Gate passes when all jobs succeed
- [ ] CI Gate fails when any job fails