### PR TITLE
fix(minigame): stop pause timer leak and fix arcade key-history popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Pausing an arcade/survival/challenge mini-game session no longer lets the active scenario's countdown timer keep draining in real time; elapsed time now excludes accumulated paused duration (#271)
+- Arcade mode's key-history popup is now gated behind a visibility flag reset on scenario transitions instead of staying permanently visible after the first keypress, matching Training mode's behavior; the popup is also repositioned/capped to avoid overlapping the Target/Timer/Score HUD or corrupting editor pane borders in both modes (#272)
+
 ## [0.5.12] - 2026-07-27
 
 ### Dependencies

--- a/src/constants/ui.rs
+++ b/src/constants/ui.rs
@@ -12,7 +12,11 @@ pub const HINT_POPUP_MAX_HEIGHT: u16 = 10;
 /// Number of keys to show in key history
 pub const KEY_HISTORY_DISPLAY_SIZE: usize = 5;
 /// Width of each big text character (in cells)
-pub const BIG_TEXT_CHAR_WIDTH_CELLS: usize = 5;
+///
+/// The `tui-big-text` glyph is 8 pixels wide; `PixelSize::HalfHeight` only
+/// changes the vertical pixel-to-cell ratio, so the horizontal ratio stays
+/// 1:1 and each character still occupies a full 8 cells.
+pub const BIG_TEXT_CHAR_WIDTH_CELLS: usize = 8;
 /// Minimum width for key history popup
 pub const KEY_HISTORY_MIN_WIDTH: u16 = 30;
 /// Height of big text display (in lines)

--- a/src/minigame/session.rs
+++ b/src/minigame/session.rs
@@ -54,6 +54,12 @@ pub struct ActiveMiniScenario {
 
     /// Actions taken so far
     actions: Vec<String>,
+
+    /// When the current pause span began, if paused
+    paused_at: Option<Instant>,
+
+    /// Total duration accumulated across all completed pause spans
+    total_paused: Duration,
 }
 
 impl ActiveMiniScenario {
@@ -73,6 +79,8 @@ impl ActiveMiniScenario {
             started_at: Instant::now(),
             time_limit,
             actions: Vec::new(),
+            paused_at: None,
+            total_paused: Duration::ZERO,
         })
     }
 
@@ -81,9 +89,32 @@ impl ActiveMiniScenario {
         self.simulator.matches_snapshot(&self.target_snapshot)
     }
 
-    /// Get elapsed time since scenario started
+    /// Freeze the countdown timer
+    ///
+    /// Idempotent: calling this while already paused has no effect.
+    pub fn pause(&mut self) {
+        if self.paused_at.is_none() {
+            self.paused_at = Some(Instant::now());
+        }
+    }
+
+    /// Resume the countdown timer, accumulating the just-finished pause span
+    ///
+    /// Idempotent: calling this while not paused has no effect.
+    pub fn resume(&mut self) {
+        if let Some(paused_at) = self.paused_at.take() {
+            self.total_paused += paused_at.elapsed();
+        }
+    }
+
+    /// Get elapsed time since scenario started, excluding any paused duration
     pub fn elapsed(&self) -> Duration {
-        self.started_at.elapsed()
+        let paused = self.total_paused
+            + self
+                .paused_at
+                .map(|p| p.elapsed())
+                .unwrap_or(Duration::ZERO);
+        self.started_at.elapsed().saturating_sub(paused)
     }
 
     /// Get remaining time before timeout
