### PR TITLE
release: v0.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.9] - 2026-03-07
+
 ### Fixed
 
 - Fix double keypress on Windows by filtering `KeyEventKind::Release` events (#182)
@@ -1233,7 +1235,8 @@ With this release, all Phase 1 components are fully implemented:
 
 ---
 
-[Unreleased]: https://github.com/bug-ops/helix-trainer/compare/v0.5.8...HEAD
+[Unreleased]: https://github.com/bug-ops/helix-trainer/compare/v0.5.9...HEAD
+[0.5.9]: https://github.com/bug-ops/helix-trainer/compare/v0.5.8...v0.5.9
 [0.5.8]: https://github.com/bug-ops/helix-trainer/compare/v0.5.7...v0.5.8
 [0.5.7]: https://github.com/bug-ops/helix-trainer/compare/v0.5.6...v0.5.7
 [0.5.6]: https://github.com/bug-ops/helix-trainer/compare/v0.5.5...v0.5.6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2546,7 +2546,7 @@ dependencies = [
 
 [[package]]
 name = "helix-trainer"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helix-trainer"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Andrei G <andrei.g@my.com>"]


### PR DESCRIPTION
## Summary

- Bump version from 0.5.8 to 0.5.9
- Update CHANGELOG.md with release notes
- Update Cargo.lock

## Changes included

- Fix double keypress on Windows by filtering `KeyEventKind::Release` events (#182)

## Checklist

- [x] Version updated in Cargo.toml
- [x] CHANGELOG.md has release section with date
- [x] All CI checks pass locally (1793 tests, clippy clean, fmt clean)
- [ ] Ready for tagging after merge