### PR TITLE
fix(learning): sync FSRS data on every mid-session profile save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Quest completion now marks `UserProfile::completed_quests_today`, so `StreakManager::update_streak` (still evaluated once per app launch, at profile load) can increment `current_streak` on the following day's session instead of the set staying permanently empty (#267)
   - Streak-freeze eligibility now requires completing every quest generated for the day rather than a fixed count of 5, which the quest generator can never produce (max 4/day) and was therefore unreachable; eligible completion grants a freeze via `StreakManager::grant_freeze`, surfaced with a new `StreakFreezeGranted` notification (#257)
   - Scenario completion and profile load now check `AchievementEngine::check_achievements` and unlock newly satisfied achievements — including retroactively unlocking every tier a profile already qualifies for, not just the highest one — surfaced via the existing `Achievement` notification (#256)
+- FSRS review history, XP, level, and quest progress are no longer lost on a crash, forced kill, or terminal close mid-session (#258, #273). Every mid-session profile save — scenario completion, XP award, mini-game game-over, and review-session completion/abandon — now syncs the live FSRS tracker state before writing, routed through a single centralized `ProgressState::save_immediate`/`save_debounced` path instead of five duplicated (and partly stale) save call sites.
+- Profile saves (`~/.config/helix-trainer/profile.json`) are now atomic: the write goes to a temp file, is `fsync`ed, and is renamed into place, so a crash or power loss mid-write can no longer leave a truncated or corrupted profile behind.
 
 ### Changed
 

--- a/src/data_handling.rs
+++ b/src/data_handling.rs
@@ -130,11 +130,24 @@ mod tests {
         gamification::ProfileStorage,
     };
 
-    // Binary crate tests cannot access the library's #[cfg(test)] modules,
-    // so we define minimal local helpers here
+    // Binary crate tests cannot access the library's #[cfg(test)]-gated
+    // `ProfileStorage::for_test()`, so we mirror it locally here: a unique file
+    // under a process-lifetime temp dir, never the real user profile path.
+    fn test_profile_storage() -> ProfileStorage {
+        use std::sync::OnceLock;
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        static TEST_DIR: OnceLock<tempfile::TempDir> = OnceLock::new();
+        static FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+        let dir = TEST_DIR.get_or_init(|| tempfile::TempDir::new().expect("create test temp dir"));
+        let id = FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+        ProfileStorage::with_path(dir.path().join(format!("profile-{id}.json")))
+    }
+
     fn empty_test_app_state() -> AppState {
         let profile = UserProfile::new();
-        let storage = ProfileStorage::new();
+        let storage = test_profile_storage();
         let tracker = PerformanceTracker::new();
         AppState::new(vec![], profile, storage, tracker)
     }

--- a/src/gamification/storage.rs
+++ b/src/gamification/storage.rs
@@ -1,11 +1,20 @@
 //! Profile storage and persistence
 
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use serde::{Deserialize, Serialize};
 
 use super::{GamificationError, Result, UserProfile};
+
+/// Per-process counter used to make temporary save files unique.
+///
+/// Combined with the process id, this guarantees two concurrent saves (e.g.
+/// two `ProfileStorage` instances pointed at the same path, as happens in
+/// tests) never share a temp file name and race each other's rename.
+static TMP_SUFFIX_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Wrapper for profile serialization
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -42,6 +51,33 @@ impl ProfileStorage {
         Self {
             file_path: path.as_ref().to_path_buf(),
         }
+    }
+
+    /// Create storage backed by a unique file under a process-lifetime temp directory.
+    ///
+    /// This is the single safe default for test fixtures: every call returns a
+    /// distinct path, so it can never collide with the real
+    /// `~/.config/helix-trainer/profile.json` or with another test's storage, even
+    /// under parallel `cargo nextest` execution. All test fixture builders (
+    /// `src/testing/app_state.rs` and the per-file `create_test_state()` helpers)
+    /// must construct `ProfileStorage` through this function, not `new()` — `new()`
+    /// resolves to the real user profile path and a test that reaches a save call
+    /// with it will silently overwrite the developer's real progress data.
+    ///
+    /// The backing temp directory is intentionally never cleaned up mid-process
+    /// (it outlives any single test), relying on the OS to reclaim it; this mirrors
+    /// the tradeoff every other `tempfile::TempDir`-based test already makes, just
+    /// centralized instead of per-call-site.
+    #[cfg(test)]
+    pub fn for_test() -> Self {
+        use std::sync::OnceLock;
+
+        static TEST_DIR: OnceLock<tempfile::TempDir> = OnceLock::new();
+        static FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+        let dir = TEST_DIR.get_or_init(|| tempfile::TempDir::new().expect("create test temp dir"));
+        let id = FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+        Self::with_path(dir.path().join(format!("profile-{id}.json")))
     }
 
     /// Get default storage path
@@ -89,11 +125,16 @@ impl ProfileStorage {
 
     /// Save profile to disk
     ///
-    /// Creates parent directory if needed
+    /// Creates parent directory if needed. Writes to a temporary file in the
+    /// same directory, `fsync`s it, and renames it into place, so a crash,
+    /// kill, or power loss mid-write cannot leave a truncated `profile.json`
+    /// behind — `fs::rename` is atomic on the same filesystem on both POSIX
+    /// and Windows, and the prior `sync_all` ensures the renamed data is
+    /// actually durable rather than sitting in a write-back cache.
     ///
     /// # Errors
     ///
-    /// Returns error if file cannot be written
+    /// Returns error if the file cannot be written, synced, or renamed
     ///
     /// # Examples
     ///
@@ -121,8 +162,38 @@ impl ProfileStorage {
             GamificationError::StorageError(format!("Failed to serialize profile: {}", e))
         })?;
 
-        fs::write(&self.file_path, json).map_err(|e| {
-            GamificationError::StorageError(format!("Failed to write profile: {}", e))
+        let suffix = TMP_SUFFIX_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let mut tmp_file_name = self
+            .file_path
+            .file_name()
+            .unwrap_or_default()
+            .to_os_string();
+        tmp_file_name.push(format!(".{}.{}.tmp", std::process::id(), suffix));
+        let tmp_path = self.file_path.with_file_name(tmp_file_name);
+
+        let write_result = (|| {
+            let mut tmp_file = fs::File::create(&tmp_path)?;
+            tmp_file.write_all(json.as_bytes())?;
+            tmp_file.sync_all()
+        })();
+        if let Err(e) = write_result {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(GamificationError::StorageError(format!(
+                "Failed to write profile: {}",
+                e
+            )));
+        }
+
+        // Best-effort: carry the existing file's permissions onto the temp file so a
+        // save doesn't silently reset them to the umask default via the rename below.
+        // Skipped (not an error) if the target doesn't exist yet or metadata can't be read.
+        if let Ok(metadata) = fs::metadata(&self.file_path) {
+            let _ = fs::set_permissions(&tmp_path, metadata.permissions());
+        }
+
+        fs::rename(&tmp_path, &self.file_path).map_err(|e| {
+            let _ = fs::remove_file(&tmp_path);
+            GamificationError::StorageError(format!("Failed to persist profile: {}", e))
         })?;
 
         Ok(())
@@ -237,6 +308,53 @@ mod tests {
         storage.save(&profile).unwrap();
 
         assert!(storage.exists());
+    }
+
+    /// Regression test for S3: a save that fails partway (e.g. the temp-file write
+    /// errors before the atomic rename) must leave the existing `profile.json`
+    /// byte-for-byte untouched, not truncated or partially overwritten.
+    #[cfg(unix)]
+    #[test]
+    fn test_failed_save_does_not_corrupt_existing_profile() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("profile.json");
+        let storage = ProfileStorage::with_path(&file_path);
+
+        let mut profile = UserProfile::new();
+        profile.add_xp(100);
+        storage.save(&profile).unwrap();
+        let bytes_before = fs::read_to_string(&file_path).unwrap();
+
+        // Strip write permission from the directory so the next save's
+        // temp-file write fails before it ever reaches `fs::rename`.
+        let original_perms = fs::metadata(temp_dir.path()).unwrap().permissions();
+        let mut readonly_perms = original_perms.clone();
+        readonly_perms.set_mode(0o555);
+        fs::set_permissions(temp_dir.path(), readonly_perms).unwrap();
+
+        let mut profile2 = profile.clone();
+        profile2.add_xp(500);
+        let result = storage.save(&profile2);
+
+        // Restore permissions before any assertion so TempDir can clean up
+        // even if an assertion below panics.
+        fs::set_permissions(temp_dir.path(), original_perms).unwrap();
+
+        assert!(
+            result.is_err(),
+            "save should fail when the directory is read-only"
+        );
+
+        let bytes_after = fs::read_to_string(&file_path).unwrap();
+        assert_eq!(
+            bytes_before, bytes_after,
+            "existing profile.json must be untouched by a failed save"
+        );
+
+        let reloaded = storage.load().unwrap();
+        assert_eq!(reloaded.total_xp, profile.total_xp);
     }
 
     #[test]

--- a/src/testing/app_state.rs
+++ b/src/testing/app_state.rs
@@ -19,7 +19,7 @@ pub fn empty_test_app_state() -> AppState {
 /// Uses default profile, storage, and tracker.
 pub fn test_app_state_with_scenarios(scenarios: Vec<Scenario>) -> AppState {
     let profile = UserProfile::new();
-    let storage = ProfileStorage::new();
+    let storage = ProfileStorage::for_test();
     let tracker = PerformanceTracker::new();
     AppState::new(scenarios, profile, storage, tracker)
 }
@@ -82,7 +82,7 @@ impl TestAppStateBuilder {
     /// Build the AppState
     pub fn build(self) -> AppState {
         let profile = self.profile.unwrap_or_default();
-        let storage = self.storage.unwrap_or_default();
+        let storage = self.storage.unwrap_or_else(ProfileStorage::for_test);
         let tracker = self.tracker.unwrap_or_default();
         AppState::new(self.scenarios, profile, storage, tracker)
     }

--- a/src/ui/render/category_filters.rs
+++ b/src/ui/render/category_filters.rs
@@ -223,7 +223,7 @@ mod tests {
             progress: ProgressState::new(
                 UserProfile::new(),
                 PerformanceTracker::new(),
-                ProfileStorage::new(),
+                ProfileStorage::for_test(),
             ),
             config: ConfigState::default(),
         };
@@ -239,7 +239,7 @@ mod tests {
             progress: ProgressState::new(
                 UserProfile::new(),
                 PerformanceTracker::new(),
-                ProfileStorage::new(),
+                ProfileStorage::for_test(),
             ),
             config: ConfigState::default(),
         };
@@ -417,7 +417,7 @@ mod tests {
             progress: ProgressState::new(
                 UserProfile::new(),
                 PerformanceTracker::new(),
-                ProfileStorage::new(),
+                ProfileStorage::for_test(),
             ),
             config: ConfigState::default(),
         };

--- a/src/ui/render/minigame.rs
+++ b/src/ui/render/minigame.rs
@@ -549,7 +549,7 @@ mod tests {
         let mut state = AppState::new(
             vec![],
             UserProfile::new(),
-            ProfileStorage::new(),
+            ProfileStorage::for_test(),
             PerformanceTracker::new(),
         );
         state.screen = TypedScreen::MiniGame(MiniGameData::default());
@@ -571,7 +571,7 @@ mod tests {
         let mut state = AppState::new(
             vec![],
             UserProfile::new(),
-            ProfileStorage::new(),
+            ProfileStorage::for_test(),
             PerformanceTracker::new(),
         );
         state.screen = TypedScreen::MiniGame(MiniGameData::default());
@@ -591,7 +591,7 @@ mod tests {
         let mut state = AppState::new(
             vec![],
             UserProfile::new(),
-            ProfileStorage::new(),
+            ProfileStorage::for_test(),
             PerformanceTracker::new(),
         );
         state.screen = TypedScreen::Menu(MenuData::default());

--- a/src/ui/render/mode_selection.rs
+++ b/src/ui/render/mode_selection.rs
@@ -220,7 +220,7 @@ mod tests {
         let mut state = AppState::new(
             vec![],
             UserProfile::new(),
-            ProfileStorage::new(),
+            ProfileStorage::for_test(),
             PerformanceTracker::new(),
         );
         state.screen = TypedScreen::ModeSelection(ModeSelectionData::default());
@@ -239,7 +239,7 @@ mod tests {
         let mut state = AppState::new(
             vec![],
             UserProfile::new(),
-            ProfileStorage::new(),
+            ProfileStorage::for_test(),
             PerformanceTracker::new(),
         );
         state.screen = TypedScreen::Menu(MenuData::default());

--- a/src/ui/state/handlers/category_filters.rs
+++ b/src/ui/state/handlers/category_filters.rs
@@ -182,7 +182,7 @@ mod tests {
             progress: ProgressState::new(
                 UserProfile::new(),
                 PerformanceTracker::new(),
-                ProfileStorage::new(),
+                ProfileStorage::for_test(),
             ),
             config: ConfigState::default(),
         }
@@ -196,7 +196,7 @@ mod tests {
             progress: ProgressState::new(
                 UserProfile::new(),
                 PerformanceTracker::new(),
-                ProfileStorage::new(),
+                ProfileStorage::for_test(),
             ),
             config: ConfigState::default(),
         }

--- a/src/ui/state/handlers/minigame.rs
+++ b/src/ui/state/handlers/minigame.rs
@@ -331,13 +331,9 @@ pub(in crate::ui::state) fn handle_minigame_game_over(
         );
 
         // 4. Persist profile to disk (non-fatal error - log but continue)
-        let save_result = state.progress.storage.save(&state.progress.profile);
-
-        if let Err(e) = save_result {
+        if let Err(e) = state.progress.save_immediate() {
             tracing::error!("Failed to save profile after mini-game: {:?}", e);
             // Don't return error - game over screen should still display
-        } else {
-            state.progress.mark_saved();
         }
     }
 
@@ -392,7 +388,7 @@ mod tests {
             progress: ProgressState::new(
                 UserProfile::new(),
                 PerformanceTracker::new(),
-                ProfileStorage::new(),
+                ProfileStorage::for_test(),
             ),
             config: ConfigState::default(),
         }
@@ -540,7 +536,12 @@ mod tests {
 
     #[test]
     fn test_minigame_back_to_menu() {
+        use crate::gamification::ProfileStorage;
+        use tempfile::TempDir;
+
         let mut state = create_test_state();
+        let temp_dir = TempDir::new().unwrap();
+        state.progress.storage = ProfileStorage::with_path(temp_dir.path().join("profile.json"));
         start_minigame(&mut state);
 
         assert!(state.game.minigame_session.is_some());
@@ -578,9 +579,12 @@ mod tests {
 
     #[test]
     fn test_minigame_game_over_awards_xp() {
-        use crate::gamification::XPCalculator;
+        use crate::gamification::{ProfileStorage, XPCalculator};
+        use tempfile::TempDir;
 
         let mut state = create_test_state();
+        let temp_dir = TempDir::new().unwrap();
+        state.progress.storage = ProfileStorage::with_path(temp_dir.path().join("profile.json"));
         start_minigame(&mut state);
 
         // Transition to playing state
@@ -612,7 +616,12 @@ mod tests {
 
     #[test]
     fn test_minigame_updates_high_score() {
+        use crate::gamification::ProfileStorage;
+        use tempfile::TempDir;
+
         let mut state = create_test_state();
+        let temp_dir = TempDir::new().unwrap();
+        state.progress.storage = ProfileStorage::with_path(temp_dir.path().join("profile.json"));
         start_minigame(&mut state);
 
         // Set initial high score
@@ -630,6 +639,44 @@ mod tests {
 
         // Check high score was updated
         assert_eq!(state.progress.profile.minigame_high_score, 5000);
+    }
+
+    /// Regression test for #258: `handle_minigame_game_over`'s save must go through
+    /// `ProgressState::save_immediate`, which syncs `performance_tracker` into
+    /// `profile.performance_data` before writing, instead of persisting a stale copy.
+    #[test]
+    fn test_minigame_game_over_persists_synced_fsrs_data() {
+        use crate::gamification::ProfileStorage;
+        use std::time::Duration;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let profile_path = temp_dir.path().join("profile.json");
+
+        let mut state = create_test_state();
+        state.progress.storage = ProfileStorage::with_path(&profile_path);
+        start_minigame(&mut state);
+
+        if let Some(ref mut session) = state.game.minigame_session {
+            session.tick_countdown();
+            session.tick_countdown();
+            session.tick_countdown();
+            session.stats.score = 5000;
+        }
+
+        // Seed tracker state as if reviews happened earlier in the session.
+        state.progress.performance_tracker.record_attempt(
+            "j",
+            Duration::from_millis(500),
+            true,
+            Duration::from_millis(500),
+        );
+
+        handle_minigame_game_over(&mut state).unwrap();
+
+        let persisted = ProfileStorage::with_path(&profile_path).load().unwrap();
+        assert!(!persisted.performance_data.is_empty());
+        assert!(persisted.performance_data.contains_key("j"));
     }
 
     #[test]
@@ -700,7 +747,12 @@ mod tests {
 
     #[test]
     fn test_minigame_timeout_to_game_over() {
+        use crate::gamification::ProfileStorage;
+        use tempfile::TempDir;
+
         let mut state = create_test_state();
+        let temp_dir = TempDir::new().unwrap();
+        state.progress.storage = ProfileStorage::with_path(temp_dir.path().join("profile.json"));
         start_minigame(&mut state);
 
         // Transition to playing state
@@ -747,9 +799,13 @@ mod tests {
 
     #[test]
     fn test_minigame_render_game_over() {
+        use crate::gamification::ProfileStorage;
         use ratatui::{Terminal, backend::TestBackend};
+        use tempfile::TempDir;
 
         let mut state = create_test_state();
+        let temp_dir = TempDir::new().unwrap();
+        state.progress.storage = ProfileStorage::with_path(temp_dir.path().join("profile.json"));
         start_minigame(&mut state);
 
         // Progress to playing
@@ -784,8 +840,12 @@ mod tests {
     #[test]
     fn test_minigame_game_over_handles_errors_gracefully() {
         // Test that game over handler doesn't return error even if save fails
-        // (uses test storage that doesn't actually persist, so save succeeds)
+        use crate::gamification::ProfileStorage;
+        use tempfile::TempDir;
+
         let mut state = create_test_state();
+        let temp_dir = TempDir::new().unwrap();
+        state.progress.storage = ProfileStorage::with_path(temp_dir.path().join("profile.json"));
         start_minigame(&mut state);
 
         // Progress to playing
@@ -1121,7 +1181,12 @@ mod tests {
 
     #[test]
     fn test_minigame_updates_best_streak() {
+        use crate::gamification::ProfileStorage;
+        use tempfile::TempDir;
+
         let mut state = create_test_state();
+        let temp_dir = TempDir::new().unwrap();
+        state.progress.storage = ProfileStorage::with_path(temp_dir.path().join("profile.json"));
         start_minigame(&mut state);
 
         // Set initial best streak
@@ -1143,7 +1208,12 @@ mod tests {
 
     #[test]
     fn test_minigame_does_not_lower_high_score() {
+        use crate::gamification::ProfileStorage;
+        use tempfile::TempDir;
+
         let mut state = create_test_state();
+        let temp_dir = TempDir::new().unwrap();
+        state.progress.storage = ProfileStorage::with_path(temp_dir.path().join("profile.json"));
         start_minigame(&mut state);
 
         // Set high score
@@ -1186,7 +1256,12 @@ mod tests {
 
     #[test]
     fn test_minigame_back_to_menu_increments_games_played() {
+        use crate::gamification::ProfileStorage;
+        use tempfile::TempDir;
+
         let mut state = create_test_state();
+        let temp_dir = TempDir::new().unwrap();
+        state.progress.storage = ProfileStorage::with_path(temp_dir.path().join("profile.json"));
         start_minigame(&mut state);
 
         // Verify initial games_played is 0
@@ -1213,7 +1288,12 @@ mod tests {
 
     #[test]
     fn test_minigame_game_over_increments_games_played() {
+        use crate::gamification::ProfileStorage;
+        use tempfile::TempDir;
+
         let mut state = create_test_state();
+        let temp_dir = TempDir::new().unwrap();
+        state.progress.storage = ProfileStorage::with_path(temp_dir.path().join("profile.json"));
         start_minigame(&mut state);
 
         // Verify initial games_played is 0

--- a/src/ui/state/handlers/mode_selection.rs
+++ b/src/ui/state/handlers/mode_selection.rs
@@ -181,7 +181,7 @@ mod tests {
             ProgressState::new(
                 UserProfile::new(),
                 PerformanceTracker::new(),
-                ProfileStorage::new(),
+                ProfileStorage::for_test(),
             ),
             ConfigState::default(),
         )
@@ -199,7 +199,7 @@ mod tests {
             ProgressState::new(
                 UserProfile::new(),
                 PerformanceTracker::new(),
-                ProfileStorage::new(),
+                ProfileStorage::for_test(),
             ),
             ConfigState::default(),
         )

--- a/src/ui/state/handlers/navigation.rs
+++ b/src/ui/state/handlers/navigation.rs
@@ -98,7 +98,7 @@ mod tests {
             ProgressState::new(
                 UserProfile::new(),
                 PerformanceTracker::new(),
-                ProfileStorage::new(),
+                ProfileStorage::for_test(),
             ),
             ConfigState::default(),
         )

--- a/src/ui/state/handlers/profile.rs
+++ b/src/ui/state/handlers/profile.rs
@@ -54,11 +54,7 @@ pub fn handle_award_xp(ctx: &mut HandlerContext<'_>, amount: u64) -> Result<(), 
         );
         ctx.ui.notifications.push(notification);
 
-        ctx.progress
-            .storage
-            .save(&ctx.progress.profile)
-            .map_err(UserError::from)?;
-        ctx.progress.mark_saved();
+        ctx.progress.save_immediate().map_err(UserError::from)?;
     }
     Ok(())
 }
@@ -101,7 +97,7 @@ mod tests {
             progress: ProgressState::new(
                 UserProfile::new(),
                 PerformanceTracker::new(),
-                ProfileStorage::new(),
+                ProfileStorage::for_test(),
             ),
             config: ConfigState::default(),
         }
@@ -296,9 +292,12 @@ mod tests {
 
     #[test]
     fn test_award_xp_with_level_up() {
-        use crate::gamification::XPCalculator;
+        use crate::gamification::{ProfileStorage, XPCalculator};
+        use tempfile::TempDir;
 
         let mut state = create_test_state();
+        let temp_dir = TempDir::new().unwrap();
+        state.progress.storage = ProfileStorage::with_path(temp_dir.path().join("profile.json"));
 
         // Set XP just below level 2 threshold
         let xp_for_level_2 = XPCalculator::xp_for_level(2);
@@ -336,9 +335,12 @@ mod tests {
 
     #[test]
     fn test_award_xp_multiple_levels() {
-        use crate::gamification::XPCalculator;
+        use crate::gamification::{ProfileStorage, XPCalculator};
+        use tempfile::TempDir;
 
         let mut state = create_test_state();
+        let temp_dir = TempDir::new().unwrap();
+        state.progress.storage = ProfileStorage::with_path(temp_dir.path().join("profile.json"));
         state.progress.profile.total_xp = 0;
         state.progress.profile.level = 1;
 
@@ -383,9 +385,12 @@ mod tests {
 
     #[test]
     fn test_award_xp_calls_save_on_level_up() {
-        use crate::gamification::XPCalculator;
+        use crate::gamification::{ProfileStorage, XPCalculator};
+        use tempfile::TempDir;
 
         let mut state = create_test_state();
+        let temp_dir = TempDir::new().unwrap();
+        state.progress.storage = ProfileStorage::with_path(temp_dir.path().join("profile.json"));
 
         // Set XP just below next level
         let xp_for_next = XPCalculator::xp_for_level(2);
@@ -427,5 +432,48 @@ mod tests {
 
         // XP should increase correctly
         assert_eq!(state.progress.profile.total_xp, initial_xp + large_xp);
+    }
+
+    /// Regression test for #258: `handle_award_xp`'s level-up save must go through
+    /// `ProgressState::save_immediate`, which syncs `performance_tracker` into
+    /// `profile.performance_data` before writing, not a raw `storage.save` that would
+    /// persist a stale/empty `performance_data`.
+    #[test]
+    fn test_award_xp_level_up_persists_synced_fsrs_data() {
+        use crate::gamification::{ProfileStorage, XPCalculator};
+        use std::time::Duration;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let profile_path = temp_dir.path().join("profile.json");
+
+        let mut state = create_test_state();
+        state.progress.storage = ProfileStorage::with_path(&profile_path);
+
+        // Seed tracker state as if a review happened earlier in the session.
+        state.progress.performance_tracker.record_attempt(
+            "x",
+            Duration::from_millis(500),
+            true,
+            Duration::from_millis(500),
+        );
+
+        let xp_for_next = XPCalculator::xp_for_level(2);
+        state.progress.profile.total_xp = xp_for_next - 10;
+        state.progress.profile.level = 1;
+
+        let mut ctx = HandlerContext::new(
+            &mut state.ui,
+            &mut state.game,
+            &mut state.progress,
+            &state.config,
+        );
+
+        handle_award_xp(&mut ctx, 100).unwrap();
+        assert_eq!(ctx.progress.profile.level, 2);
+
+        let persisted = ProfileStorage::with_path(&profile_path).load().unwrap();
+        assert!(!persisted.performance_data.is_empty());
+        assert!(persisted.performance_data.contains_key("x"));
     }
 }

--- a/src/ui/state/handlers/review.rs
+++ b/src/ui/state/handlers/review.rs
@@ -72,6 +72,12 @@ pub fn handle_complete_review_command(
         // Update performance tracker
         let tracker = &mut ctx.progress.performance_tracker;
         tracker.record_attempt(command, duration, success, OPTIMAL_REVIEW_TIME);
+
+        // Persist periodically so review progress survives a crash mid-session
+        // (non-fatal error - log but continue, a review keypress must not kill the session)
+        if let Err(e) = ctx.progress.save_debounced() {
+            tracing::error!("Failed to save profile during review session: {:?}", e);
+        }
     }
 
     // Delegate to next review handler for screen transition logic
@@ -103,8 +109,7 @@ pub fn handle_next_review_command(
 
             // Award XP for review session
             let xp = (completed as u64 * 10) + (success_rate * 20.0) as u64;
-            let profile = &mut ctx.progress.profile;
-            profile.add_xp(xp);
+            ctx.progress.profile.add_xp(xp);
 
             // Show session summary notification
             ctx.ui
@@ -117,6 +122,12 @@ pub fn handle_next_review_command(
 
             // Clear review session
             ctx.game.review_session = None;
+
+            // Persist FSRS state and profile now that the review session has ended
+            // (non-fatal error - log but continue, matches handle_minigame_game_over's policy)
+            if let Err(e) = ctx.progress.save_immediate() {
+                tracing::error!("Failed to save profile after review session: {:?}", e);
+            }
 
             // Return to menu
             return Ok(HandlerOutcome::Transition(Box::new(TypedScreen::Menu(
@@ -137,6 +148,16 @@ pub fn handle_abandon_review_session(
     ctx: &mut HandlerContext<'_>,
 ) -> Result<HandlerOutcome, UserError> {
     ctx.game.review_session = None;
+
+    // Persist attempts already recorded so far - abandoning mid-session (e.g. Esc)
+    // is the likelier interrupted-user path, so it should flush just like completion does
+    if let Err(e) = ctx.progress.save_immediate() {
+        tracing::error!(
+            "Failed to save profile after abandoning review session: {:?}",
+            e
+        );
+    }
+
     Ok(HandlerOutcome::Transition(Box::new(TypedScreen::Menu(
         MenuData::default(),
     ))))

--- a/src/ui/state/handlers/scenario.rs
+++ b/src/ui/state/handlers/scenario.rs
@@ -84,23 +84,7 @@ fn record_scenario_completion(
     let leveled_up = ctx.progress.profile.add_xp(total_xp);
     ScenarioCompletionService::update_profile_counters(&mut ctx.progress.profile, is_perfect);
 
-    if leveled_up {
-        ctx.progress
-            .storage
-            .save(&ctx.progress.profile)
-            .map_err(UserError::from)?;
-        ctx.progress.mark_saved();
-    }
-
     ctx.progress.scenarios_completed_today += 1;
-
-    if ctx.progress.should_save() {
-        ctx.progress
-            .storage
-            .save(&ctx.progress.profile)
-            .map_err(UserError::from)?;
-        ctx.progress.mark_saved();
-    }
 
     let commands = ScenarioCompletionService::extract_commands(feedback);
     ctx.progress.profile.commands_executed = ctx
@@ -115,6 +99,14 @@ fn record_scenario_completion(
         feedback.duration,
         feedback.score > 0,
     );
+
+    // Save after FSRS data has been recorded so `performance_data` reflects this
+    // scenario's review history, not the state before it.
+    if leveled_up {
+        ctx.progress.save_immediate().map_err(UserError::from)?;
+    } else {
+        ctx.progress.save_debounced().map_err(UserError::from)?;
+    }
 
     // Generate notifications for mastery level ups
     for (command, new_level) in mastery_changes {
@@ -438,7 +430,7 @@ mod tests {
             progress: ProgressState::new(
                 UserProfile::new(),
                 PerformanceTracker::new(),
-                ProfileStorage::new(),
+                ProfileStorage::for_test(),
             ),
             config: ConfigState::default(),
         }
@@ -704,8 +696,12 @@ mod tests {
     #[test]
     fn test_handle_complete_scenario_full_flow() {
         use crate::game::SessionAfterAction;
+        use crate::gamification::ProfileStorage;
+        use tempfile::TempDir;
 
         let mut state = create_test_state();
+        let temp_dir = TempDir::new().unwrap();
+        state.progress.storage = ProfileStorage::with_path(temp_dir.path().join("profile.json"));
         let scenario = create_test_scenario();
         let session = GameSession::new(scenario).unwrap();
 
@@ -784,6 +780,118 @@ mod tests {
         )));
     }
 
+    /// Compares the fields that `save_immediate`/`save_debounced` sync from the
+    /// tracker. `CommandPerformance` has no `PartialEq` impl.
+    fn stats_match(
+        a: &std::collections::HashMap<String, crate::learning::CommandPerformance>,
+        b: &std::collections::HashMap<String, crate::learning::CommandPerformance>,
+    ) -> bool {
+        a.len() == b.len()
+            && a.iter().all(|(k, v)| {
+                b.get(k).is_some_and(|other| {
+                    other.attempts == v.attempts
+                        && other.successes == v.successes
+                        && other.reps == v.reps
+                        && other.command == v.command
+                })
+            })
+    }
+
+    fn completed_feedback_with_commands() -> crate::game::Feedback {
+        use crate::game::SessionAfterAction;
+
+        let scenario = create_test_scenario();
+        let session = GameSession::new(scenario).unwrap();
+
+        let result = session.record_action("x".to_string()).unwrap();
+        let session = match result {
+            SessionAfterAction::StillActive(s) => s,
+            SessionAfterAction::Completed(_) => panic!("Should not complete after just 'x'"),
+        };
+        let result = session.record_action("d".to_string()).unwrap();
+        let completed = match result {
+            SessionAfterAction::Completed(c) => c,
+            SessionAfterAction::StillActive(_) => panic!("Should complete after 'x' + 'd'"),
+        };
+
+        completed.feedback().unwrap()
+    }
+
+    /// Regression test for #273: the FSRS-recording step in `record_scenario_completion`
+    /// must run *before* the save, otherwise the persisted profile captures stale
+    /// (pre-completion) tracker state even though the in-memory tracker is up to date.
+    #[test]
+    fn test_record_scenario_completion_persists_fsrs_data_no_level_up() {
+        use crate::gamification::ProfileStorage;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let profile_path = temp_dir.path().join("profile.json");
+
+        let mut state = create_test_state();
+        state.progress.storage = ProfileStorage::with_path(&profile_path);
+        // Fresh profile: no prior save recorded, so save_debounced will fire.
+        assert!(state.progress.should_save());
+
+        let feedback = completed_feedback_with_commands();
+
+        let mut ctx = HandlerContext::new(
+            &mut state.ui,
+            &mut state.game,
+            &mut state.progress,
+            &state.config,
+        );
+
+        // Small XP amount that should not trigger a level-up, exercising the
+        // save_debounced branch.
+        record_scenario_completion(&mut ctx, &feedback, 1).unwrap();
+
+        let persisted = ProfileStorage::with_path(&profile_path).load().unwrap();
+        assert!(
+            !persisted.performance_data.is_empty(),
+            "persisted profile should contain FSRS data recorded during completion"
+        );
+        assert!(stats_match(
+            &persisted.performance_data,
+            &ctx.progress.performance_tracker.get_stats_clone()
+        ));
+    }
+
+    /// Same as above but through the level-up (save_immediate) branch.
+    #[test]
+    fn test_record_scenario_completion_persists_fsrs_data_on_level_up() {
+        use crate::gamification::{ProfileStorage, XPCalculator};
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let profile_path = temp_dir.path().join("profile.json");
+
+        let mut state = create_test_state();
+        state.progress.storage = ProfileStorage::with_path(&profile_path);
+        let xp_for_level_2 = XPCalculator::xp_for_level(2);
+        state.progress.profile.total_xp = xp_for_level_2 - 10;
+        state.progress.profile.level = 1;
+
+        let feedback = completed_feedback_with_commands();
+
+        let mut ctx = HandlerContext::new(
+            &mut state.ui,
+            &mut state.game,
+            &mut state.progress,
+            &state.config,
+        );
+
+        record_scenario_completion(&mut ctx, &feedback, 100).unwrap();
+        assert!(ctx.progress.profile.level >= 2, "expected a level-up");
+
+        let persisted = ProfileStorage::with_path(&profile_path).load().unwrap();
+        assert!(!persisted.performance_data.is_empty());
+        assert!(stats_match(
+            &persisted.performance_data,
+            &ctx.progress.performance_tracker.get_stats_clone()
+        ));
+    }
+
     #[test]
     fn test_handle_start_scenario_creates_task_screen() {
         let mut state = create_test_state();
@@ -857,7 +965,7 @@ mod tests {
             progress: ProgressState::new(
                 UserProfile::new(),
                 PerformanceTracker::new(),
-                ProfileStorage::new(),
+                ProfileStorage::for_test(),
             ),
             config: ConfigState::default(),
         }

--- a/src/ui/state/mod.rs
+++ b/src/ui/state/mod.rs
@@ -419,16 +419,7 @@ impl AppState {
     // NOTE: Debounce saves to reduce I/O overhead (5-second delay)
     // OPTIMIZE: Performance audit suggested this optimization (50-80% I/O reduction)
     pub fn save_profile_debounced(&mut self) -> Result<(), crate::gamification::GamificationError> {
-        if !self.progress.should_save() {
-            return Ok(());
-        }
-
-        self.progress.profile.performance_data =
-            self.progress.performance_tracker.get_stats_clone();
-        self.progress.storage.save(&self.progress.profile)?;
-        self.progress.mark_saved();
-
-        Ok(())
+        self.progress.save_debounced()
     }
 
     /// Force immediate save (for level-up, achievements, exit)
@@ -437,11 +428,7 @@ impl AppState {
     ///
     /// Returns error if save operation fails
     pub fn save_profile_immediate(&mut self) -> Result<(), crate::gamification::GamificationError> {
-        self.progress.profile.performance_data =
-            self.progress.performance_tracker.get_stats_clone();
-        self.progress.storage.save(&self.progress.profile)?;
-        self.progress.mark_saved();
-        Ok(())
+        self.progress.save_immediate()
     }
 }
 

--- a/src/ui/state/substates.rs
+++ b/src/ui/state/substates.rs
@@ -217,6 +217,38 @@ impl ProgressState {
     pub fn mark_saved(&mut self) {
         self.last_save_time = Some(Instant::now());
     }
+
+    /// Sync FSRS performance data from the live tracker and persist the profile immediately.
+    ///
+    /// This is the single source of truth for saving progress: every call site that
+    /// persists the profile mid-session must go through this method (or
+    /// [`ProgressState::save_debounced`]) rather than calling `storage.save` directly,
+    /// otherwise `profile.performance_data` silently goes stale.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the save operation fails.
+    pub fn save_immediate(&mut self) -> Result<(), crate::gamification::GamificationError> {
+        self.profile.performance_data = self.performance_tracker.get_stats_clone();
+        self.storage.save(&self.profile)?;
+        self.mark_saved();
+        Ok(())
+    }
+
+    /// Save the profile only if the debounce interval has elapsed since the last save.
+    ///
+    /// Syncs FSRS performance data from the live tracker before writing, same as
+    /// [`ProgressState::save_immediate`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the save operation fails.
+    pub fn save_debounced(&mut self) -> Result<(), crate::gamification::GamificationError> {
+        if !self.should_save() {
+            return Ok(());
+        }
+        self.save_immediate()
+    }
 }
 
 impl std::fmt::Debug for ProgressState {
@@ -359,7 +391,7 @@ mod tests {
         let progress = ProgressState::new(
             UserProfile::new(),
             PerformanceTracker::new(),
-            ProfileStorage::new(),
+            ProfileStorage::for_test(),
         );
 
         // Should save immediately when no previous save
@@ -374,7 +406,7 @@ mod tests {
         let mut progress = ProgressState::new(
             UserProfile::new(),
             PerformanceTracker::new(),
-            ProfileStorage::new(),
+            ProfileStorage::for_test(),
         );
 
         assert!(progress.last_save_time.is_none());
@@ -390,7 +422,7 @@ mod tests {
         let mut progress = ProgressState::new(
             UserProfile::new(),
             PerformanceTracker::new(),
-            ProfileStorage::new(),
+            ProfileStorage::for_test(),
         );
 
         // First save should be allowed
@@ -399,5 +431,132 @@ mod tests {
 
         // Immediate second save should be blocked (within 5 second window)
         assert!(!progress.should_save());
+    }
+
+    /// Compares the fields that `save_immediate`/`save_debounced` are responsible for
+    /// syncing. `CommandPerformance` has no `PartialEq` impl, so this checks the subset
+    /// of fields that prove the persisted copy reflects the tracker's state.
+    fn stats_match(
+        a: &std::collections::HashMap<String, crate::learning::CommandPerformance>,
+        b: &std::collections::HashMap<String, crate::learning::CommandPerformance>,
+    ) -> bool {
+        a.len() == b.len()
+            && a.iter().all(|(k, v)| {
+                b.get(k).is_some_and(|other| {
+                    other.attempts == v.attempts
+                        && other.successes == v.successes
+                        && other.reps == v.reps
+                        && other.command == v.command
+                })
+            })
+    }
+
+    #[test]
+    fn test_save_immediate_syncs_tracker_stats_into_persisted_profile() {
+        use crate::gamification::{ProfileStorage, UserProfile};
+        use crate::learning::PerformanceTracker;
+        use std::time::Duration;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let profile_path = temp_dir.path().join("profile.json");
+
+        let mut progress = ProgressState::new(
+            UserProfile::new(),
+            PerformanceTracker::new(),
+            ProfileStorage::with_path(&profile_path),
+        );
+
+        progress.performance_tracker.record_attempt(
+            "x",
+            Duration::from_millis(500),
+            true,
+            Duration::from_millis(500),
+        );
+
+        progress.save_immediate().unwrap();
+
+        let persisted = ProfileStorage::with_path(&profile_path).load().unwrap();
+        assert!(!persisted.performance_data.is_empty());
+        assert!(stats_match(
+            &persisted.performance_data,
+            &progress.performance_tracker.get_stats_clone()
+        ));
+    }
+
+    #[test]
+    fn test_save_debounced_does_not_write_within_debounce_window() {
+        use crate::gamification::{ProfileStorage, UserProfile};
+        use crate::learning::PerformanceTracker;
+        use std::time::Duration;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let profile_path = temp_dir.path().join("profile.json");
+
+        let mut progress = ProgressState::new(
+            UserProfile::new(),
+            PerformanceTracker::new(),
+            ProfileStorage::with_path(&profile_path),
+        );
+
+        // Establish a recent save so the debounce window is active.
+        progress.save_immediate().unwrap();
+        let after_first_save = std::fs::read_to_string(&profile_path).unwrap();
+
+        // Mutate the tracker after the save; a debounced save within the window
+        // must not pick this up.
+        progress.performance_tracker.record_attempt(
+            "d",
+            Duration::from_millis(500),
+            true,
+            Duration::from_millis(500),
+        );
+        progress.save_debounced().unwrap();
+
+        let after_debounced_call = std::fs::read_to_string(&profile_path).unwrap();
+        assert_eq!(
+            after_first_save, after_debounced_call,
+            "debounced save must not have rewritten the file within the debounce window"
+        );
+    }
+
+    #[test]
+    fn test_save_debounced_writes_once_debounce_elapses() {
+        use crate::gamification::{ProfileStorage, UserProfile};
+        use crate::learning::PerformanceTracker;
+        use std::time::{Duration, Instant};
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let profile_path = temp_dir.path().join("profile.json");
+
+        let mut progress = ProgressState::new(
+            UserProfile::new(),
+            PerformanceTracker::new(),
+            ProfileStorage::with_path(&profile_path),
+        );
+
+        // Simulate a save that happened long enough ago for the debounce to elapse,
+        // without needing to sleep in the test.
+        progress.last_save_time =
+            Some(Instant::now() - PROFILE_SAVE_DEBOUNCE - Duration::from_secs(1));
+
+        progress.performance_tracker.record_attempt(
+            "j",
+            Duration::from_millis(500),
+            true,
+            Duration::from_millis(500),
+        );
+
+        assert!(progress.should_save());
+        progress.save_debounced().unwrap();
+
+        let persisted = ProfileStorage::with_path(&profile_path).load().unwrap();
+        assert!(stats_match(
+            &persisted.performance_data,
+            &progress.performance_tracker.get_stats_clone()
+        ));
+        assert!(!persisted.performance_data.is_empty());
     }
 }

--- a/src/ui/state/tests/mode_selection_tests.rs
+++ b/src/ui/state/tests/mode_selection_tests.rs
@@ -125,8 +125,13 @@ fn test_navigate_back_from_menu_to_mode_selection() {
 
 #[test]
 fn test_navigate_back_from_minigame_to_mode_selection() {
+    use crate::gamification::ProfileStorage;
+    use tempfile::TempDir;
+
     let scenario = create_test_scenario();
     let mut state = create_test_app_state(vec![scenario]);
+    let temp_dir = TempDir::new().unwrap();
+    state.progress.storage = ProfileStorage::with_path(temp_dir.path().join("profile.json"));
 
     // Go to Arcade Mode
     update(&mut state, Message::SelectArcadeMode).unwrap();

--- a/src/ui/state/tests/review_tests.rs
+++ b/src/ui/state/tests/review_tests.rs
@@ -3,11 +3,16 @@
 //! NOTE: FSRS (the spaced repetition algorithm) schedules reviews intelligently,
 //! typically in the future even for failed attempts. These tests focus on the
 //! state management logic, not FSRS scheduling behavior.
+//!
+//! The persistence regression tests below (`test_complete_review_command_persists_*`,
+//! `test_review_session_completion_*`) bypass FSRS due-scheduling entirely by
+//! constructing `ReviewSessionState` directly, since `StartReviewSession` cannot be
+//! relied on to produce a due review deterministically.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use super::common::{create_test_app_state, create_test_scenario};
-use crate::ui::state::{Message, TypedScreen, update};
+use crate::ui::state::{Message, ReviewSessionState, TypedScreen, update};
 
 #[test]
 fn test_review_session_with_no_due_reviews() {
@@ -57,4 +62,161 @@ fn test_review_session_no_due_reviews_stays_on_menu() {
     // Should stay on ModeSelection when no reviews are due
     assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
     assert!(state.game.review_session.is_none());
+}
+
+fn review_session_with_commands(due_commands: Vec<String>) -> ReviewSessionState {
+    ReviewSessionState {
+        current_command: due_commands.first().cloned(),
+        due_commands,
+        current_index: 0,
+        session_started_at: Instant::now(),
+        completed_reviews: Vec::new(),
+    }
+}
+
+/// Regression test for #258/C1: `handle_complete_review_command`'s per-answer save
+/// must go through `save_debounced`, which syncs `performance_tracker` before
+/// writing, so a mid-session review answer is not lost if the app is killed before
+/// the session ends.
+#[test]
+fn test_complete_review_command_persists_fsrs_data_mid_session() {
+    use crate::gamification::ProfileStorage;
+    use tempfile::TempDir;
+
+    let scenario = create_test_scenario();
+    let mut state = create_test_app_state(vec![scenario]);
+    let temp_dir = TempDir::new().unwrap();
+    state.progress.storage = ProfileStorage::with_path(temp_dir.path().join("profile.json"));
+
+    // Two due commands so completing the first one does not end the session.
+    state.game.review_session = Some(review_session_with_commands(vec![
+        "x".to_string(),
+        "d".to_string(),
+    ]));
+
+    update(&mut state, Message::CompleteReviewCommand { success: true }).unwrap();
+
+    // Session should still be active (only 1 of 2 commands completed).
+    assert!(state.game.review_session.is_some());
+
+    let persisted = ProfileStorage::with_path(state.progress.storage.path())
+        .load()
+        .unwrap();
+    assert!(
+        persisted.performance_data.contains_key("x"),
+        "the completed review's FSRS data must be persisted before the session ends"
+    );
+}
+
+/// Regression test for #258/C1: ending a review session must award XP and persist
+/// both the XP change and the FSRS data via `save_immediate`, matching what the
+/// in-memory tracker/profile hold at that point.
+#[test]
+fn test_review_session_completion_persists_xp_and_fsrs_data() {
+    use crate::gamification::ProfileStorage;
+    use tempfile::TempDir;
+
+    let scenario = create_test_scenario();
+    let mut state = create_test_app_state(vec![scenario]);
+    let temp_dir = TempDir::new().unwrap();
+    state.progress.storage = ProfileStorage::with_path(temp_dir.path().join("profile.json"));
+
+    let initial_xp = state.progress.profile.total_xp;
+
+    // Single due command: completing it ends the session immediately.
+    state.game.review_session = Some(review_session_with_commands(vec!["x".to_string()]));
+
+    update(&mut state, Message::CompleteReviewCommand { success: true }).unwrap();
+
+    // Session should be cleared and XP awarded (1 completed * 10 + 100% success * 20).
+    assert!(state.game.review_session.is_none());
+    assert_eq!(state.progress.profile.total_xp, initial_xp + 30);
+    assert!(matches!(state.screen, TypedScreen::Menu(_)));
+
+    let persisted = ProfileStorage::with_path(state.progress.storage.path())
+        .load()
+        .unwrap();
+    assert_eq!(persisted.total_xp, state.progress.profile.total_xp);
+    assert!(
+        persisted.performance_data.contains_key("x"),
+        "FSRS data recorded during the review session must survive the final flush"
+    );
+}
+
+/// Regression test for #258/C1: a level-up during a review session must persist the
+/// leveled-up profile via the session-complete save.
+///
+/// Note: review sessions intentionally do not surface a `LevelUp` notification (unlike
+/// `handlers/profile.rs`'s dead `handle_award_xp`) - `scenario.rs`, the app's primary XP
+/// path, does not notify on level-up either, so adding one only here would be an
+/// inconsistent, unrelated behavior change riding along with this persistence fix.
+#[test]
+fn test_review_session_completion_persists_level_up() {
+    use crate::gamification::{ProfileStorage, XPCalculator};
+    use tempfile::TempDir;
+
+    let scenario = create_test_scenario();
+    let mut state = create_test_app_state(vec![scenario]);
+    let temp_dir = TempDir::new().unwrap();
+    state.progress.storage = ProfileStorage::with_path(temp_dir.path().join("profile.json"));
+
+    let xp_for_level_2 = XPCalculator::xp_for_level(2);
+    state.progress.profile.total_xp = xp_for_level_2 - 10;
+    state.progress.profile.level = 1;
+
+    state.game.review_session = Some(review_session_with_commands(vec!["x".to_string()]));
+
+    update(&mut state, Message::CompleteReviewCommand { success: true }).unwrap();
+
+    assert_eq!(state.progress.profile.level, 2);
+
+    let persisted = ProfileStorage::with_path(state.progress.storage.path())
+        .load()
+        .unwrap();
+    assert_eq!(persisted.level, 2);
+}
+
+/// Regression test for M4: abandoning a review session (e.g. pressing Esc mid-session)
+/// must flush already-recorded FSRS data via `save_immediate`, unconditionally, even
+/// when a prior debounced save was skipped because the debounce window was still open.
+#[test]
+fn test_abandon_review_session_persists_partial_progress() {
+    use crate::gamification::ProfileStorage;
+    use tempfile::TempDir;
+
+    let scenario = create_test_scenario();
+    let mut state = create_test_app_state(vec![scenario]);
+    let temp_dir = TempDir::new().unwrap();
+    state.progress.storage = ProfileStorage::with_path(temp_dir.path().join("profile.json"));
+
+    // Simulate a save that just happened, so the per-answer debounced save below
+    // is skipped and nothing is on disk yet.
+    state.progress.mark_saved();
+
+    // Two due commands so completing the first one does not end the session.
+    state.game.review_session = Some(review_session_with_commands(vec![
+        "x".to_string(),
+        "d".to_string(),
+    ]));
+
+    update(&mut state, Message::CompleteReviewCommand { success: true }).unwrap();
+    assert!(state.game.review_session.is_some(), "session still active");
+
+    // Nothing persisted yet: the debounce window is still open.
+    let profile_path = temp_dir.path().join("profile.json");
+    assert!(
+        !profile_path.exists(),
+        "debounced save should have been skipped"
+    );
+
+    update(&mut state, Message::AbandonReviewSession).unwrap();
+
+    assert!(state.game.review_session.is_none());
+    assert!(matches!(state.screen, TypedScreen::Menu(_)));
+
+    let persisted = ProfileStorage::with_path(&profile_path).load().unwrap();
+    assert!(
+        persisted.performance_data.contains_key("x"),
+        "abandoning must flush FSRS data recorded before the debounce window elapsed"
+    );
 }

--- a/src/ui/state/tests/scenario_tests.rs
+++ b/src/ui/state/tests/scenario_tests.rs
@@ -35,8 +35,13 @@ fn test_start_invalid_scenario_index() {
 
 #[test]
 fn test_complete_scenario_navigates_to_results() {
+    use crate::gamification::ProfileStorage;
+    use tempfile::TempDir;
+
     let scenario = create_test_scenario();
     let mut state = create_test_app_state(vec![scenario]);
+    let temp_dir = TempDir::new().unwrap();
+    state.progress.storage = ProfileStorage::with_path(temp_dir.path().join("profile.json"));
 
     update(&mut state, Message::StartScenario(0)).unwrap();
     assert!(matches!(state.screen, TypedScreen::Task(_)));
@@ -150,10 +155,13 @@ fn test_next_scenario_clears_session() {
 
 #[test]
 fn test_previously_completed_quests_tracking() {
-    use crate::gamification::{Quest, QuestDifficulty, QuestType};
+    use crate::gamification::{ProfileStorage, Quest, QuestDifficulty, QuestType};
+    use tempfile::TempDir;
 
     let scenario = create_test_scenario();
     let mut state = create_test_app_state(vec![scenario.clone()]);
+    let temp_dir = TempDir::new().unwrap();
+    state.progress.storage = ProfileStorage::with_path(temp_dir.path().join("profile.json"));
 
     // Add a quest that will be completed on first scenario
     // In Helix, use 'x' (select_line) for line-based quests


### PR DESCRIPTION
## Summary

- Mid-session profile saves (scenario completion, XP award, mini-game game-over, review-session completion/abandon) previously persisted stale `performance_data` because only the clean-exit save path synced the live FSRS tracker before writing. All five in-session save call sites now route through a single centralized `ProgressState::save_immediate`/`save_debounced` sync-then-save path instead of duplicating (and partly skipping) the sync step.
- `ProfileStorage::save` now writes atomically (temp file + `fsync` + `rename`), preserves file permissions, and cleans up the temp file on any failure path, so a crash or forced kill mid-save can no longer truncate/corrupt the on-disk profile.
- Review-session flow (`src/ui/state/handlers/review.rs`) previously never persisted FSRS/XP changes at all; it now saves on a non-fatal, log-and-continue basis matching the mini-game handler's error policy.
- Test fixtures across the codebase were writing to the real user profile path during `cargo nextest run`; added a `#[cfg(test)]`-gated `ProfileStorage::for_test()` backed by a process-lifetime temp directory and rewired every shared/per-file test fixture default to use it.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (1805/1805 passed)
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Verified the real on-disk profile is untouched by a full test run (hash before/after)
- [x] Added regression tests proving mid-session events persist synced FSRS data to actual storage, not just in-memory state

Fixes #258
Fixes #273