@@ -154,7 +185,7 @@ impl crate::game::PlayableScenario for ActiveMiniScenario {
     }
 
     fn elapsed(&self) -> std::time::Duration {
-        self.started_at.elapsed()
+        ActiveMiniScenario::elapsed(self)
     }
 
     fn all_cursors(&self) -> Vec<(usize, usize)> {
@@ -649,6 +680,9 @@ impl MiniGameSession {
     pub fn pause(&mut self) {
         if self.state.is_playing() {
             self.state = MiniGameState::Paused;
+            if let Some(ref mut current) = self.current {
+                current.pause();
+            }
         }
     }
 
@@ -667,6 +701,9 @@ impl MiniGameSession {
     pub fn resume(&mut self) {
         if self.state.is_paused() {
             self.state = MiniGameState::Playing;
+            if let Some(ref mut current) = self.current {
+                current.resume();
+            }
         }
     }
 
@@ -1067,6 +1104,108 @@ mod tests {
 
         session.pause();
         assert!(session.state.is_paused());
+
+        session.resume();
+        assert!(session.state.is_playing());
+    }
+
+    #[test]
+    fn test_active_scenario_pause_freezes_elapsed_time() {
+        let scenario = create_test_scenario("s1", Difficulty::Beginner);
+        let mut active = ActiveMiniScenario::new(scenario, Duration::from_secs(60)).unwrap();
+
+        let elapsed_before_pause = active.elapsed();
+        active.pause();
+
+        std::thread::sleep(Duration::from_millis(50));
+        let elapsed_while_paused = active.elapsed();
+
+        // Elapsed time must not advance while paused, even though real time passed.
+        assert!(
+            elapsed_while_paused < elapsed_before_pause + Duration::from_millis(20),
+            "elapsed grew while paused: before={elapsed_before_pause:?} during={elapsed_while_paused:?}"
+        );
+
+        active.resume();
+        std::thread::sleep(Duration::from_millis(30));
+        let elapsed_after_resume = active.elapsed();
+
+        // Once resumed, elapsed time should advance again.
+        assert!(
+            elapsed_after_resume > elapsed_while_paused,
+            "elapsed did not advance after resume: during={elapsed_while_paused:?} after={elapsed_after_resume:?}"
+        );
+    }
+
+    #[test]
+    fn test_active_scenario_repeated_pause_resume_accumulates_total_paused() {
+        let scenario = create_test_scenario("s1", Difficulty::Beginner);
+        let mut active = ActiveMiniScenario::new(scenario, Duration::from_secs(60)).unwrap();
+
+        // First pause/resume cycle.
+        active.pause();
+        std::thread::sleep(Duration::from_millis(30));
+        active.resume();
+        let total_paused_after_first = active.total_paused;
+        assert!(total_paused_after_first >= Duration::from_millis(20));
+
+        // Second pause/resume cycle should add to the accumulated total, not reset it.
+        active.pause();
+        std::thread::sleep(Duration::from_millis(30));
+        active.resume();
+        let total_paused_after_second = active.total_paused;
+
+        assert!(
+            total_paused_after_second > total_paused_after_first,
+            "second pause cycle did not accumulate: first={total_paused_after_first:?} second={total_paused_after_second:?}"
+        );
+    }
+
+    #[test]
+    fn test_active_scenario_pause_resume_idempotent() {
+        let scenario = create_test_scenario("s1", Difficulty::Beginner);
+        let mut active = ActiveMiniScenario::new(scenario, Duration::from_secs(60)).unwrap();
+
+        // Resuming without a prior pause is a no-op.
+        active.resume();
+        assert_eq!(active.total_paused, Duration::ZERO);
+        assert!(active.paused_at.is_none());
+
+        // Pausing twice in a row should not reset the paused_at anchor.
+        active.pause();
+        let paused_at_first = active.paused_at;
+        std::thread::sleep(Duration::from_millis(10));
+        active.pause();
+        assert_eq!(active.paused_at, paused_at_first);
+
+        active.resume();
+        assert!(active.total_paused >= Duration::from_millis(5));
+    }
+
+    #[test]
+    fn test_minigame_session_pause_resume_freezes_scenario_elapsed() {
+        let scenarios = Arc::new(vec![create_test_scenario("s1", Difficulty::Beginner)]);
+        let mut session = MiniGameSession::new(scenarios, None);
+        session.state = MiniGameState::Playing;
+        let _ = session.load_next_scenario();
+
+        session.pause();
+        assert!(session.state.is_paused());
+
+        let elapsed_at_pause = session
+            .current_scenario()
+            .expect("scenario should be active")
+            .elapsed();
+        std::thread::sleep(Duration::from_millis(40));
+
+        let elapsed_while_paused = session
+            .current_scenario()
+            .expect("scenario should still be active")
+            .elapsed();
+        assert!(
+            elapsed_while_paused < elapsed_at_pause + Duration::from_millis(20),
+            "session-level pause did not freeze scenario elapsed time"
+        );
 
         session.resume();
         assert!(session.state.is_playing());

--- a/src/ui/render/minigame.rs
+++ b/src/ui/render/minigame.rs
@@ -48,8 +48,12 @@ pub(super) fn render_minigame(frame: &mut Frame, state: &AppState) {
         render_countdown(frame, area, session);
     } else if session.state().is_playing() {
         render_playing(frame, area, session);
-        // Show key history during gameplay
-        super::popups::render_key_history_popup(frame, minigame_data.key_history.keys());
+        // Show key history popup after first keypress (reset on scenario transitions)
+        // Reserve space for the Timer + Stats bars (3 + 3) so the popup never
+        // overlaps them.
+        if state.ui.show_key_history {
+            super::popups::render_key_history_popup(frame, minigame_data.key_history.keys(), 6);
+        }
     } else if session.state().is_transition() {
         render_transition(frame, area, session, minigame_data.last_xp_earned);
     } else if session.state().is_paused() {

--- a/src/ui/render/popups.rs
+++ b/src/ui/render/popups.rs
@@ -52,8 +52,17 @@ pub(super) fn render_hint_popup(frame: &mut Frame, state: &AppState) {
 
 /// Render key history popup showing last 5 keys pressed with large text
 ///
-/// Used by both training mode and arcade mode.
-pub(super) fn render_key_history_popup(frame: &mut Frame, key_history: &[String]) {
+/// Used by both training mode and arcade mode. `reserved_bottom` is the height
+/// (in rows) of the fixed-height status/HUD bars anchored to the bottom of the
+/// screen (e.g. stats, timer, instructions bars); the popup is positioned
+/// directly above that reserved strip so it never overlaps those panes, and is
+/// skipped entirely if there isn't enough room to render without corrupting
+/// the editor panes above it.
+pub(super) fn render_key_history_popup(
+    frame: &mut Frame,
+    key_history: &[String],
+    reserved_bottom: u16,
+) {
     if key_history.is_empty() {
         return;
     }
@@ -74,24 +83,34 @@ pub(super) fn render_key_history_popup(frame: &mut Frame, key_history: &[String]
     }
 
     // Calculate required dimensions before consuming key_text
-    // Each character in Full size is approximately 4 cells wide, plus spacing
+    // PixelSize::HalfHeight only halves the glyph height, not the width - each
+    // character (including the space separators) is still BIG_TEXT_CHAR_WIDTH_CELLS wide
     let chars_count = key_text.chars().count();
     let popup_width =
         ((chars_count * BIG_TEXT_CHAR_WIDTH_CELLS).max(KEY_HISTORY_MIN_WIDTH as usize) as u16)
             .min(area.width.saturating_sub(4));
-    let popup_height = BIG_TEXT_HEIGHT_LINES + 2; // +2 for borders
+    // HalfHeight halves the glyph height (BIG_TEXT_HEIGHT_LINES) so the popup fits
+    // within the space reserved above the bottom HUD bars instead of spilling
+    // into the editor panes.
+    let popup_height = BIG_TEXT_HEIGHT_LINES / 2 + 2; // +2 for borders
+
+    // Not enough vertical room above the reserved HUD strip - skip rendering
+    // rather than overlapping the editor panes or the HUD bars themselves.
+    if area.height < reserved_bottom + popup_height {
+        return;
+    }
 
     // Create BigText widget with large font and cyan color
     let big_text = BigText::builder()
-        .pixel_size(PixelSize::Full)
+        .pixel_size(PixelSize::HalfHeight)
         .style(Style::default().fg(Color::Cyan))
         .lines(vec![key_text.into()])
         .centered()
         .build();
 
-    // Position in bottom right corner
+    // Position in bottom right corner, directly above the reserved HUD strip
     let popup_x = area.width.saturating_sub(popup_width + 2);
-    let popup_y = area.height.saturating_sub(popup_height + 2);
+    let popup_y = area.height.saturating_sub(reserved_bottom + popup_height);
 
     let popup_area = Rect {
         x: popup_x,
@@ -213,5 +232,79 @@ pub(super) fn render_notifications(frame: &mut Frame, state: &AppState) {
             );
 
         frame.render_widget(paragraph, popup_area);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::{Terminal, backend::TestBackend, buffer::Buffer};
+
+    /// `BIG_TEXT_HEIGHT_LINES / 2 + 2` from `render_key_history_popup`.
+    const POPUP_HEIGHT: u16 = BIG_TEXT_HEIGHT_LINES / 2 + 2;
+
+    fn render_popup(width: u16, height: u16, reserved_bottom: u16, keys: &[String]) -> Buffer {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render_key_history_popup(frame, keys, reserved_bottom))
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    fn is_blank(buffer: &Buffer) -> bool {
+        buffer
+            .content
+            .iter()
+            .all(|cell| cell.symbol() == " " || cell.symbol().is_empty())
+    }
+
+    fn row_is_blank(buffer: &Buffer, y: u16) -> bool {
+        (0..buffer.area.width).all(|x| {
+            let symbol = buffer[(x, y)].symbol();
+            symbol == " " || symbol.is_empty()
+        })
+    }
+
+    #[test]
+    fn test_render_key_history_popup_empty_history_skips_render() {
+        let buffer = render_popup(80, 20, 6, &[]);
+        assert!(is_blank(&buffer), "empty key history must render nothing");
+    }
+
+    #[test]
+    fn test_render_key_history_popup_skips_when_not_enough_room() {
+        let reserved_bottom = 6;
+        // One row short of the minimum height the popup needs above the reserved strip.
+        let height = reserved_bottom + POPUP_HEIGHT - 1;
+        let buffer = render_popup(80, height, reserved_bottom, &["a".to_string()]);
+
+        assert!(
+            is_blank(&buffer),
+            "popup must not render when there isn't enough vertical room"
+        );
+    }
+
+    #[test]
+    fn test_render_key_history_popup_reserves_space_above_bar() {
+        let reserved_bottom = 6;
+        let height = 20;
+        let buffer = render_popup(80, height, reserved_bottom, &["a".to_string()]);
+
+        // The reserved HUD strip (the bottom `reserved_bottom` rows) must stay untouched.
+        for y in (height - reserved_bottom)..height {
+            assert!(
+                row_is_blank(&buffer, y),
+                "reserved bottom row {y} was overwritten by the popup"
+            );
+        }
+
+        // The popup itself must have rendered directly above the reserved strip
+        // (its bottom border sits on the row just above the reserved area).
+        let popup_bottom_row = height - reserved_bottom - 1;
+        assert!(
+            !row_is_blank(&buffer, popup_bottom_row),
+            "popup was not rendered directly above the reserved strip"
+        );
     }
 }

--- a/src/ui/render/task.rs
+++ b/src/ui/render/task.rs
@@ -223,8 +223,10 @@ pub(super) fn render_task_screen(frame: &mut Frame, state: &AppState) {
         }
 
         // Show key history popup if visible
+        // Reserve space for the Stats + Instructions bars (3 + 3) plus the
+        // screen's outer margin(1) so the popup never overlaps them.
         if state.ui.show_key_history {
-            render_key_history_popup(frame, task_data.key_history.keys());
+            render_key_history_popup(frame, task_data.key_history.keys(), 7);
         }
 
         // Show success message if scenario just completed

--- a/src/ui/state/handlers/minigame.rs
+++ b/src/ui/state/handlers/minigame.rs
@@ -60,6 +60,7 @@ pub(in crate::ui::state) fn handle_start_minigame(
 ) -> Result<HandlerOutcome, UserError> {
     // Pass performance tracker for FSRS-weighted scenario selection
     create_minigame_session(ctx.game, Some(&ctx.progress.performance_tracker));
+    ctx.ui.show_key_history = false;
     Ok(HandlerOutcome::Transition(Box::new(TypedScreen::MiniGame(
         MiniGameData::default(),
     ))))
@@ -108,6 +109,9 @@ fn execute_minigame_command(state: &mut AppState, command: &str) -> Result<(), U
     if let TypedScreen::MiniGame(ref mut data) = state.screen {
         data.add_key_to_history(format_key_for_display(command));
     }
+
+    // Show key history popup after first keypress (reset on scenario transitions)
+    state.ui.show_key_history = true;
 
     // Snapshot quest completion status before updates
     let was_completed = super::snapshot_quest_completion(state);
@@ -194,14 +198,10 @@ pub(in crate::ui::state) fn handle_minigame_command(
     state: &mut AppState,
     command: std::borrow::Cow<'static, str>,
 ) -> Result<(), UserError> {
-    // Get minigame data for input state machine
-    let TypedScreen::MiniGame(ref mut minigame_data) = state.screen else {
+    // Only handle if we're on the MiniGame screen
+    if !matches!(state.screen, TypedScreen::MiniGame(_)) {
         return Ok(());
-    };
-
-    // Add key to history for display
-    let display_key = format_key_for_display(&command);
-    minigame_data.add_key_to_history(display_key);
+    }
 
     // Check if we're in insert mode
     let is_insert_mode = state
@@ -220,7 +220,6 @@ pub(in crate::ui::state) fn handle_minigame_command(
     // Convert the command string to a KeyEvent for the state machine
     let key_event = command_to_key_event(&command);
 
-    // Need to re-borrow minigame_data after getting is_insert_mode
     let TypedScreen::MiniGame(ref mut minigame_data) = state.screen else {
         return Ok(());
     };
@@ -264,12 +263,18 @@ pub(in crate::ui::state) fn handle_minigame_scenario_complete(
 
 /// Handle advancing to next scenario (after transition delay)
 pub(in crate::ui::state) fn handle_minigame_next_scenario(
-    ctx: &mut HandlerContext<'_>,
+    state: &mut AppState,
 ) -> Result<HandlerOutcome, UserError> {
-    if let Some(ref mut session) = ctx.game.minigame_session
+    if let Some(ref mut session) = state.game.minigame_session
         && let Err(e) = session.complete_transition()
     {
         tracing::warn!("Failed to load next mini-game scenario: {:?}", e);
+    }
+    // Hide the key history popup and clear its buffered keys so the previous
+    // scenario's keys don't leak into the new scenario's display
+    state.ui.show_key_history = false;
+    if let TypedScreen::MiniGame(ref mut data) = state.screen {
+        data.clear_key_history();
     }
     Ok(HandlerOutcome::Stay)
 }
@@ -414,6 +419,72 @@ mod tests {
 
         if let Some(ref session) = state.game.minigame_session {
             assert!(session.state().is_countdown());
+        }
+    }
+
+    #[test]
+    fn test_start_minigame_hides_key_history() {
+        let mut state = create_test_state();
+        // Default UIState starts with show_key_history true; starting a session
+        // must reset it so a stale popup from a previous session isn't shown.
+        state.ui.show_key_history = true;
+
+        start_minigame(&mut state);
+
+        assert!(!state.ui.show_key_history);
+    }
+
+    #[test]
+    fn test_execute_minigame_command_shows_key_history() {
+        let mut state = create_test_state();
+        start_minigame(&mut state);
+        state.ui.show_key_history = false;
+
+        // Transition to playing
+        if let Some(ref mut session) = state.game.minigame_session {
+            session.tick_countdown();
+            session.tick_countdown();
+            session.tick_countdown();
+        }
+
+        let _ = execute_minigame_command(&mut state, "h");
+
+        assert!(
+            state.ui.show_key_history,
+            "first keypress should reveal the key history popup"
+        );
+    }
+
+    #[test]
+    fn test_handle_minigame_next_scenario_hides_key_history() {
+        let mut state = create_test_state();
+        start_minigame(&mut state);
+
+        // Transition to playing and simulate a keypress that revealed the popup
+        if let Some(ref mut session) = state.game.minigame_session {
+            session.tick_countdown();
+            session.tick_countdown();
+            session.tick_countdown();
+            session.advance_to_next();
+        }
+        state.ui.show_key_history = true;
+        if let TypedScreen::MiniGame(ref mut data) = state.screen {
+            data.add_key_to_history("h".to_string());
+        }
+
+        handle_minigame_next_scenario(&mut state).unwrap();
+
+        assert!(
+            !state.ui.show_key_history,
+            "advancing to the next scenario should hide the stale key history popup"
+        );
+        if let TypedScreen::MiniGame(ref data) = state.screen {
+            assert!(
+                data.key_history.is_empty(),
+                "advancing to the next scenario should clear the previous scenario's buffered keys"
+            );
+        } else {
+            panic!("expected MiniGame screen");
         }
     }
 
@@ -789,6 +860,36 @@ mod tests {
     }
 
     #[test]
+    fn test_handle_minigame_command_pushes_key_history_once_per_keypress() {
+        use std::borrow::Cow;
+
+        let mut state = create_test_state();
+        start_minigame(&mut state);
+
+        // Transition to playing
+        if let Some(ref mut session) = state.game.minigame_session {
+            session.tick_countdown();
+            session.tick_countdown();
+            session.tick_countdown();
+        }
+
+        // Regression test for S3: handle_minigame_command used to push to key
+        // history itself AND call execute_minigame_command (which also pushes),
+        // double-counting every resolved keystroke.
+        let _ = handle_minigame_command(&mut state, Cow::Borrowed("j"));
+
+        if let TypedScreen::MiniGame(ref data) = state.screen {
+            assert_eq!(
+                data.key_history.len(),
+                1,
+                "a single resolved keypress must add exactly one history entry"
+            );
+        } else {
+            panic!("expected MiniGame screen");
+        }
+    }
+
+    #[test]
     fn test_handle_minigame_command_no_session() {
         use std::borrow::Cow;
 
@@ -887,13 +988,7 @@ mod tests {
             session.advance_to_next();
         }
 
-        let mut ctx = HandlerContext::new(
-            &mut state.ui,
-            &mut state.game,
-            &mut state.progress,
-            &state.config,
-        );
-        let outcome = handle_minigame_next_scenario(&mut ctx).unwrap();
+        let outcome = handle_minigame_next_scenario(&mut state).unwrap();
 
         assert!(matches!(outcome, HandlerOutcome::Stay));
     }

--- a/src/ui/state/handlers/mode_selection.rs
+++ b/src/ui/state/handlers/mode_selection.rs
@@ -100,6 +100,7 @@ pub(in crate::ui::state) fn handle_select_arcade_mode(
 ) -> Result<HandlerOutcome, UserError> {
     // Use shared session creation with FSRS tracker for weighted selection
     super::minigame::create_minigame_session(ctx.game, Some(&ctx.progress.performance_tracker));
+    ctx.ui.show_key_history = false;
 
     Ok(HandlerOutcome::Transition(Box::new(TypedScreen::MiniGame(
         MiniGameData::default(),
@@ -139,6 +140,7 @@ pub(in crate::ui::state) fn handle_launch_minigame_mode(
     let mut session = MiniGameSession::with_mode(Arc::new(scenarios), tracker_clone, mode);
     session.start(); // Begin countdown
     ctx.game.minigame_session = Some(session);
+    ctx.ui.show_key_history = false;
 
     // Create MiniGameData with mode info
     let minigame_data = MiniGameData {
@@ -273,6 +275,33 @@ mod tests {
         if let HandlerOutcome::Transition(screen) = outcome {
             assert!(matches!(*screen, TypedScreen::MiniGame(_)));
         }
+    }
+
+    #[test]
+    fn test_select_arcade_mode_hides_key_history() {
+        // Regression test for S1: this is a live dispatch path (unlike
+        // handle_start_minigame, which nothing emits), so it must reset the
+        // flag itself rather than relying on a caller to do it.
+        let (mut ui, mut game, mut progress, config) = create_test_context();
+        ui.show_key_history = true;
+        let mut ctx = HandlerContext::new(&mut ui, &mut game, &mut progress, &config);
+
+        handle_select_arcade_mode(&mut ctx).unwrap();
+
+        assert!(!ctx.ui.show_key_history);
+    }
+
+    #[test]
+    fn test_launch_minigame_mode_hides_key_history() {
+        // Regression test for S1 on the second live dispatch path.
+        let (mut ui, mut game, mut progress, config) = create_test_context_with_scenarios();
+        ui.show_key_history = true;
+        let mut ctx = HandlerContext::new(&mut ui, &mut game, &mut progress, &config);
+
+        let mode = crate::minigame::MiniGameMode::default();
+        handle_launch_minigame_mode(&mut ctx, mode).unwrap();
+
+        assert!(!ctx.ui.show_key_history);
     }
 
     #[test]

--- a/src/ui/state/mod.rs
+++ b/src/ui/state/mod.rs
@@ -673,13 +673,7 @@ pub fn update(state: &mut AppState, msg: Message) -> Result<(), UserError> {
             Ok(())
         }
         Message::MiniGameNextScenario => {
-            let mut ctx = HandlerContext::new(
-                &mut state.ui,
-                &mut state.game,
-                &mut state.progress,
-                &state.config,
-            );
-            let outcome = handlers::handle_minigame_next_scenario(&mut ctx)?;
+            let outcome = handlers::handle_minigame_next_scenario(state)?;
             apply_outcome(state, outcome);
             Ok(())
         }


### PR DESCRIPTION
## Summary
- Arcade/survival/challenge pause no longer leaks real wall-clock time into the scenario countdown: `ActiveMiniScenario` now accumulates paused duration (`paused_at`/`total_paused`) and subtracts it in `elapsed()`; `MiniGameSession::pause()`/`resume()` propagate to the active scenario.
- The arcade key-history popup is now gated behind `UIState::show_key_history` and cleared on scenario transitions, mirroring Training mode, instead of rendering permanently after the first keypress.
- Fixed a latent double key-push per keystroke in the arcade key-history buffer, and corrected the popup's glyph width/positioning so it no longer overlaps the Timer/Score HUD or Target panel in either mode.

## Test plan
- [x] `cargo nextest run --workspace --all-features --lib --bins` (1806/1806 pass, including 14 new/updated tests for pause-freeze accumulation, key-history gating on the real dispatch paths, and single-push-per-keystroke)
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Adversarial critique pass and code review completed and approved

Fixes #271
Fixes #272