### PR TITLE
fix(helix-core): yank/paste range bugs and no-op redo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pausing an arcade/survival/challenge mini-game session no longer lets the active scenario's countdown timer keep draining in real time; elapsed time now excludes accumulated paused duration (#271)
 - Arcade mode's key-history popup is now gated behind a visibility flag reset on scenario transitions instead of staying permanently visible after the first keypress, matching Training mode's behavior; the popup is also repositioned/capped to avoid overlapping the Target/Timer/Score HUD or corrupting editor pane borders in both modes (#272)
 - Scenario `id` fields with an empty string now fail validation, matching quest template behavior (#275)
+- `yank` (`y`) now copies the full `anchor..head` range of the primary selection instead of a single character, so text objects and extend motions yank the entire selected text (#266)
+- `paste_after`/`paste_before` (`p`/`P`) now insert at the correct end of a range selection regardless of its direction, instead of always using the raw (possibly backward) `head` position (#266)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scenario `id` fields with an empty string now fail validation, matching quest template behavior (#275)
 - `yank` (`y`) now copies the full `anchor..head` range of the primary selection instead of a single character, so text objects and extend motions yank the entire selected text (#266)
 - `paste_after`/`paste_before` (`p`/`P`) now insert at the correct end of a range selection regardless of its direction, instead of always using the raw (possibly backward) `head` position (#266)
+- `redo` (`U`, `Ctrl-r`) now restores the most recently undone change via a redo stack built on the existing document history, instead of being a no-op; repeated redo walks forward through history and round-trips correctly with undo (#265)
+- Applying a transaction with no actual document changes no longer records a spurious undo step or discards pending redo history (#265)
 
 ### Changed
 

--- a/src/helix/simulator/commands/clipboard.rs
+++ b/src/helix/simulator/commands/clipboard.rs
@@ -4,16 +4,26 @@ use crate::helix::simulator::{EditorMode, HelixSimulator};
 use crate::security::UserError;
 use helix_core::{Selection, Transaction};
 
-/// Yank (copy) current character to clipboard
+/// Yank (copy) the primary selection to clipboard
+///
+/// Copies the full `anchor..head` range of the primary selection, normalized
+/// regardless of selection direction. A point selection (`anchor == head`),
+/// as used for a plain cursor with no active selection, falls back to
+/// yanking the single character under the cursor.
 pub fn yank<M: EditorMode>(sim: &mut HelixSimulator<M>) -> Result<(), UserError> {
-    let head = sim.selection.primary().head;
+    let range = sim.selection.primary();
 
-    if head >= sim.doc.len_chars() {
-        return Ok(());
+    if range.anchor == range.head {
+        let head = range.head;
+        if head >= sim.doc.len_chars() {
+            return Ok(());
+        }
+        sim.clipboard = Some(sim.doc.char(head).to_string());
+    } else {
+        let text = range.fragment(sim.doc.slice(..)).into_owned();
+        sim.clipboard = Some(text);
     }
 
-    let current_char = sim.doc.char(head);
-    sim.clipboard = Some(current_char.to_string());
     Ok(())
 }
 
@@ -22,8 +32,15 @@ pub fn yank<M: EditorMode>(sim: &mut HelixSimulator<M>) -> Result<(), UserError>
 /// In Helix, cursor stays on the last pasted character
 pub fn paste_after<M: EditorMode>(sim: &mut HelixSimulator<M>) -> Result<(), UserError> {
     if let Some(text) = &sim.clipboard {
-        let head = sim.selection.primary().head;
-        let insert_pos = (head + 1).min(sim.doc.len_chars());
+        let range = sim.selection.primary();
+        // A point selection (plain cursor) sits ON its char, so "after" is
+        // one past it. A range selection's `to()` is already one past its
+        // last char (half-open, like `Range::fragment`), so insert there.
+        let insert_pos = if range.anchor == range.head {
+            (range.head + 1).min(sim.doc.len_chars())
+        } else {
+            range.to().min(sim.doc.len_chars())
+        };
         let text_len = text.chars().count();
 
         let transaction = Transaction::change(
@@ -45,18 +62,20 @@ pub fn paste_after<M: EditorMode>(sim: &mut HelixSimulator<M>) -> Result<(), Use
 /// In Helix, cursor stays on the last pasted character
 pub fn paste_before<M: EditorMode>(sim: &mut HelixSimulator<M>) -> Result<(), UserError> {
     if let Some(text) = &sim.clipboard {
-        let head = sim.selection.primary().head;
+        // Insert before the start of the selection (or at the cursor for a
+        // point selection, where `from()` equals `head`).
+        let insert_pos = sim.selection.primary().from();
         let text_len = text.chars().count();
 
         let transaction = Transaction::change(
             &sim.doc,
-            [(head, head, Some(text.as_str().into()))].into_iter(),
+            [(insert_pos, insert_pos, Some(text.as_str().into()))].into_iter(),
         );
 
         sim.apply_transaction(transaction);
 
         // Cursor stays on last pasted character (Helix behavior)
-        let new_pos = head + text_len.saturating_sub(1);
+        let new_pos = insert_pos + text_len.saturating_sub(1);
         sim.selection = Selection::point(new_pos.min(sim.doc.len_chars().saturating_sub(1)));
     }
     Ok(())

--- a/src/helix/simulator/mod.rs
+++ b/src/helix/simulator/mod.rs
@@ -76,8 +76,14 @@ pub struct HelixSimulator<M: EditorMode = NormalMode> {
     /// Current selection(s) with head and anchor positions
     pub(super) selection: Selection,
 
-    /// Undo history stack storing both transactions and previous document states
-    pub(super) history: Vec<(Transaction, Rope)>,
+    /// Undo history stack storing the document state from immediately
+    /// before each applied transaction.
+    pub(super) history: Vec<Rope>,
+
+    /// Redo stack storing the document state each `undo` moves away from,
+    /// so `redo` can restore it. Cleared whenever a new transaction is
+    /// applied, matching standard editor undo/redo semantics.
+    pub(super) redo_stack: Vec<Rope>,
 
     /// Clipboard for yank and paste operations
     pub(super) clipboard: Option<String>,
@@ -237,11 +243,21 @@ impl<M: EditorMode> HelixSimulator<M> {
     }
 
     /// Apply transaction and save history
+    ///
+    /// No-op transactions (empty change set) are skipped entirely: they
+    /// leave the document unchanged, so recording them would create a
+    /// spurious undo step and needlessly discard valid redo history.
     pub(super) fn apply_transaction(&mut self, transaction: Transaction) {
+        if transaction.changes().is_empty() {
+            return;
+        }
+
         // Save previous state before applying transaction
         let prev_doc = self.doc.clone();
-        self.history.push((transaction.clone(), prev_doc));
+        self.history.push(prev_doc);
         transaction.apply(&mut self.doc);
+        // A new edit invalidates any previously undone changes
+        self.redo_stack.clear();
     }
 }
 
@@ -253,6 +269,7 @@ impl HelixSimulator<NormalMode> {
             doc: Rope::from(content.as_str()),
             selection: Selection::point(0),
             history: Vec::new(),
+            redo_stack: Vec::new(),
             clipboard: None,
             repeat_buffer: RepeatBuffer::new(),
             is_repeating: false,
@@ -294,6 +311,7 @@ impl HelixSimulator<NormalMode> {
             doc: rope,
             selection,
             history: Vec::new(),
+            redo_stack: Vec::new(),
             clipboard: None,
             repeat_buffer: RepeatBuffer::new(),
             is_repeating: false,
@@ -362,6 +380,7 @@ impl HelixSimulator<NormalMode> {
             doc: rope,
             selection,
             history: Vec::new(),
+            redo_stack: Vec::new(),
             clipboard: None,
             repeat_buffer: RepeatBuffer::new(),
             is_repeating: false,
@@ -385,6 +404,7 @@ impl HelixSimulator<NormalMode> {
             doc: self.doc,
             selection: collapsed_selection,
             history: self.history,
+            redo_stack: self.redo_stack,
             clipboard: self.clipboard,
             repeat_buffer: self.repeat_buffer,
             is_repeating: self.is_repeating,
@@ -425,6 +445,7 @@ impl HelixSimulator<InsertMode> {
             doc: self.doc,
             selection: self.selection,
             history: self.history,
+            redo_stack: self.redo_stack,
             clipboard: self.clipboard,
             repeat_buffer: self.repeat_buffer,
             is_repeating: self.is_repeating,

--- a/src/helix/simulator/tests/clipboard_tests.rs
+++ b/src/helix/simulator/tests/clipboard_tests.rs
@@ -5,6 +5,8 @@
 //! - Paste after: p
 //! - Paste before: P
 
+use crate::game::EditorState;
+use crate::game::editor_state::{CursorPosition, Selection};
 use crate::helix::commands::*;
 use crate::helix::simulator::AnyModeSimulator;
 
@@ -115,6 +117,151 @@ fn test_paste_before_cursor_scenario() {
         1,
         "Cursor should be at position 1 (on pasted 'z')"
     );
+}
+
+// ============================================================================
+// Multi-Character Selection Yank Tests (Issue #266)
+// ============================================================================
+
+#[test]
+fn test_yank_multichar_forward_selection_round_trips_full_text() {
+    // "world" as a forward range (anchor=6 < head=11)
+    let cursor = CursorPosition::new(0, 11).unwrap();
+    let sel = Selection::new(CursorPosition::new(0, 6).unwrap(), cursor);
+    let state = EditorState::new("hello world".to_string(), cursor, Some(sel)).unwrap();
+
+    let mut sim = AnyModeSimulator::from_editor_state(&state);
+    sim.execute_command(CMD_YANK).unwrap();
+    sim.execute_command(CMD_PASTE_AFTER).unwrap();
+
+    let state = sim.get_state().unwrap();
+    assert_eq!(
+        state.content(),
+        "hello worldworld",
+        "Full 'world' range should be yanked and pasted, not just the head char"
+    );
+}
+
+#[test]
+fn test_yank_multichar_backward_selection_extracts_same_range() {
+    // Same "world" range, flipped to a backward selection (anchor=11 > head=6)
+    let cursor = CursorPosition::new(0, 11).unwrap();
+    let sel = Selection::new(CursorPosition::new(0, 6).unwrap(), cursor);
+    let state = EditorState::new("hello world".to_string(), cursor, Some(sel)).unwrap();
+
+    let mut sim = AnyModeSimulator::from_editor_state(&state);
+    sim.execute_command(CMD_FLIP_SELECTIONS).unwrap();
+    sim.execute_command(CMD_YANK).unwrap();
+    sim.execute_command(CMD_PASTE_AFTER).unwrap();
+
+    let state = sim.get_state().unwrap();
+    assert_eq!(
+        state.content(),
+        "hello worldworld",
+        "Yank must normalize a backward (anchor > head) selection to the same text, \
+         and paste-after must insert after the end of the selection regardless of \
+         its direction (issue #266/#265 critic finding S1/S2)"
+    );
+}
+
+#[test]
+fn test_paste_before_multichar_forward_selection_inserts_at_selection_start() {
+    // "world" as a forward range (anchor=6 < head=11)
+    let cursor = CursorPosition::new(0, 11).unwrap();
+    let sel = Selection::new(CursorPosition::new(0, 6).unwrap(), cursor);
+    let state = EditorState::new("hello world".to_string(), cursor, Some(sel)).unwrap();
+
+    let mut sim = AnyModeSimulator::from_editor_state(&state);
+    sim.execute_command(CMD_YANK).unwrap();
+    sim.execute_command(CMD_PASTE_BEFORE).unwrap();
+
+    let state = sim.get_state().unwrap();
+    assert_eq!(
+        state.content(),
+        "hello worldworld",
+        "paste-before must insert at the start of the selection"
+    );
+}
+
+#[test]
+fn test_paste_before_multichar_backward_selection_inserts_at_selection_start() {
+    // Same "world" range, flipped to a backward selection (anchor=11 > head=6)
+    let cursor = CursorPosition::new(0, 11).unwrap();
+    let sel = Selection::new(CursorPosition::new(0, 6).unwrap(), cursor);
+    let state = EditorState::new("hello world".to_string(), cursor, Some(sel)).unwrap();
+
+    let mut sim = AnyModeSimulator::from_editor_state(&state);
+    sim.execute_command(CMD_FLIP_SELECTIONS).unwrap();
+    sim.execute_command(CMD_YANK).unwrap();
+    sim.execute_command(CMD_PASTE_BEFORE).unwrap();
+
+    let state = sim.get_state().unwrap();
+    assert_eq!(
+        state.content(),
+        "hello worldworld",
+        "paste-before must insert at the start of the selection regardless of \
+         its direction (issue #266/#265 critic finding S1/S2), not at the raw head"
+    );
+}
+
+#[test]
+fn test_paste_after_select_line_yank_paste_matches_helix() {
+    // Critic finding S1 exact repro: `x y p` on "hello\nworld\n" must match
+    // real Helix ("hello\nhello\nworld\n"), not the old head+1 offset bug
+    // ("hhello\nello\nworld\n").
+    let mut sim = AnyModeSimulator::new("hello\nworld\n".to_string());
+
+    sim.execute_command(CMD_SELECT_LINE).unwrap();
+    sim.execute_command(CMD_YANK).unwrap();
+    sim.execute_command(CMD_PASTE_AFTER).unwrap();
+
+    let state = sim.get_state().unwrap();
+    assert_eq!(state.content(), "hello\nhello\nworld\n");
+}
+
+#[test]
+fn test_paste_before_divergent_clipboard_matches_helix() {
+    // Critic finding S2 exact repro: `y Alt-x P` on "ab cd" must match real
+    // Helix ("aab cd"), not the old raw-head offset bug ("ab cda"). The
+    // divergent clipboard ('a', yanked from a point selection) versus the
+    // later whole-line selection unmasks a `paste_before` offset bug that a
+    // same-text yank/paste round-trip cannot detect.
+    let mut sim = AnyModeSimulator::new("ab cd".to_string());
+
+    sim.execute_command(CMD_YANK).unwrap();
+    sim.execute_command(CMD_SHRINK_TO_LINE_BOUNDS).unwrap();
+    sim.execute_command(CMD_PASTE_BEFORE).unwrap();
+
+    let state = sim.get_state().unwrap();
+    assert_eq!(state.content(), "aab cd");
+}
+
+#[test]
+fn test_yank_select_line_round_trips_full_line() {
+    // 'x' (select_line) produces a backward range (anchor=line_end, head=line_start)
+    let mut sim = AnyModeSimulator::new("abc\nXYZ\n".to_string());
+
+    sim.execute_command(CMD_SELECT_LINE).unwrap();
+    sim.execute_command(CMD_YANK).unwrap();
+    sim.execute_command(CMD_COLLAPSE_SELECTION).unwrap();
+    sim.execute_command(CMD_MOVE_DOWN).unwrap();
+    sim.execute_command(CMD_PASTE_AFTER).unwrap();
+
+    let state = sim.get_state().unwrap();
+    assert_eq!(state.content(), "abc\nXabc\nYZ\n");
+}
+
+#[test]
+fn test_yank_point_selection_still_yanks_single_char() {
+    // Plain cursor with no active selection (anchor == head) must keep the
+    // pre-#266 behavior of yanking exactly one character.
+    let mut sim = AnyModeSimulator::new("hello world".to_string());
+
+    sim.execute_command(CMD_YANK).unwrap();
+    sim.execute_command(CMD_PASTE_AFTER).unwrap();
+
+    let state = sim.get_state().unwrap();
+    assert_eq!(state.content(), "hhello world");
 }
 
 // ============================================================================

--- a/src/helix/simulator/tests/editing_tests.rs
+++ b/src/helix/simulator/tests/editing_tests.rs
@@ -53,7 +53,7 @@ fn test_multiple_line_deletions() {
 }
 
 // ============================================================================
-// Undo Tests
+// Undo/Redo Tests
 // ============================================================================
 
 #[test]
@@ -67,6 +67,136 @@ fn test_undo() {
 
     sim.execute_command(CMD_UNDO).unwrap();
     assert_eq!(sim.get_state().unwrap().content(), "test\n");
+}
+
+#[test]
+fn test_undo_then_redo_round_trip() {
+    let mut sim = AnyModeSimulator::new("test\n".to_string());
+
+    sim.execute_command(CMD_SELECT_LINE).unwrap();
+    sim.execute_command(CMD_DELETE_SELECTION).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "");
+
+    sim.execute_command(CMD_UNDO).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "test\n");
+
+    sim.execute_command(CMD_REDO).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "");
+}
+
+#[test]
+fn test_redo_via_ctrl_r_alias() {
+    let mut sim = AnyModeSimulator::new("test\n".to_string());
+
+    sim.execute_command(CMD_SELECT_LINE).unwrap();
+    sim.execute_command(CMD_DELETE_SELECTION).unwrap();
+    sim.execute_command(CMD_UNDO).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "test\n");
+
+    sim.execute_command(CMD_CTRL_R).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "");
+}
+
+#[test]
+fn test_multiple_sequential_undo_redo_walks_full_history() {
+    let mut sim = AnyModeSimulator::new("aaa\nbbb\nccc\n".to_string());
+
+    // Three edits, each deleting the current (now-first) line
+    sim.execute_command(CMD_SELECT_LINE).unwrap();
+    sim.execute_command(CMD_DELETE_SELECTION).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "bbb\nccc\n");
+
+    sim.execute_command(CMD_SELECT_LINE).unwrap();
+    sim.execute_command(CMD_DELETE_SELECTION).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "ccc\n");
+
+    sim.execute_command(CMD_SELECT_LINE).unwrap();
+    sim.execute_command(CMD_DELETE_SELECTION).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "");
+
+    // Undo 3x should walk back through each intermediate state
+    sim.execute_command(CMD_UNDO).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "ccc\n");
+
+    sim.execute_command(CMD_UNDO).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "bbb\nccc\n");
+
+    sim.execute_command(CMD_UNDO).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "aaa\nbbb\nccc\n");
+
+    // Redo 3x should walk forward and land back at the latest state
+    sim.execute_command(CMD_REDO).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "bbb\nccc\n");
+
+    sim.execute_command(CMD_REDO).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "ccc\n");
+
+    sim.execute_command(CMD_REDO).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "");
+}
+
+#[test]
+fn test_new_edit_after_undo_clears_redo_stack() {
+    let mut sim = AnyModeSimulator::new("line1\nline2\nline3\n".to_string());
+
+    // Delete line1, then undo it back
+    sim.execute_command(CMD_SELECT_LINE).unwrap();
+    sim.execute_command(CMD_DELETE_SELECTION).unwrap();
+    sim.execute_command(CMD_UNDO).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "line1\nline2\nline3\n");
+
+    // A fresh edit on a different line must invalidate the pending redo
+    sim.execute_command(CMD_MOVE_DOWN).unwrap();
+    sim.execute_command(CMD_SELECT_LINE).unwrap();
+    sim.execute_command(CMD_DELETE_SELECTION).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "line1\nline3\n");
+
+    // Redo should now be a no-op: the stale "restore line1 deletion" entry is gone
+    sim.execute_command(CMD_REDO).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "line1\nline3\n");
+}
+
+#[test]
+fn test_noop_command_after_undo_does_not_clear_pending_redo() {
+    // Critic finding S3: a command that produces a pure-retain (no-op)
+    // changeset — e.g. uppercasing a point selection, which has no text to
+    // change — must not wipe a pending redo_stack. Exercised through the
+    // real command path (Alt-`) rather than a hand-built Transaction.
+    let mut sim = AnyModeSimulator::new("test\n".to_string());
+
+    sim.execute_command(CMD_SELECT_LINE).unwrap();
+    sim.execute_command(CMD_DELETE_SELECTION).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "");
+
+    sim.execute_command(CMD_UNDO).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "test\n");
+
+    // Point selection (anchor == head) at the start of the doc: no text to
+    // uppercase, so this produces an empty changeset.
+    sim.execute_command(CMD_SWITCH_TO_UPPERCASE).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "test\n");
+
+    // The pending redo from the earlier undo must still be intact.
+    sim.execute_command(CMD_REDO).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "");
+}
+
+#[test]
+fn test_interleaved_undo_redo_undo_round_trips() {
+    let mut sim = AnyModeSimulator::new("aaa\nbbb\n".to_string());
+
+    sim.execute_command(CMD_SELECT_LINE).unwrap();
+    sim.execute_command(CMD_DELETE_SELECTION).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "bbb\n");
+
+    sim.execute_command(CMD_UNDO).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "aaa\nbbb\n");
+
+    sim.execute_command(CMD_REDO).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "bbb\n");
+
+    sim.execute_command(CMD_UNDO).unwrap();
+    assert_eq!(sim.get_state().unwrap().content(), "aaa\nbbb\n");
 }
 
 // ============================================================================

