### PR TITLE
fix(gamification): wire streak, freeze, and achievement triggers into live gameplay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `paste_after`/`paste_before` (`p`/`P`) now insert at the correct end of a range selection regardless of its direction, instead of always using the raw (possibly backward) `head` position (#266)
 - `redo` (`U`, `Ctrl-r`) now restores the most recently undone change via a redo stack built on the existing document history, instead of being a no-op; repeated redo walks forward through history and round-trips correctly with undo (#265)
 - Applying a transaction with no actual document changes no longer records a spurious undo step or discards pending redo history (#265)
+- Wire up daily-streak, streak-freeze, and achievement triggers that were fully implemented but never invoked outside of unit tests (#267, #257, #256):
+  - Quest completion now marks `UserProfile::completed_quests_today`, so `StreakManager::update_streak` (still evaluated once per app launch, at profile load) can increment `current_streak` on the following day's session instead of the set staying permanently empty (#267)
+  - Streak-freeze eligibility now requires completing every quest generated for the day rather than a fixed count of 5, which the quest generator can never produce (max 4/day) and was therefore unreachable; eligible completion grants a freeze via `StreakManager::grant_freeze`, surfaced with a new `StreakFreezeGranted` notification (#257)
+  - Scenario completion and profile load now check `AchievementEngine::check_achievements` and unlock newly satisfied achievements — including retroactively unlocking every tier a profile already qualifies for, not just the highest one — surfaced via the existing `Achievement` notification (#256)
 
 ### Changed
 

--- a/src/constants/gameplay.rs
+++ b/src/constants/gameplay.rs
@@ -31,10 +31,6 @@ pub const OPTIMAL_EFFICIENCY_BONUS: f64 = 0.25;
 /// Efficiency bonus for >80% efficiency (12.5%)
 pub const MAX_EFFICIENCY_BONUS: f64 = 0.125;
 
-// Streak system
-/// Number of quests completed to earn a streak freeze
-pub const QUESTS_FOR_STREAK_FREEZE: u32 = 5;
-
 // Streak milestones (in days)
 /// Week streak milestone (7 days)
 pub const STREAK_MILESTONE_WEEK: u32 = 7;

--- a/src/data_handling.rs
+++ b/src/data_handling.rs
@@ -8,9 +8,12 @@ use chrono::{DateTime, Utc};
 use helix_trainer::{
     async_state::DataLoadMessage,
     config::ScenarioCollection,
-    gamification::{QuestGenerator, QuestTemplateRegistry, StreakManager, UserProfile},
+    gamification::{
+        Achievement, AchievementEngine, QuestGenerator, QuestTemplateRegistry, StreakManager,
+        UserProfile,
+    },
     learning::PerformanceTracker,
-    ui::AppState,
+    ui::{AppState, Notification, NotificationType},
 };
 
 /// Check if daily quests should be refreshed
@@ -68,6 +71,28 @@ pub fn handle_data_message(state: &mut AppState, msg: DataLoadMessage) -> Result
             state.progress.performance_tracker =
                 PerformanceTracker::from_stats(updated_profile.performance_data.clone());
             state.progress.profile = updated_profile;
+
+            // Streak (and possibly quest history) may have just changed above;
+            // surface any achievements that are now satisfied.
+            let newly_unlocked = AchievementEngine::check_and_unlock(
+                &mut state.progress.profile,
+                &state.progress.performance_tracker,
+            );
+            if !newly_unlocked.is_empty() {
+                for achievement_id in newly_unlocked {
+                    let achievement = Achievement::new(achievement_id);
+                    state
+                        .ui
+                        .notifications
+                        .push(Notification::new(NotificationType::Achievement {
+                            name: achievement.name,
+                            description: achievement.description,
+                        }));
+                }
+                state.progress.storage.save(&state.progress.profile)?;
+                state.progress.mark_saved();
+            }
+
             tracing::info!("Profile loaded");
         }
 
@@ -197,6 +222,36 @@ mod tests {
         let loaded_profile = &state.progress.profile;
         assert_eq!(loaded_profile.total_xp, 500);
         assert_eq!(loaded_profile.level, 3);
+    }
+
+    /// Regression test for #256: a streak that crosses a milestone at load time (the only
+    /// place `StreakManager::update_streak` runs) must unlock the corresponding achievement
+    /// and notify the user, not just update `current_streak`.
+    #[test]
+    fn test_handle_profile_ready_unlocks_streak_achievement() {
+        use helix_trainer::gamification::AchievementId;
+
+        let mut state = empty_test_app_state();
+        let mut profile = UserProfile::new();
+        profile.current_streak = 6;
+        profile.completed_quests_today.insert("quest_0".to_string());
+        profile.last_activity = Utc::now() - chrono::Duration::days(1);
+
+        let result = handle_data_message(&mut state, DataLoadMessage::ProfileReady(profile));
+
+        assert!(result.is_ok());
+        // Streak should have incremented from 6 to 7, crossing the Streak7Days threshold
+        assert_eq!(state.progress.profile.current_streak, 7);
+        assert!(
+            state
+                .progress
+                .profile
+                .has_achievement(&AchievementId::Streak7Days)
+        );
+        assert!(state.ui.notifications.visible().iter().any(|n| matches!(
+            n.notification_type,
+            NotificationType::Achievement { ref name, .. } if name == "7-Day Warrior"
+        )));
     }
 
     #[test]

--- a/src/gamification/achievements.rs
+++ b/src/gamification/achievements.rs
@@ -153,16 +153,50 @@ impl AchievementEngine {
         unlocked
     }
 
+    /// Check achievement conditions and unlock any newly satisfied achievements on `profile`
+    ///
+    /// Returns the ids that were newly unlocked by this call, for the caller to surface
+    /// (e.g. as notifications).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use helix_trainer::gamification::{AchievementEngine, UserProfile};
+    /// use helix_trainer::learning::PerformanceTracker;
+    ///
+    /// let mut profile = UserProfile::new();
+    /// profile.perfect_scenarios = 1;
+    ///
+    /// let tracker = PerformanceTracker::new();
+    /// let unlocked = AchievementEngine::check_and_unlock(&mut profile, &tracker);
+    ///
+    /// assert!(profile.has_achievement(&helix_trainer::gamification::AchievementId::FirstPerfect));
+    /// assert_eq!(unlocked.len(), 1);
+    /// ```
+    pub fn check_and_unlock(
+        profile: &mut UserProfile,
+        tracker: &PerformanceTracker,
+    ) -> Vec<AchievementId> {
+        let newly_unlocked = Self::check_achievements(profile, tracker);
+        for &id in &newly_unlocked {
+            profile.unlock_achievement(id);
+        }
+        newly_unlocked
+    }
+
     fn check_streak_achievements(profile: &UserProfile, unlocked: &mut Vec<AchievementId>) {
         let streak = profile.current_streak;
 
         if streak >= 365 && !profile.has_achievement(&AchievementId::Streak365Days) {
             unlocked.push(AchievementId::Streak365Days);
-        } else if streak >= 90 && !profile.has_achievement(&AchievementId::Streak90Days) {
+        }
+        if streak >= 90 && !profile.has_achievement(&AchievementId::Streak90Days) {
             unlocked.push(AchievementId::Streak90Days);
-        } else if streak >= 30 && !profile.has_achievement(&AchievementId::Streak30Days) {
+        }
+        if streak >= 30 && !profile.has_achievement(&AchievementId::Streak30Days) {
             unlocked.push(AchievementId::Streak30Days);
-        } else if streak >= 7 && !profile.has_achievement(&AchievementId::Streak7Days) {
+        }
+        if streak >= 7 && !profile.has_achievement(&AchievementId::Streak7Days) {
             unlocked.push(AchievementId::Streak7Days);
         }
     }
@@ -177,9 +211,11 @@ impl AchievementEngine {
 
         if perfect_count >= 100 && !profile.has_achievement(&AchievementId::Perfect100) {
             unlocked.push(AchievementId::Perfect100);
-        } else if perfect_count >= 10 && !profile.has_achievement(&AchievementId::Perfect10) {
+        }
+        if perfect_count >= 10 && !profile.has_achievement(&AchievementId::Perfect10) {
             unlocked.push(AchievementId::Perfect10);
-        } else if perfect_count >= 1 && !profile.has_achievement(&AchievementId::FirstPerfect) {
+        }
+        if perfect_count >= 1 && !profile.has_achievement(&AchievementId::FirstPerfect) {
             unlocked.push(AchievementId::FirstPerfect);
         }
 
@@ -197,9 +233,8 @@ impl AchievementEngine {
 
         if mastered_commands >= 10 && !profile.has_achievement(&AchievementId::MasterTenCommands) {
             unlocked.push(AchievementId::MasterTenCommands);
-        } else if mastered_commands >= 1
-            && !profile.has_achievement(&AchievementId::MasterOneCommand)
-        {
+        }
+        if mastered_commands >= 1 && !profile.has_achievement(&AchievementId::MasterOneCommand) {
             unlocked.push(AchievementId::MasterOneCommand);
         }
 
@@ -227,9 +262,11 @@ impl AchievementEngine {
 
         if completed >= 1000 && !profile.has_achievement(&AchievementId::Legend) {
             unlocked.push(AchievementId::Legend);
-        } else if completed >= 500 && !profile.has_achievement(&AchievementId::Veteran) {
+        }
+        if completed >= 500 && !profile.has_achievement(&AchievementId::Veteran) {
             unlocked.push(AchievementId::Veteran);
-        } else if completed >= 100 && !profile.has_achievement(&AchievementId::Centurion) {
+        }
+        if completed >= 100 && !profile.has_achievement(&AchievementId::Centurion) {
             unlocked.push(AchievementId::Centurion);
         }
     }
@@ -367,6 +404,23 @@ mod tests {
         assert!(unlocked.contains(&AchievementId::Legend));
     }
 
+    /// Regression test: retroactively checking an existing profile (e.g. on load) must
+    /// unlock every satisfied tier at once, not just the highest one. Previously an
+    /// `else if` cascade meant a profile with `scenarios_completed = 600` unlocked only
+    /// `Veteran` (>= 500) and could never also unlock `Centurion` (>= 100).
+    #[test]
+    fn test_milestone_achievements_unlock_all_satisfied_tiers_at_once() {
+        let tracker = PerformanceTracker::new();
+        let mut profile = UserProfile::new();
+        profile.scenarios_completed = 600;
+
+        let unlocked = AchievementEngine::check_achievements(&profile, &tracker);
+
+        assert!(unlocked.contains(&AchievementId::Centurion));
+        assert!(unlocked.contains(&AchievementId::Veteran));
+        assert!(!unlocked.contains(&AchievementId::Legend));
+    }
+
     #[test]
     fn test_exploration_jack_of_all_trades() {
         let mut tracker = PerformanceTracker::new();
@@ -385,6 +439,22 @@ mod tests {
 
         let unlocked = AchievementEngine::check_achievements(&profile, &tracker);
         assert!(unlocked.contains(&AchievementId::JackOfAllTrades));
+    }
+
+    #[test]
+    fn test_check_and_unlock_marks_profile_and_returns_ids() {
+        let tracker = PerformanceTracker::new();
+        let mut profile = UserProfile::new();
+        profile.perfect_scenarios = 1;
+
+        let unlocked = AchievementEngine::check_and_unlock(&mut profile, &tracker);
+
+        assert_eq!(unlocked, vec![AchievementId::FirstPerfect]);
+        assert!(profile.has_achievement(&AchievementId::FirstPerfect));
+
+        // Calling again should not re-unlock the same achievement
+        let unlocked_again = AchievementEngine::check_and_unlock(&mut profile, &tracker);
+        assert!(unlocked_again.is_empty());
     }
 
     #[test]

--- a/src/gamification/streak.rs
+++ b/src/gamification/streak.rs
@@ -5,8 +5,7 @@ use chrono::{DateTime, Utc};
 use super::{GamificationError, Result, UserProfile};
 use crate::constants::{
     MILESTONE_7_DAY_XP, MILESTONE_30_DAY_XP, MILESTONE_90_DAY_XP, MILESTONE_365_DAY_XP,
-    QUESTS_FOR_STREAK_FREEZE, STREAK_MILESTONE_MONTH, STREAK_MILESTONE_QUARTER,
-    STREAK_MILESTONE_WEEK, STREAK_MILESTONE_YEAR,
+    STREAK_MILESTONE_MONTH, STREAK_MILESTONE_QUARTER, STREAK_MILESTONE_WEEK, STREAK_MILESTONE_YEAR,
 };
 
 /// Streak change event
@@ -108,17 +107,20 @@ impl StreakManager {
         Ok(())
     }
 
-    /// Grant streak freeze (earned by completing 5 quests in a day)
+    /// Grant streak freeze (earned by completing all of today's daily quests)
     pub fn grant_freeze(profile: &mut UserProfile) {
         profile.streak_freeze_available = true;
     }
 
     /// Check if user should be granted a freeze
     ///
-    /// Grants freeze once per week if enough quests completed in a day
+    /// Eligible once every quest generated for today has been completed, and no
+    /// freeze is currently held. A profile with no quests generated yet is never
+    /// eligible.
     pub fn check_freeze_eligibility(profile: &UserProfile) -> bool {
         !profile.streak_freeze_available
-            && profile.completed_quests_today.len() >= QUESTS_FOR_STREAK_FREEZE as usize
+            && !profile.daily_quests.is_empty()
+            && profile.completed_quests_today.len() >= profile.daily_quests.len()
     }
 
     /// Calculate days between two dates
@@ -249,20 +251,38 @@ mod tests {
 
     #[test]
     fn test_freeze_eligibility() {
+        use crate::gamification::{Quest, QuestDifficulty, QuestType};
+
         let mut profile = UserProfile::new();
 
-        // Not eligible - no quests
+        // Not eligible - no quests generated for today
         assert!(!StreakManager::check_freeze_eligibility(&profile));
 
-        // Not eligible - already has freeze
+        for i in 0..3 {
+            profile.daily_quests.push(Quest::new(
+                format!("quest_{}", i),
+                QuestType::CommandPractice {
+                    command: "x".to_string(),
+                    target: 1,
+                    current: 0,
+                },
+                format!("Quest {}", i),
+                QuestDifficulty::Easy,
+            ));
+        }
+
+        // Not eligible - quests generated but none completed yet
+        assert!(!StreakManager::check_freeze_eligibility(&profile));
+
+        // Not eligible - already has freeze, even if all quests are completed
         profile.streak_freeze_available = true;
-        assert!(!StreakManager::check_freeze_eligibility(&profile));
-
-        // Eligible - 5 quests completed, no freeze
-        profile.streak_freeze_available = false;
-        for i in 0..5 {
+        for i in 0..3 {
             profile.complete_quest(format!("quest_{}", i));
         }
+        assert!(!StreakManager::check_freeze_eligibility(&profile));
+
+        // Eligible - all of today's quests completed, no freeze held
+        profile.streak_freeze_available = false;
         assert!(StreakManager::check_freeze_eligibility(&profile));
     }
 

--- a/src/ui/notification.rs
+++ b/src/ui/notification.rs
@@ -26,6 +26,9 @@ pub enum NotificationType {
     /// Streak milestone reached
     StreakMilestone { streak: u32 },
 
+    /// Streak freeze earned (protects the streak if a day is missed)
+    StreakFreezeGranted,
+
     /// Informational message
     Info { message: String },
 
@@ -122,6 +125,7 @@ impl Notification {
             NotificationType::Achievement { name, .. } => format!("Achievement Unlocked: {}", name),
             NotificationType::QuestComplete { .. } => "Quest Complete!".to_string(),
             NotificationType::StreakMilestone { streak } => format!("{} Day Streak!", streak),
+            NotificationType::StreakFreezeGranted => "Streak Freeze Earned!".to_string(),
             NotificationType::Info { .. } => "Info".to_string(),
             NotificationType::ReviewSessionComplete { .. } => "Review Complete!".to_string(),
             NotificationType::MasteryLevelUp { command, .. } => {
@@ -145,6 +149,9 @@ impl Notification {
             }
             NotificationType::StreakMilestone { streak } => {
                 format!("Keep it up! {} days in a row", streak)
+            }
+            NotificationType::StreakFreezeGranted => {
+                "Miss a day without breaking your streak".to_string()
             }
             NotificationType::Info { message } => message.clone(),
             NotificationType::ReviewSessionComplete {
@@ -171,6 +178,7 @@ impl Notification {
             NotificationType::Achievement { .. } => Color::Magenta,
             NotificationType::QuestComplete { .. } => Color::Green,
             NotificationType::StreakMilestone { .. } => Color::Cyan,
+            NotificationType::StreakFreezeGranted => Color::Cyan,
             NotificationType::Info { .. } => Color::Blue,
             NotificationType::ReviewSessionComplete { .. } => Color::Green,
             NotificationType::MasteryLevelUp { .. } => Color::Yellow,
@@ -376,6 +384,13 @@ mod tests {
         assert_eq!(info.title(), "Info");
         assert_eq!(info.message(), "Test info message");
 
+        let freeze_granted = Notification::new(NotificationType::StreakFreezeGranted);
+        assert_eq!(freeze_granted.title(), "Streak Freeze Earned!");
+        assert_eq!(
+            freeze_granted.message(),
+            "Miss a day without breaking your streak"
+        );
+
         let review_complete = Notification::new(NotificationType::ReviewSessionComplete {
             completed: 5,
             success_count: 4,
@@ -413,6 +428,9 @@ mod tests {
 
         let streak = Notification::new(NotificationType::StreakMilestone { streak: 5 });
         assert_eq!(streak.color(), Color::Cyan);
+
+        let freeze_granted = Notification::new(NotificationType::StreakFreezeGranted);
+        assert_eq!(freeze_granted.color(), Color::Cyan);
 
         let info = Notification::new(NotificationType::Info {
             message: "Test".to_string(),

--- a/src/ui/state/handlers/quests.rs
+++ b/src/ui/state/handlers/quests.rs
@@ -2,8 +2,9 @@
 //!
 //! Handles quest progress updates and tracking
 
-use crate::gamification::{QuestTracker, QuestType};
+use crate::gamification::{QuestTracker, QuestType, StreakManager};
 use crate::security::UserError;
+use crate::ui::notification::{Notification, NotificationType};
 use crate::ui::state::{AppState, QuestProgressChange};
 use std::collections::HashMap;
 use std::time::Duration;
@@ -39,9 +40,11 @@ pub fn track_scenario_completion_for_quests(
 
 /// Check and award XP for newly completed quests
 ///
-/// Returns total XP awarded for quest completions.
+/// Marks each newly completed quest on the profile's `completed_quests_today` set (which
+/// gates next-day streak increments), grants a streak freeze once every quest generated
+/// for today is completed, and returns total XP awarded for quest completions.
 pub fn award_quest_completion_xp(state: &mut AppState, was_completed: &[bool]) -> u64 {
-    let newly_completed: Vec<(String, u32)> = {
+    let newly_completed: Vec<(String, String, u32)> = {
         let profile = &state.progress.profile;
         profile
             .daily_quests
@@ -49,7 +52,7 @@ pub fn award_quest_completion_xp(state: &mut AppState, was_completed: &[bool]) -
             .enumerate()
             .filter_map(|(idx, quest)| {
                 if idx < was_completed.len() && !was_completed[idx] && quest.completed {
-                    Some((quest.description.clone(), quest.xp_reward))
+                    Some((quest.id.clone(), quest.description.clone(), quest.xp_reward))
                 } else {
                     None
                 }
@@ -57,26 +60,38 @@ pub fn award_quest_completion_xp(state: &mut AppState, was_completed: &[bool]) -
             .collect()
     };
 
-    if !newly_completed.is_empty() {
-        let total_bonus_xp: u64 = newly_completed.iter().map(|(_, xp)| *xp as u64).sum();
-        let profile = &mut state.progress.profile;
-        profile.add_xp(total_bonus_xp);
-
-        // Show notifications for each completed quest
-        for (description, xp_reward) in newly_completed {
-            let notification = crate::ui::notification::Notification::new(
-                crate::ui::notification::NotificationType::QuestComplete {
-                    description,
-                    xp_reward,
-                },
-            );
-            state.ui.notifications.push(notification);
-        }
-
-        total_bonus_xp
-    } else {
-        0
+    if newly_completed.is_empty() {
+        return 0;
     }
+
+    let total_bonus_xp: u64 = newly_completed.iter().map(|(_, _, xp)| *xp as u64).sum();
+    let profile = &mut state.progress.profile;
+    profile.add_xp(total_bonus_xp);
+    for (quest_id, _, _) in &newly_completed {
+        profile.complete_quest(quest_id.clone());
+    }
+
+    // Show notifications for each completed quest
+    for (_, description, xp_reward) in newly_completed {
+        state
+            .ui
+            .notifications
+            .push(Notification::new(NotificationType::QuestComplete {
+                description,
+                xp_reward,
+            }));
+    }
+
+    // Grant a streak freeze once every quest generated for today is completed
+    if StreakManager::check_freeze_eligibility(&state.progress.profile) {
+        StreakManager::grant_freeze(&mut state.progress.profile);
+        state
+            .ui
+            .notifications
+            .push(Notification::new(NotificationType::StreakFreezeGranted));
+    }
+
+    total_bonus_xp
 }
 
 /// Snapshot quest completion status before updates

--- a/src/ui/state/handlers/scenario.rs
+++ b/src/ui/state/handlers/scenario.rs
@@ -4,6 +4,7 @@
 
 use crate::game::GameSession;
 use crate::game::services::ScenarioCompletionService;
+use crate::gamification::{Achievement, AchievementEngine};
 use crate::security::UserError;
 use crate::ui::notification::{Notification, NotificationType};
 use crate::ui::state::{
@@ -123,6 +124,29 @@ fn record_scenario_completion(
                 command,
                 new_level,
             }));
+    }
+
+    // Check and unlock any achievements newly satisfied by this completion
+    // (perfect/scenario counters and command mastery all just changed above)
+    let newly_unlocked = AchievementEngine::check_and_unlock(
+        &mut ctx.progress.profile,
+        &ctx.progress.performance_tracker,
+    );
+    if !newly_unlocked.is_empty() {
+        for achievement_id in newly_unlocked {
+            let achievement = Achievement::new(achievement_id);
+            ctx.ui
+                .notifications
+                .push(Notification::new(NotificationType::Achievement {
+                    name: achievement.name,
+                    description: achievement.description,
+                }));
+        }
+        ctx.progress
+            .storage
+            .save(&ctx.progress.profile)
+            .map_err(UserError::from)?;
+        ctx.progress.mark_saved();
     }
 
     Ok(())
@@ -712,6 +736,52 @@ mod tests {
 
         assert!(state.progress.profile.total_xp > initial_xp);
         assert_eq!(state.progress.scenarios_completed_today, 1);
+    }
+
+    /// Regression test for #256: achievements must unlock through the live scenario
+    /// completion path (`handle_complete_scenario`), not just via direct
+    /// `AchievementEngine::check_achievements` calls.
+    #[test]
+    fn test_handle_complete_scenario_unlocks_achievement() {
+        use crate::game::SessionAfterAction;
+        use crate::gamification::AchievementId;
+
+        let mut state = create_test_state();
+        // One completion away from the Centurion milestone (100 scenarios completed),
+        // regardless of this scenario's score.
+        state.progress.profile.scenarios_completed = 99;
+
+        let scenario = create_test_scenario();
+        let session = GameSession::new(scenario).unwrap();
+
+        let result = session.record_action("x".to_string()).unwrap();
+        let session = match result {
+            SessionAfterAction::StillActive(s) => s,
+            SessionAfterAction::Completed(_) => panic!("Should not complete after just 'x'"),
+        };
+        let result = session.record_action("d".to_string()).unwrap();
+        let completed = match result {
+            SessionAfterAction::Completed(c) => c,
+            SessionAfterAction::StillActive(_) => panic!("Should complete after 'x' + 'd'"),
+        };
+
+        let feedback = completed.feedback().unwrap();
+        state.ui.last_feedback = Some(feedback);
+        state.game.pending_completed_session = Some(completed);
+
+        handle_complete_scenario(&mut state).unwrap();
+
+        assert!(
+            state
+                .progress
+                .profile
+                .has_achievement(&AchievementId::Centurion)
+        );
+        assert!(state.ui.notifications.visible().iter().any(|n| matches!(
+            n.notification_type,
+            crate::ui::notification::NotificationType::Achievement { ref name, .. }
+                if name == "Centurion"
+        )));
     }
 
     #[test]

--- a/src/ui/state/tests/quest_tests.rs
+++ b/src/ui/state/tests/quest_tests.rs
@@ -4,7 +4,8 @@ use std::collections::HashSet;
 use std::time::Duration;
 
 use super::common::{create_test_app_state, create_test_scenario};
-use crate::gamification::{Quest, QuestDifficulty, QuestType};
+use crate::gamification::{Quest, QuestDifficulty, QuestType, StreakManager};
+use crate::ui::notification::NotificationType;
 use crate::ui::state::{Message, update};
 
 #[test]
@@ -342,4 +343,184 @@ fn test_quest_progress_changes_tracking() {
     assert_eq!(change.old_progress, 0);
     assert_eq!(change.new_progress, 1);
     assert!(change.quest_description.contains("x"));
+}
+
+/// Regression test for #267: completing a quest through the live message-passing
+/// flow must populate `completed_quests_today`, since `StreakManager::update_streak`
+/// gates next-day streak increments on that set being non-empty.
+#[test]
+fn test_quest_completion_populates_completed_quests_today() {
+    let scenario = create_test_scenario();
+    let mut state = create_test_app_state(vec![scenario]);
+
+    {
+        let profile = &mut state.progress.profile;
+        profile.daily_quests.push(Quest::new(
+            "test_quest".to_string(),
+            QuestType::CommandPractice {
+                command: "x".to_string(),
+                target: 1,
+                current: 0,
+            },
+            "Delete 1 character".to_string(),
+            QuestDifficulty::Easy,
+        ));
+    }
+
+    assert!(state.progress.profile.completed_quests_today.is_empty());
+
+    update(
+        &mut state,
+        Message::UpdateQuestProgress {
+            command: Some("x".to_string()),
+            scenario_completed: false,
+            scenario_id: None,
+            duration: Duration::from_secs(0),
+        },
+    )
+    .unwrap();
+
+    assert!(
+        state
+            .progress
+            .profile
+            .completed_quests_today
+            .contains("test_quest")
+    );
+}
+
+/// Regression test for #267: the streak can now increment on the next session because
+/// `completed_quests_today` was populated by a live quest completion the day before.
+#[test]
+fn test_streak_increments_next_day_after_live_quest_completion() {
+    let scenario = create_test_scenario();
+    let mut state = create_test_app_state(vec![scenario]);
+    state.progress.profile.current_streak = 3;
+
+    {
+        let profile = &mut state.progress.profile;
+        profile.daily_quests.push(Quest::new(
+            "test_quest".to_string(),
+            QuestType::CommandPractice {
+                command: "x".to_string(),
+                target: 1,
+                current: 0,
+            },
+            "Delete 1 character".to_string(),
+            QuestDifficulty::Easy,
+        ));
+    }
+
+    update(
+        &mut state,
+        Message::UpdateQuestProgress {
+            command: Some("x".to_string()),
+            scenario_completed: false,
+            scenario_id: None,
+            duration: Duration::from_secs(0),
+        },
+    )
+    .unwrap();
+
+    // Simulate that this activity happened yesterday, as `StreakManager` would see it
+    // at the start of the next session.
+    state.progress.profile.last_activity = chrono::Utc::now() - chrono::Duration::days(1);
+
+    let change = StreakManager::update_streak(&mut state.progress.profile);
+
+    assert_eq!(
+        change,
+        crate::gamification::StreakChange::Incremented { new_streak: 4 }
+    );
+    assert_eq!(state.progress.profile.current_streak, 4);
+}
+
+/// Regression test for #257: completing *all* of today's daily quests through the live
+/// flow grants a streak freeze. Eligibility is based on completing every quest generated
+/// for the day, not a fixed count — the quest generator produces at most 4 quests/day, so
+/// the old fixed threshold of 5 was unreachable in production.
+#[test]
+fn test_streak_freeze_granted_after_all_daily_quests_completed_live() {
+    let scenario = create_test_scenario();
+    let mut state = create_test_app_state(vec![scenario]);
+
+    let quest_ids = ["quest_0", "quest_1", "quest_2"];
+    for id in quest_ids {
+        state.progress.profile.daily_quests.push(Quest::new(
+            id.to_string(),
+            QuestType::CommandPractice {
+                command: id.to_string(),
+                target: 1,
+                current: 0,
+            },
+            format!("Use {}", id),
+            QuestDifficulty::Easy,
+        ));
+    }
+
+    for (i, id) in quest_ids.iter().enumerate() {
+        update(
+            &mut state,
+            Message::UpdateQuestProgress {
+                command: Some(id.to_string()),
+                scenario_completed: false,
+                scenario_id: None,
+                duration: Duration::from_secs(0),
+            },
+        )
+        .unwrap();
+
+        // Freeze must not be granted until every daily quest is completed
+        let is_last = i == quest_ids.len() - 1;
+        assert_eq!(state.progress.profile.streak_freeze_available, is_last);
+    }
+
+    assert!(
+        state
+            .ui
+            .notifications
+            .visible()
+            .iter()
+            .any(|n| n.notification_type == NotificationType::StreakFreezeGranted)
+    );
+}
+
+/// A freeze already held must not be granted (or notified) again, even if the
+/// "all daily quests completed" condition is met again.
+#[test]
+fn test_streak_freeze_not_granted_twice() {
+    let scenario = create_test_scenario();
+    let mut state = create_test_app_state(vec![scenario]);
+    state.progress.profile.streak_freeze_available = true;
+    state.progress.profile.daily_quests.push(Quest::new(
+        "quest_0".to_string(),
+        QuestType::CommandPractice {
+            command: "x".to_string(),
+            target: 1,
+            current: 0,
+        },
+        "Use x".to_string(),
+        QuestDifficulty::Easy,
+    ));
+
+    update(
+        &mut state,
+        Message::UpdateQuestProgress {
+            command: Some("x".to_string()),
+            scenario_completed: false,
+            scenario_id: None,
+            duration: Duration::from_secs(0),
+        },
+    )
+    .unwrap();
+
+    assert!(state.progress.profile.streak_freeze_available);
+    assert!(
+        !state
+            .ui
+            .notifications
+            .visible()
+            .iter()
+            .any(|n| n.notification_type == NotificationType::StreakFreezeGranted)
+    );
 }

--- a/tests/gamification.rs
+++ b/tests/gamification.rs
@@ -379,15 +379,29 @@ fn test_scenario_xp_calculation() {
 fn test_freeze_eligibility() {
     let mut profile = UserProfile::new();
 
-    // Not eligible initially
+    // Not eligible initially - no quests generated for today
     assert!(!StreakManager::check_freeze_eligibility(&profile));
 
-    // Complete 5 quests
-    for i in 0..5 {
+    // Generate today's quests
+    for i in 0..3 {
+        profile.daily_quests.push(Quest::new(
+            format!("quest_{}", i),
+            QuestType::CommandPractice {
+                command: "x".to_string(),
+                target: 1,
+                current: 0,
+            },
+            format!("Quest {}", i),
+            QuestDifficulty::Easy,
+        ));
+    }
+
+    // Complete all of today's quests
+    for i in 0..3 {
         profile.complete_quest(format!("quest_{}", i));
     }
 
-    // Now eligible
+    // Now eligible - all of today's quests completed
     assert!(StreakManager::check_freeze_eligibility(&profile));
 
     // Grant freeze


### PR DESCRIPTION
## Summary

`completed_quests_today`, streak-freeze eligibility, and achievement unlocks were fully implemented and unit-tested but never invoked from the live scenario-completion path, so daily streaks could never increment, freezes could never be earned, and achievements never unlocked for real players.

- Quest completion now calls `UserProfile::complete_quest` so `StreakManager::update_streak` can increment `current_streak` on the following day's session (still evaluated once per app launch, at profile load)
- Streak-freeze eligibility is now based on completing every quest generated for the day instead of a fixed count of 5, which the quest generator can never reach (max 4/day) and was therefore unreachable; grants surface via a new `StreakFreezeGranted` notification
- Scenario completion and profile load now run `AchievementEngine::check_achievements` and unlock newly satisfied achievements, including every tier a profile already qualifies for (fixed an `else if` cascade that would only ever unlock the highest matching tier) rather than only the highest one

## Out of scope (follow-up issues to be filed)

- 4 of 17 achievements (SpeedDemon, Speedrunner, Flash, Polyglot) have no evaluation arm in `check_achievements` at all — pre-existing gap, not introduced by this change
- Arcade/minigame completion path never calls `check_and_unlock`
- No achievement UI/locale strings, silent freeze consumption at day-boundary, and a pre-existing double-XP path in `award_quest_completion_xp`/`collect_quest_bonuses`

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (1814/1814 passed)
- [x] `cargo test --doc`
- [x] New live-flow regression tests: quest completion populates `completed_quests_today`; streak increments the following session; freeze granted only once all daily quests are completed and not double-granted; achievement unlocks through `handle_complete_scenario` and through `ProfileReady` (retroactive multi-tier unlock)

Fixes #267
Fixes #257
Fixes #256