### PR TITLE
docs: correct README command, scenario, and quest counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,15 @@ All modes feature:
 
 ### Training Features
 
+<img src="assets/training-mode.png" width="600" alt="Training Mode scenario list with daily quests">
+
 - **Smart Scenario Discovery** — Filter by category, difficulty, commands, or completion status with 6 sort modes
 - **Rich Metadata** — Every scenario tagged with category, difficulty, taught commands, and practice focus
 - **Syntax Highlighting** — Realistic Rust code snippets with proper highlighting
 - **Real Helix Accuracy** — Uses official `helix-core` library (v25.07.1)
-- **45+ Commands** — Movement, editing, clipboard, undo/redo, repeat, surround, text objects
-- **136 Training Scenarios** — From basics to intermediate workflows with difficulty indicators
-- **55 Daily Quests** — Easy, medium, and hard challenges across all commands
+- **100 Commands** — Movement, editing, clipboard, undo/redo, repeat, surround, text objects, multi-cursor
+- **134 Training Scenarios** — From basics to intermediate workflows with difficulty indicators
+- **70 Daily Quests** — Easy, medium, and hard challenges across all commands
 - **100% Offline** — No cloud, no tracking, all data stays local (`~/.config/helix-trainer/`)
 - **Arrow Key Navigation** — Optional `enable_arrow_keys_in_normal_mode` configuration for cursor movement
 
@@ -65,15 +67,6 @@ All modes feature:
 
 > [!NOTE]
 > **Requirements**: Terminal with Unicode support. No additional dependencies needed for pre-built binaries.
-
-### From crates.io
-
-```bash
-cargo install helix-trainer
-```
-
-> [!TIP]
-> Use `cargo binstall helix-trainer` for faster installation without compilation.
 
 ### Pre-built binaries (recommended)
 
@@ -142,7 +135,7 @@ Mode Selection
 │  │  ├─ ✅ Practice: Complete 3 scenarios
 │  │  ├─ ⏳ Learning: Try 2 new scenarios
 │  │  └─ 🔄 Review: 5 cards due
-│  ├─ Scenario List (136 available)
+│  ├─ Scenario List (134 available)
 │  │  ├─ Basic Movement (Mastered - 20% XP)
 │  │  ├─ Word Navigation (Proficient - 50% XP)
 │  │  └─ Delete Line (Learning - 100% XP)
@@ -157,19 +150,20 @@ Mode Selection
 
 | Category | Commands |
 |----------|----------|