--- a/src/helix/simulator/undo.rs
+++ b/src/helix/simulator/undo.rs
@@ -6,10 +6,13 @@ use helix_core::Selection;
 
 impl<M: EditorMode> HelixSimulator<M> {
     /// Undo the last operation
+    ///
+    /// The document state being undone away from is moved onto the redo
+    /// stack, so a subsequent `redo` can restore it.
     pub fn undo(&mut self) -> Result<(), UserError> {
-        if let Some((_transaction, prev_doc)) = self.history.pop() {
-            // Restore the previous document state
-            self.doc = prev_doc;
+        if let Some(prev_doc) = self.history.pop() {
+            let undone_doc = std::mem::replace(&mut self.doc, prev_doc);
+            self.redo_stack.push(undone_doc);
 
             // Clamp cursor to valid position
             let head = self.selection.primary().head.min(self.doc.len_chars());
@@ -18,12 +21,65 @@ impl<M: EditorMode> HelixSimulator<M> {
         Ok(())
     }
 
-    /// Redo the last undone operation
+    /// Redo the most recently undone operation
     ///
-    /// Currently a placeholder - full redo would require a separate redo stack
+    /// Restores the document state that `undo` last moved onto the redo
+    /// stack and pushes the state being redone away from back onto the undo
+    /// history, so repeated `Ctrl-r` presses walk forward through history
+    /// and `undo`/`redo` round-trip.
     pub fn redo(&mut self) -> Result<(), UserError> {
-        // Full redo would require keeping a separate redo stack
-        // For now, this is a placeholder
+        if let Some(redone_doc) = self.redo_stack.pop() {
+            let prev_doc = std::mem::replace(&mut self.doc, redone_doc);
+            self.history.push(prev_doc);
+
+            // Clamp cursor to valid position
+            let head = self.selection.primary().head.min(self.doc.len_chars());
+            self.selection = Selection::point(head);
+        }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::helix::simulator::HelixSimulator;
+    use crate::helix::simulator::NormalMode;
+    use helix_core::Transaction;
+
+    #[test]
+    fn test_apply_transaction_skips_noop_history_entry() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("hello".to_string());
+
+        // A transaction built from the current doc with no changes applied
+        // has an empty change set.
+        let noop = Transaction::new(&sim.doc);
+        assert!(noop.changes().is_empty());
+
+        sim.apply_transaction(noop);
+
+        assert_eq!(
+            sim.history.len(),
+            0,
+            "a no-op transaction must not create a spurious undo entry"
+        );
+    }
+
+    #[test]
+    fn test_apply_transaction_noop_preserves_pending_redo() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("hello".to_string());
+
+        let edit = Transaction::change(&sim.doc, [(0, 0, Some("x".into()))].into_iter());
+        sim.apply_transaction(edit);
+        sim.undo().unwrap();
+        assert_eq!(sim.redo_stack.len(), 1, "undo should leave one redo entry");
+
+        let noop = Transaction::new(&sim.doc);
+        sim.apply_transaction(noop);
+
+        assert_eq!(
+            sim.redo_stack.len(),
+            1,
+            "a no-op transaction must not discard valid redo history"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two P1 bugs in the Helix simulator's command layer, both in `src/helix/simulator/`:

- `yank()` (`y`) copied only the single character at selection head, discarding the rest of any multi-character selection produced by text objects (`miw`, `ma(`) or extend motions. It now reads the full `anchor..head` range for non-point selections, while a plain cursor (point selection) still yanks exactly one character as before.
- `paste_after`/`paste_before` (`p`/`P`) inserted at the raw `head` position, which was only correct for a point selection; for a range selection (especially a backward one) this landed the paste at the wrong offset. They now insert at the correct end of the selection based on its direction.
- `redo()` (`U`, `Ctrl-r`) was a placeholder that performed no undo-stack operation, making it a silent no-op after any undo. `HelixSimulator` now maintains a `redo_stack` alongside the existing undo history; `undo()` pushes the undone state onto it instead of discarding it, and `redo()` pops from it and restores that state, so repeated `Ctrl-r` walks forward through history and round-trips correctly with `undo`.
- `apply_transaction()` now skips no-op transactions (empty changesets) entirely, so they neither record a spurious undo step nor discard pending redo history.

Fixes #266
Fixes #265

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (1809/1809 passed)
- [x] New regression tests: multi-character yank (forward/backward selection), paste-before/paste-after direction correctness, no-op transaction leaving `redo_stack` intact, undo/redo round-trip