### PR TITLE
fix(config): unify scenario/quest id validation and harden config invariants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pausing an arcade/survival/challenge mini-game session no longer lets the active scenario's countdown timer keep draining in real time; elapsed time now excludes accumulated paused duration (#271)
 - Arcade mode's key-history popup is now gated behind a visibility flag reset on scenario transitions instead of staying permanently visible after the first keypress, matching Training mode's behavior; the popup is also repositioned/capped to avoid overlapping the Target/Timer/Score HUD or corrupting editor pane borders in both modes (#272)
+- Scenario `id` fields with an empty string now fail validation, matching quest template behavior (#275)
+
+### Changed
+
+- **BREAKING**: `ScoringConfig.optimal_count` is now `NonZeroUsize` instead of `usize`; TOML layout is unchanged, but zero rejection now happens at parse time, so `optimal_count = 0` now surfaces as "Failed to load scenario file..." instead of "Operation failed..." (#277)
+- **BREAKING**: Removed the now-unreachable `SecurityError::InvalidScoringConfig` variant (#277)
+- Unified scenario and quest ID validation into `security::validators::validate_id_field` (#275)
+- Consolidated scenario/quest TOML parsing, count-limit enforcement, and per-item validation into a shared `config::loader::parse_and_validate` pipeline (#276)
 
 ## [0.5.12] - 2026-07-27
 

--- a/benches/filtering_sorting.rs
+++ b/benches/filtering_sorting.rs
@@ -46,7 +46,7 @@ fn create_scenario(
         alternatives: vec![],
         hints: vec!["Use x to delete a line".to_string()],
         scoring: ScoringConfig {
-            optimal_count: 1,
+            optimal_count: std::num::NonZeroUsize::new(1).unwrap(),
             max_points: 100,
             tolerance: 0,
         },

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -1,0 +1,121 @@
+//! Shared TOML parse-and-validate pipeline for scenario/quest files.
+
+use crate::security::SecurityError;
+
+/// TOML file wrapper carrying a list of domain items.
+pub(crate) trait ItemsFile: serde::de::DeserializeOwned {
+    type Item;
+    fn into_items(self) -> Vec<Self::Item>;
+}
+
+/// Parses `content` as `F`, unwraps its items, enforces `max_count`, and
+/// runs `validate` over each item.
+///
+/// Returns the unsanitized `SecurityError` (rather than `UserError`) so
+/// callers can log the precise cause (e.g. `toml::de::Error` line/column)
+/// before converting to a sanitized error for the user.
+pub(crate) fn parse_and_validate<F>(
+    content: &str,
+    max_count: usize,
+    validate: impl Fn(&F::Item) -> Result<(), SecurityError>,
+) -> Result<Vec<F::Item>, SecurityError>
+where
+    F: ItemsFile,
+{
+    let file: F = toml::from_str(content).map_err(|e| SecurityError::InvalidToml(e.to_string()))?;
+
+    let items = file.into_items();
+
+    if items.len() > max_count {
+        return Err(SecurityError::TooManyScenarios {
+            max: max_count,
+            actual: items.len(),
+        });
+    }
+
+    for item in &items {
+        validate(item)?;
+    }
+
+    Ok(items)
+}
+
+impl ItemsFile for super::scenarios::ScenariosFile {
+    type Item = super::scenarios::Scenario;
+    fn into_items(self) -> Vec<Self::Item> {
+        self.scenarios
+    }
+}
+
+impl ItemsFile for super::quests::QuestsFile {
+    type Item = super::quests::QuestTemplate;
+    fn into_items(self) -> Vec<Self::Item> {
+        self.quests
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::scenarios::ScenariosFile;
+    use super::*;
+
+    fn two_scenario_toml() -> String {
+        let scenario = |id: &str| {
+            format!(
+                r#"
+[[scenarios]]
+id = "{id}"
+name = "Test"
+description = "Test"
+
+[scenarios.setup]
+file_content = "test"
+cursor_position = [0, 0]
+
+[scenarios.target]
+file_content = "test"
+cursor_position = [0, 0]
+
+[scenarios.solution]
+commands = ["test"]
+description = "test"
+
+[scenarios.scoring]
+optimal_count = 1
+max_points = 100
+tolerance = 0
+"#
+            )
+        };
+        format!("{}\n{}", scenario("scenario_a"), scenario("scenario_b"))
+    }
+
+    #[test]
+    fn parse_and_validate_returns_items_within_limit() {
+        let toml = two_scenario_toml();
+        let items = parse_and_validate::<ScenariosFile>(&toml, 2, |_| Ok(())).unwrap();
+        assert_eq!(items.len(), 2);
+    }
+
+    #[test]
+    fn parse_and_validate_rejects_invalid_toml() {
+        let result = parse_and_validate::<ScenariosFile>("not valid toml {{{", 100, |_| Ok(()));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_and_validate_rejects_over_max_count() {
+        let toml = two_scenario_toml();
+        let result = parse_and_validate::<ScenariosFile>(&toml, 1, |_| Ok(()));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_and_validate_propagates_item_validation_error() {
+        let toml = two_scenario_toml();
+        let result = parse_and_validate::<ScenariosFile>(&toml, 2, |_| {
+            Err(SecurityError::InvalidInput("bad item".to_string()))
+        });
+        assert!(result.is_err());
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,6 +4,7 @@
 //! as well as application configuration.
 
 pub mod app_config;
+mod loader;
 pub mod quests;
 pub mod scenario_collection;
 pub mod scenarios;

--- a/src/config/quests/mod.rs
+++ b/src/config/quests/mod.rs
@@ -4,6 +4,7 @@
 //! security patterns as scenario loading.
 
 use crate::security::limits::*;
+use crate::security::validators::validate_id_field;
 use crate::security::{SecurityError, UserError, path_validator, sanitizer};
 use serde::Deserialize;
 use std::collections::HashSet;
@@ -101,6 +102,9 @@ pub struct XpConfig {
 }
 
 /// Quest unlock conditions
+///
+/// INVARIANT: min_level <= max_level when both are set, checked by
+/// `QuestLoader::validate_quest`.
 #[derive(Deserialize, Debug, Clone, Default)]
 #[serde(deny_unknown_fields)]
 pub struct QuestConditions {
@@ -112,28 +116,6 @@ pub struct QuestConditions {
     pub requires_commands: Vec<String>,
     #[serde(default)]
     pub requires_scenarios: Vec<String>,
-}
-
-/// Custom deserialization for ID field to validate format
-fn validate_id_field<'de, D>(deserializer: D) -> Result<String, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let s = String::deserialize(deserializer)?;
-
-    // Validate ID is not empty
-    if s.is_empty() {
-        return Err(serde::de::Error::custom("Invalid ID: cannot be empty"));
-    }
-
-    // Validate ID format: alphanumeric with underscores, max 64 chars
-    if s.len() > 64 || !s.chars().all(|c| c.is_alphanumeric() || c == '_') {
-        return Err(serde::de::Error::custom(
-            "Invalid ID: must be alphanumeric with underscores, max 64 chars",
-        ));
-    }
-
-    Ok(s)
 }
 
 /// Custom deserialization for version field to validate format
@@ -247,24 +229,13 @@ impl QuestLoader {
             UserError::ScenarioLoadError
         })?;
 
-        // Parse TOML with proper error handling
-        let quests_file: QuestsFile = toml::from_str(&content)
-            .map_err(|e| UserError::from(SecurityError::InvalidToml(e.to_string())))?;
-
-        let quests = quests_file.quests;
-
-        // Validate quest count
-        if quests.len() > MAX_QUEST_TEMPLATES_PER_FILE {
-            return Err(UserError::from(SecurityError::TooManyScenarios {
-                max: MAX_QUEST_TEMPLATES_PER_FILE,
-                actual: quests.len(),
-            }));
-        }
-
-        // Validate each quest template
-        for quest in &quests {
-            self.validate_quest(quest).map_err(UserError::from)?;
-        }
+        // Parse, count-check, and validate each quest template
+        let quests = super::loader::parse_and_validate::<QuestsFile>(
+            &content,
+            MAX_QUEST_TEMPLATES_PER_FILE,
+            |q| self.validate_quest(q),
+        )
+        .map_err(UserError::from)?;
 
         tracing::info!(count = quests.len(), "Successfully loaded quest templates");
 
@@ -301,30 +272,20 @@ impl QuestLoader {
 
         tracing::info!(locale = locale, "Loading quests from embedded data");
 
-        // Parse TOML content
-        let quests_file: QuestsFile = toml::from_str(content).map_err(|e| {
+        // Parse, count-check, and validate each quest template
+        let quests = super::loader::parse_and_validate::<QuestsFile>(
+            content,
+            MAX_QUEST_TEMPLATES_PER_FILE,
+            |q| self.validate_quest(q),
+        )
+        .map_err(|e| {
             tracing::error!(
                 locale = locale,
-                "Failed to parse embedded quest TOML: {}",
+                "Failed to load embedded quest file: {:?}",
                 e
             );
-            UserError::from(SecurityError::InvalidToml(e.to_string()))
+            UserError::from(e)
         })?;
-
-        let quests = quests_file.quests;
-
-        // Validate quest count
-        if quests.len() > MAX_QUEST_TEMPLATES_PER_FILE {
-            return Err(UserError::from(SecurityError::TooManyScenarios {
-                max: MAX_QUEST_TEMPLATES_PER_FILE,
-                actual: quests.len(),
-            }));
-        }
-
-        // Validate each quest template
-        for quest in &quests {
-            self.validate_quest(quest).map_err(UserError::from)?;
-        }
 
         tracing::info!(
             locale = locale,

--- a/src/config/scenario_collection/tests.rs
+++ b/src/config/scenario_collection/tests.rs
@@ -36,7 +36,7 @@ fn create_scenario(
         alternatives: vec![],
         hints: vec![],
         scoring: ScoringConfig {
-            optimal_count: 1,
+            optimal_count: std::num::NonZeroUsize::new(1).unwrap(),
             max_points: 100,
             tolerance: 0,
         },
@@ -613,7 +613,7 @@ fn test_scenarios_without_metadata() {
         alternatives: vec![],
         hints: vec![],
         scoring: ScoringConfig {
-            optimal_count: 1,
+            optimal_count: std::num::NonZeroUsize::new(1).unwrap(),
             max_points: 100,
             tolerance: 0,
         },

--- a/src/config/scenarios.rs
+++ b/src/config/scenarios.rs
@@ -3,9 +3,11 @@
 //! This module handles loading TOML scenario files with security validations.
 
 use crate::security::limits::*;
+use crate::security::validators::validate_id_field;
 use crate::security::{SecurityError, UserError, path_validator, sanitizer};
 use serde::Deserialize;
 use std::fs;
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 
 /// Wrapper for scenarios array in TOML file
@@ -101,6 +103,9 @@ pub struct Scenario {
 /// Supports two formats:
 /// - Single cursor: `cursor_position = [row, col]` with optional `selection`
 /// - Multi-cursor: `cursors = [[row, col], ...]` or `selections = [[start_row, start_col, end_row, end_col], ...]`
+///
+/// INVARIANT: at least one of cursor_position/cursors/selections must be set,
+/// checked by `ScenarioLoader::validate_setup_or_target_config`.
 #[derive(Deserialize, Debug, Clone)]
 pub struct Setup {
     pub file_content: String,
@@ -127,6 +132,9 @@ pub struct Setup {
 /// Supports two formats:
 /// - Single cursor: `cursor_position = [row, col]` with optional `selection`
 /// - Multi-cursor: `cursors = [[row, col], ...]` or `selections = [[start_row, start_col, end_row, end_col], ...]`
+///
+/// INVARIANT: at least one of cursor_position/cursors/selections must be set,
+/// checked by `ScenarioLoader::validate_setup_or_target_config`.
 #[derive(Deserialize, Debug, Clone)]
 pub struct TargetState {
     pub file_content: String,
@@ -166,7 +174,7 @@ pub struct AlternativeSolution {
 /// Scoring configuration
 #[derive(Deserialize, Debug, Clone)]
 pub struct ScoringConfig {
-    pub optimal_count: usize,
+    pub optimal_count: NonZeroUsize,
     pub max_points: u32,
     pub tolerance: usize,
 }
@@ -331,23 +339,6 @@ impl TargetState {
     pub fn selections_ref(&self) -> Option<&[[usize; 4]]> {
         self.selections.as_deref()
     }
-}
-
-/// Custom deserialization for ID field to validate format
-fn validate_id_field<'de, D>(deserializer: D) -> Result<String, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let s = String::deserialize(deserializer)?;
-
-    // Validate ID format: alphanumeric with underscores, max 64 chars
-    if s.len() > 64 || !s.chars().all(|c| c.is_alphanumeric() || c == '_') {
-        return Err(serde::de::Error::custom(
-            "Invalid ID: must be alphanumeric with underscores, max 64 chars",
-        ));
-    }
-
-    Ok(s)
 }
 
 /// Secure scenario loader with path validation and content verification
@@ -529,24 +520,13 @@ impl ScenarioLoader {
             UserError::ScenarioLoadError
         })?;
 
-        // Parse TOML with proper error handling
-        let scenarios_file: ScenariosFile = toml::from_str(&content)
-            .map_err(|e| UserError::from(SecurityError::InvalidToml(e.to_string())))?;
-
-        let scenarios = scenarios_file.scenarios;
-
-        // Validate scenario count
-        if scenarios.len() > MAX_SCENARIOS_PER_FILE {
-            return Err(UserError::from(SecurityError::TooManyScenarios {
-                max: MAX_SCENARIOS_PER_FILE,
-                actual: scenarios.len(),
-            }));
-        }
-
-        // Validate each scenario
-        for scenario in &scenarios {
-            self.validate_scenario(scenario).map_err(UserError::from)?;
-        }
+        // Parse, count-check, and validate each scenario
+        let scenarios = super::loader::parse_and_validate::<ScenariosFile>(
+            &content,
+            MAX_SCENARIOS_PER_FILE,
+            |s| self.validate_scenario(s),
+        )
+        .map_err(UserError::from)?;
 
         tracing::info!(count = scenarios.len(), "Successfully loaded scenarios");
 
@@ -592,31 +572,21 @@ impl ScenarioLoader {
         let mut all_scenarios = Vec::new();
 
         for (index, content) in embedded_contents.iter().enumerate() {
-            // Parse TOML content
-            let scenarios_file: ScenariosFile = toml::from_str(content).map_err(|e| {
+            // Parse, count-check, and validate each scenario
+            let scenarios = super::loader::parse_and_validate::<ScenariosFile>(
+                content,
+                MAX_SCENARIOS_PER_FILE,
+                |s| self.validate_scenario(s),
+            )
+            .map_err(|e| {
                 tracing::error!(
                     locale = locale,
                     index = index,
-                    "Failed to parse embedded scenario TOML: {}",
+                    "Failed to load embedded scenario file: {:?}",
                     e
                 );
-                UserError::from(SecurityError::InvalidToml(e.to_string()))
+                UserError::from(e)
             })?;
-
-            let scenarios = scenarios_file.scenarios;
-
-            // Validate scenario count per file
-            if scenarios.len() > MAX_SCENARIOS_PER_FILE {
-                return Err(UserError::from(SecurityError::TooManyScenarios {
-                    max: MAX_SCENARIOS_PER_FILE,
-                    actual: scenarios.len(),
-                }));
-            }
-
-            // Validate each scenario
-            for scenario in &scenarios {
-                self.validate_scenario(scenario).map_err(UserError::from)?;
-            }
 
             all_scenarios.extend(scenarios);
         }
@@ -684,11 +654,6 @@ impl ScenarioLoader {
             return Err(SecurityError::TooManyAlternatives {
                 max: MAX_ALTERNATIVES,
             });
-        }
-
-        // Validate scoring configuration
-        if scenario.scoring.optimal_count == 0 {
-            return Err(SecurityError::InvalidScoringConfig);
         }
 
         // Validate command sequences

--- a/src/config/scenarios/tests.rs
+++ b/src/config/scenarios/tests.rs
@@ -93,6 +93,43 @@ tolerance = 0
 }
 
 #[test]
+fn test_empty_id_rejection() {
+    let toml = r#"
+[[scenarios]]
+id = ""
+name = "Test"
+description = "Test"
+
+[scenarios.setup]
+file_content = "test"
+cursor_position = [0, 0]
+
+[scenarios.target]
+file_content = "test"
+cursor_position = [0, 0]
+
+[scenarios.solution]
+commands = ["test"]
+description = "test"
+
+[scenarios.scoring]
+optimal_count = 1
+max_points = 100
+tolerance = 0
+        "#;
+
+    let mut temp_file = NamedTempFile::new().unwrap();
+    temp_file.write_all(toml.as_bytes()).unwrap();
+    temp_file.flush().unwrap();
+
+    let parent_dir = temp_file.path().parent().unwrap().canonicalize().unwrap();
+    let loader = ScenarioLoader::with_allowed_paths(vec![parent_dir]);
+
+    let result = loader.load(temp_file.path());
+    assert!(result.is_err());
+}
+
+#[test]
 fn test_oversized_content_rejection() {
     let huge_content = "A".repeat(200_000);
     let toml = format!(

--- a/src/data_handling.rs
+++ b/src/data_handling.rs
@@ -140,7 +140,7 @@ mod tests {
             alternatives: vec![],
             hints: vec![],
             scoring: ScoringConfig {
-                optimal_count: 2,
+                optimal_count: std::num::NonZeroUsize::new(2).unwrap(),
                 max_points: 100,
                 tolerance: 0,
             },

--- a/src/game/scorer.rs
+++ b/src/game/scorer.rs
@@ -15,7 +15,7 @@
 //!
 //! // Using scenario configuration
 //! let config = ScoringConfig {
-//!     optimal_count: 5,
+//!     optimal_count: std::num::NonZeroUsize::new(5).unwrap(),
 //!     max_points: 100,
 //!     tolerance: 2,
 //! };
@@ -115,7 +115,7 @@ impl Scorer {
     /// use helix_trainer::config::ScoringConfig;
     ///
     /// let config = ScoringConfig {
-    ///     optimal_count: 5,
+    ///     optimal_count: std::num::NonZeroUsize::new(5).unwrap(),
     ///     max_points: 100,
     ///     tolerance: 2,
     /// };
@@ -128,7 +128,7 @@ impl Scorer {
         actual_count: usize,
     ) -> Result<u32, SecurityError> {
         Self::calculate_score(
-            config.optimal_count,
+            config.optimal_count.get(),
             actual_count,
             config.tolerance,
             config.max_points,
@@ -370,7 +370,7 @@ mod tests {
     #[test]
     fn test_score_with_config() {
         let config = ScoringConfig {
-            optimal_count: 5,
+            optimal_count: std::num::NonZeroUsize::new(5).unwrap(),
             max_points: 100,
             tolerance: 2,
         };

--- a/src/game/session/mod.rs
+++ b/src/game/session/mod.rs
@@ -705,7 +705,7 @@ impl GameSession<Completed> {
     /// ```
     pub fn feedback(&self) -> Result<Feedback, SecurityError> {
         let actions_taken = self.user_actions.len();
-        let optimal_actions = self.scenario.scoring.optimal_count;
+        let optimal_actions = self.scenario.scoring.optimal_count.get();
         let max_points = self.scenario.scoring.max_points;
 
         let score = self.score()?;
@@ -771,7 +771,7 @@ impl GameSession<Abandoned> {
             max_points: self.scenario.scoring.max_points,
             rating: PerformanceRating::Poor,
             actions_taken: self.user_actions.len(),
-            optimal_actions: self.scenario.scoring.optimal_count,
+            optimal_actions: self.scenario.scoring.optimal_count.get(),
             duration: self.started_at.elapsed(),
             hint: Some(format!(
                 "Solution: {}. {}",

--- a/src/input/handlers.rs
+++ b/src/input/handlers.rs
@@ -872,7 +872,7 @@ mod tests {
                     description: "Delete char".to_string(),
                 },
                 scoring: ScoringConfig {
-                    optimal_count: 1,
+                    optimal_count: std::num::NonZeroUsize::new(1).unwrap(),
                     max_points: 100,
                     tolerance: 0,
                 },
@@ -1116,7 +1116,7 @@ mod tests {
                     description: "Delete char".to_string(),
                 },
                 scoring: ScoringConfig {
-                    optimal_count: 1,
+                    optimal_count: std::num::NonZeroUsize::new(1).unwrap(),
                     max_points: 100,
                     tolerance: 0,
                 },
@@ -1176,7 +1176,7 @@ mod tests {
                     description: "Delete char".to_string(),
                 },
                 scoring: ScoringConfig {
-                    optimal_count: 1,
+                    optimal_count: std::num::NonZeroUsize::new(1).unwrap(),
                     max_points: 100,
                     tolerance: 0,
                 },
@@ -1264,7 +1264,7 @@ mod tests {
                     description: "Delete char".to_string(),
                 },
                 scoring: ScoringConfig {
-                    optimal_count: 1,
+                    optimal_count: std::num::NonZeroUsize::new(1).unwrap(),
                     max_points: 100,
                     tolerance: 0,
                 },

--- a/src/minigame/scorer.rs
+++ b/src/minigame/scorer.rs
@@ -233,7 +233,7 @@ mod tests {
             alternatives: vec![],
             hints: vec![],
             scoring: ScoringConfig {
-                optimal_count: 1,
+                optimal_count: std::num::NonZeroUsize::new(1).unwrap(),
                 max_points: 100,
                 tolerance: 0,
             },

--- a/src/minigame/session.rs
+++ b/src/minigame/session.rs
@@ -493,7 +493,7 @@ impl MiniGameSession {
         if let Some(ref scenario) = self.current {
             // Calculate metrics for scoring
             let time_ratio = scenario.progress_percent();
-            let optimal_count = scenario.scenario.scoring.optimal_count.max(1);
+            let optimal_count = scenario.scenario.scoring.optimal_count.get();
             let actual_count = scenario.action_count().max(1);
             let efficiency = (optimal_count as f64 / actual_count as f64).min(1.0);
             let scenario_difficulty = scenario
@@ -867,7 +867,7 @@ impl MiniGameSession {
 
             // Optimal time estimate: time_limit / action_count would be "perfect"
             // We'll use optimal_count from scenario as reference
-            let optimal_count = scenario.scenario.scoring.optimal_count.max(1);
+            let optimal_count = scenario.scenario.scoring.optimal_count.get();
             let optimal_time_per_command = scenario.time_limit / optimal_count as u32;
 
             // Record each unique command used

--- a/src/minigame/tests.rs
+++ b/src/minigame/tests.rs
@@ -34,7 +34,7 @@ fn create_simple_scenario(id: &str) -> Scenario {
         alternatives: vec![],
         hints: vec![],
         scoring: ScoringConfig {
-            optimal_count: 1,
+            optimal_count: std::num::NonZeroUsize::new(1).unwrap(),
             max_points: 100,
             tolerance: 0,
         },

--- a/src/security.rs
+++ b/src/security.rs
@@ -49,9 +49,6 @@ pub enum SecurityError {
     #[error("Session timeout (max duration: {0:?})")]
     SessionTimeout(Duration),
 
-    #[error("Invalid scenario configuration")]
-    InvalidScoringConfig,
-
     #[error("Too many actions (max: 1000000)")]
     TooManyActions,
 
@@ -258,6 +255,9 @@ pub mod limits {
 
     /// Maximum number of selections per scenario
     pub const MAX_SELECTIONS_PER_SCENARIO: usize = 100;
+
+    /// Maximum length of a scenario or quest ID
+    pub const MAX_ID_LENGTH: usize = 64;
 }
 
 /// Path validation utilities
@@ -320,6 +320,35 @@ pub mod path_validator {
         }
 
         Ok(())
+    }
+}
+
+/// Shared serde validators for scenario/quest configuration fields
+pub mod validators {
+    use super::limits::MAX_ID_LENGTH;
+    use serde::Deserialize;
+
+    /// Custom deserialization for ID field to validate format
+    pub fn validate_id_field<'de, D>(deserializer: D) -> Result<String, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+
+        // Validate ID is not empty
+        if s.is_empty() {
+            return Err(serde::de::Error::custom("Invalid ID: cannot be empty"));
+        }
+
+        // Validate ID format: alphanumeric with underscores, max MAX_ID_LENGTH chars
+        if s.len() > MAX_ID_LENGTH || !s.chars().all(|c| c.is_alphanumeric() || c == '_') {
+            return Err(serde::de::Error::custom(format!(
+                "Invalid ID: must be alphanumeric with underscores, max {} chars",
+                MAX_ID_LENGTH
+            )));
+        }
+
+        Ok(s)
     }
 }
 
@@ -901,11 +930,6 @@ mod tests {
             SecurityError::SessionTimeout(Duration::from_secs(60))
                 .to_string()
                 .contains("timeout")
-        );
-        assert!(
-            SecurityError::InvalidScoringConfig
-                .to_string()
-                .contains("scenario configuration")
         );
         assert!(
             SecurityError::TooManyActions

--- a/src/testing/scenario.rs
+++ b/src/testing/scenario.rs
@@ -6,6 +6,7 @@ use crate::config::{
     AlternativeSolution, Difficulty, Scenario, ScenarioCategory, ScenarioMetadata, ScoringConfig,
     Setup, Solution, TargetState,
 };
+use std::num::NonZeroUsize;
 
 /// Builder for creating test scenarios with sensible defaults
 ///
@@ -180,6 +181,10 @@ impl ScenarioBuilder {
     }
 
     /// Set the optimal command count
+    ///
+    /// # Panics
+    /// [`Self::build`] panics if `count` is 0, since `ScoringConfig::optimal_count`
+    /// requires a non-zero value.
     pub fn optimal_count(mut self, count: usize) -> Self {
         self.optimal_count = count;
         self
@@ -258,7 +263,8 @@ impl ScenarioBuilder {
             alternatives: self.alternatives,
             hints: self.hints,
             scoring: ScoringConfig {
-                optimal_count: self.optimal_count,
+                optimal_count: NonZeroUsize::new(self.optimal_count)
+                    .expect("optimal_count must be non-zero"),
                 max_points: self.max_points,
                 tolerance: self.tolerance,
             },
@@ -339,6 +345,6 @@ mod tests {
         assert_eq!(scenario.setup.file_content, "hello");
         assert_eq!(scenario.target.file_content, "world");
         assert_eq!(scenario.hints.len(), 1);
-        assert_eq!(scenario.scoring.optimal_count, 3);
+        assert_eq!(scenario.scoring.optimal_count.get(), 3);
     }
 }

--- a/src/ui/render/task.rs
+++ b/src/ui/render/task.rs
@@ -119,7 +119,7 @@ pub(super) fn render_task_screen(frame: &mut Frame, state: &AppState) {
 
         // Stats with mode indicator and progress
         // Use PlayableScenario trait for common stats, completion_progress is specific to Active
-        let optimal = scenario.scoring.optimal_count;
+        let optimal = scenario.scoring.optimal_count.get();
         let actions = playable.action_count();
         let elapsed = playable.elapsed();
         let mode = playable.mode_name();

--- a/src/ui/state/screen.rs
+++ b/src/ui/state/screen.rs
@@ -632,7 +632,7 @@ mod tests {
             alternatives: vec![],
             hints: vec![],
             scoring: ScoringConfig {
-                optimal_count: 1,
+                optimal_count: std::num::NonZeroUsize::new(1).unwrap(),
                 max_points: 100,
                 tolerance: 0,
             },
@@ -685,7 +685,7 @@ mod tests {
             alternatives: vec![],
             hints: vec![],
             scoring: ScoringConfig {
-                optimal_count: 1,
+                optimal_count: std::num::NonZeroUsize::new(1).unwrap(),
                 max_points: 100,
                 tolerance: 0,
             },
@@ -734,7 +734,7 @@ mod tests {
             alternatives: vec![],
             hints: vec![],
             scoring: ScoringConfig {
-                optimal_count: 1,
+                optimal_count: std::num::NonZeroUsize::new(1).unwrap(),
                 max_points: 100,
                 tolerance: 0,
             },

--- a/tests/ui_multi_key_commands.rs
+++ b/tests/ui_multi_key_commands.rs
@@ -52,7 +52,7 @@ fn create_test_scenario(
         alternatives: vec![],
         hints: vec![],
         scoring: ScoringConfig {
-            optimal_count: 1,
+            optimal_count: std::num::NonZeroUsize::new(1).unwrap(),
             max_points: 100,
             tolerance: 0,
         },


### PR DESCRIPTION
## Summary

- Consolidate `validate_id_field` into `security::validators` so scenarios and quests share one implementation. Scenarios previously accepted an empty `id` while quests rejected it — both now reject consistently.
- Extract a shared `parse_and_validate`/`ItemsFile` pipeline in `src/config/loader.rs`, replacing four near-identical `load()`/`load_from_embedded()` implementations across `ScenarioLoader` and `QuestLoader`.
- Change `ScoringConfig::optimal_count` to `NonZeroUsize` so `optimal_count = 0` is unconstructible instead of relying on loader-only validation and silent `.max(1)` clamps. Document the remaining `Setup`/`TargetState`/`QuestConditions` invariants that are still loader-enforced only, rather than smart-constructing them (would conflict with `#[derive(Deserialize)]` simplicity / overlaps with issue #268 scope).

## Breaking changes

- `ScoringConfig::optimal_count` is now `NonZeroUsize` instead of `usize`. TOML layout is unchanged, but a zero value now fails at parse time; `optimal_count = 0` surfaces as a scenario-load error instead of the old generic "Operation failed" message.
- `SecurityError::InvalidScoringConfig` has been removed (no longer reachable).

Both documented in `CHANGELOG.md` under `[Unreleased]`.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins`
- [x] `cargo nextest run scenario`
- [x] `cargo test --doc`
- [x] New regression test confirms empty scenario `id` is rejected through `ScenarioLoader::load` (matching the existing quest-side test)
- [x] New unit tests for `parse_and_validate` (within-limit, invalid TOML, over-max-count, item-validation propagation)
- [x] New test confirms `optimal_count = 0` is unconstructible

Fixes #275
Fixes #276
Fixes #277