-| **Movement** | <kbd>h</kbd> <kbd>j</kbd> <kbd>k</kbd> <kbd>l</kbd> <kbd>w</kbd> <kbd>b</kbd> <kbd>e</kbd> <kbd>0</kbd> <kbd>$</kbd> <kbd>gg</kbd> <kbd>ge</kbd> <kbd>gh</kbd> <kbd>gl</kbd> <kbd>gs</kbd> <kbd>[p</kbd> <kbd>]p</kbd> <kbd>^</kbd> |
+| **Movement** | <kbd>h</kbd> <kbd>j</kbd> <kbd>k</kbd> <kbd>l</kbd> <kbd>w</kbd> <kbd>b</kbd> <kbd>e</kbd> <kbd>W</kbd> <kbd>B</kbd> <kbd>E</kbd> <kbd>0</kbd> <kbd>$</kbd> <kbd>^</kbd> <kbd>gg</kbd> <kbd>ge</kbd> <kbd>gh</kbd> <kbd>gl</kbd> <kbd>gs</kbd> <kbd>[p</kbd> <kbd>]p</kbd> <kbd>Ctrl</kbd>+<kbd>b</kbd>/<kbd>f</kbd>/<kbd>u</kbd>/<kbd>d</kbd> |
 | **Find/Till** | <kbd>f</kbd> <kbd>F</kbd> <kbd>t</kbd> <kbd>T</kbd> <kbd>Alt</kbd>+<kbd>.</kbd> |
 | **Match Mode** | <kbd>mm</kbd> (brackets) <kbd>ms</kbd> (surround) <kbd>md</kbd> (delete surround) <kbd>mr</kbd> (replace surround) |
 | **Text Objects** | <kbd>ma</kbd>/<kbd>mi</kbd> + <kbd>w</kbd> <kbd>W</kbd> <kbd>(</kbd> <kbd>[</kbd> <kbd>{</kbd> <kbd><</kbd> <kbd>"</kbd> <kbd>'</kbd> <kbd>`</kbd> <kbd>p</kbd> |
-| **Selection** | <kbd>x</kbd> <kbd>X</kbd> <kbd>v</kbd> <kbd>;</kbd> <kbd>,</kbd> <kbd>%</kbd> <kbd>s</kbd> <kbd>S</kbd> <kbd>C</kbd> <kbd>K</kbd> |
-| **Editing** | <kbd>i</kbd> <kbd>a</kbd> <kbd>I</kbd> <kbd>A</kbd> <kbd>o</kbd> <kbd>O</kbd> <kbd>r</kbd> <kbd>c</kbd> <kbd>d</kbd> <kbd>J</kbd> <kbd>></kbd> <kbd><</kbd> <kbd>~</kbd> <kbd>R</kbd> |
+| **Selection** | <kbd>x</kbd> <kbd>X</kbd> <kbd>v</kbd> <kbd>;</kbd> <kbd>,</kbd> <kbd>Alt</kbd>+<kbd>,</kbd> <kbd>%</kbd> <kbd>s</kbd> <kbd>S</kbd> <kbd>Alt</kbd>+<kbd>s</kbd> <kbd>Alt</kbd>+<kbd>;</kbd> <kbd>&</kbd> <kbd>_</kbd> <kbd>Alt</kbd>+<kbd>-</kbd> <kbd>Alt</kbd>+<kbd>_</kbd> <kbd>C</kbd> <kbd>Alt</kbd>+<kbd>C</kbd> <kbd>K</kbd> <kbd>Alt</kbd>+<kbd>K</kbd> |
+| **Editing** | <kbd>i</kbd> <kbd>a</kbd> <kbd>I</kbd> <kbd>A</kbd> <kbd>o</kbd> <kbd>O</kbd> <kbd>r</kbd> <kbd>c</kbd> <kbd>Alt</kbd>+<kbd>c</kbd> <kbd>d</kbd> <kbd>J</kbd> <kbd>Alt</kbd>+<kbd>J</kbd> <kbd>></kbd> <kbd><</kbd> <kbd>~</kbd> <kbd>`</kbd> <kbd>Alt</kbd>+<kbd>`</kbd> <kbd>R</kbd> <kbd>Alt</kbd>+<kbd>x</kbd> <kbd>Ctrl</kbd>+<kbd>c</kbd> (toggle comment) |
 | **Clipboard** | <kbd>y</kbd> <kbd>p</kbd> <kbd>P</kbd> |
-| **Search** | <kbd>/</kbd> <kbd>?</kbd> <kbd>n</kbd> <kbd>N</kbd> <kbd>*</kbd> |
+| **Search** | <kbd>/</kbd> <kbd>?</kbd> <kbd>n</kbd> <kbd>N</kbd> <kbd>*</kbd> <kbd>Alt</kbd>+<kbd>*</kbd> |
 | **View** | <kbd>z</kbd> <kbd>zz</kbd> <kbd>zt</kbd> <kbd>zb</kbd> <kbd>zm</kbd> <kbd>zj</kbd> <kbd>zk</kbd> |
-| **Undo/Redo** | <kbd>u</kbd> <kbd>U</kbd> |
+| **Undo/Redo** | <kbd>u</kbd> <kbd>U</kbd> <kbd>Ctrl</kbd>+<kbd>r</kbd> |
 | **Repeat** | <kbd>.</kbd> (repeat last action) |
 | **Count Prefix** | <kbd>3h</kbd> <kbd>5j</kbd> <kbd>2w</kbd> (execute N times) |
 | **Insert Mode** | Text input, <kbd>Backspace</kbd>, arrow keys, <kbd>Esc</kbd> |
+| **Arrow Keys** *(optional)* | <kbd>←</kbd> <kbd>→</kbd> <kbd>↑</kbd> <kbd>↓</kbd> for cursor movement in Normal mode via `enable_arrow_keys_in_normal_mode` |
 
 All commands powered by `helix-core` v25.07.1 for 100% accuracy.
 


### PR DESCRIPTION
## Summary

- Fix stale counts: commands 45+ -> 100, scenarios 136 -> 134, quests 55 -> 70 (verified against source/scenario/quest files)
- Remove non-functional crates.io install instructions (publishing is disabled in release.yml)
- Expand the commands table with previously undocumented bindings (long-word movement, page scroll, Alt- selection/editing commands, comment toggle, redo alt)
- Add the unused training-mode.png screenshot to the Training Features section

## Test plan

- [x] Verified counts against `src/helix/commands.rs`, `scenarios/en/**/*.toml`, and `quests/en/daily.toml`
- [x] Verified crates.io publishing is commented out in `.github/workflows/release.yml`
- [x] Confirmed all referenced assets exist in `assets/`