### PR TITLE
refactor(config): unify Setup/TargetState cursor spec and quest type/params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `Setup` and `TargetState` now share their cursor/selection fields and logic through a single `CursorSpec` type (`#[serde(flatten)]`) instead of duplicating both; scenario TOML files are unaffected (#268)
+- Quest templates now use a single adjacently-tagged `QuestSpec` enum instead of a separate `type` discriminator and untagged `params` enum, making a `type`/`params` mismatch a deserialization error instead of a runtime-only check; quest TOML files are unaffected (#274)
+
 ### Fixed
 
 - CI now runs the full `cargo nextest` test surface (`--workspace --all-features --lib --bins --tests`) instead of `--lib` only, so integration tests under `tests/` (e.g. `tests/scenario_validation.rs`, which verifies every scenario's documented solution actually completes it) are no longer silently skipped in CI (#288)

--- a/benches/filtering_sorting.rs
+++ b/benches/filtering_sorting.rs
@@ -7,8 +7,8 @@
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use helix_trainer::config::{
-    Difficulty, Scenario, ScenarioCategory, ScenarioCollection, ScenarioFilter, ScenarioMetadata,
-    ScoringConfig, Setup, Solution, SortMode, TargetState,
+    CursorSpec, Difficulty, Scenario, ScenarioCategory, ScenarioCollection, ScenarioFilter,
+    ScenarioMetadata, ScoringConfig, Setup, Solution, SortMode, TargetState,
 };
 use helix_trainer::gamification::UserProfile;
 use std::collections::HashSet;
@@ -27,17 +27,21 @@ fn create_scenario(
         description: "Test scenario".to_string(),
         setup: Setup {
             file_content: "line 1\nline 2\nline 3\n".to_string(),
-            cursor_position: Some((0, 0)),
-            selection: None,
-            cursors: None,
-            selections: None,
+            cursor: CursorSpec {
+                cursor_position: Some((0, 0)),
+                selection: None,
+                cursors: None,
+                selections: None,
+            },
         },
         target: TargetState {
             file_content: "line 2\nline 3\n".to_string(),
-            cursor_position: Some((0, 0)),
-            selection: None,
-            cursors: None,
-            selections: None,
+            cursor: CursorSpec {
+                cursor_position: Some((0, 0)),
+                selection: None,
+                cursors: None,
+                selections: None,
+            },
         },
         solution: Solution {
             commands: vec!["x".to_string()],

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -11,11 +11,11 @@ pub mod scenarios;
 
 pub use app_config::{AppConfig, ConfigStorage};
 pub use quests::{
-    QuestConditions, QuestDifficulty, QuestLoader, QuestParams, QuestTemplate, QuestTypeTag,
-    QuestsFile, QuestsMetadata, XpConfig,
+    QuestConditions, QuestDifficulty, QuestLoader, QuestSpec, QuestTemplate, QuestsFile,
+    QuestsMetadata, XpConfig,
 };
 pub use scenario_collection::{ScenarioCollection, ScenarioFilter, SortMode};
 pub use scenarios::{
-    AlternativeSolution, Difficulty, Scenario, ScenarioCategory, ScenarioLoader, ScenarioMetadata,
-    ScenariosFile, ScoringConfig, Setup, Solution, TargetState,
+    AlternativeSolution, CursorSpec, Difficulty, Scenario, ScenarioCategory, ScenarioLoader,
+    ScenarioMetadata, ScenariosFile, ScoringConfig, Setup, Solution, TargetState,
 };

--- a/src/config/quests/mod.rs
+++ b/src/config/quests/mod.rs
@@ -38,27 +38,16 @@ pub struct QuestTemplate {
     pub name: String,
     pub description: String,
 
-    #[serde(rename = "type")]
-    pub quest_type: QuestTypeTag,
     pub difficulty: QuestDifficulty,
-    pub params: QuestParams,
+
+    #[serde(flatten)]
+    pub spec: QuestSpec,
 
     #[serde(default)]
     pub xp: Option<XpConfig>,
 
     #[serde(default)]
     pub conditions: QuestConditions,
-}
-
-/// Quest type discriminator (for TOML deserialization)
-#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum QuestTypeTag {
-    CommandPractice,
-    ScenarioCompletion,
-    SpeedRun,
-    TimeInvested,
-    Exploration,
 }
 
 /// Quest difficulty (matches existing enum)
@@ -70,10 +59,15 @@ pub enum QuestDifficulty {
     Hard,
 }
 
-/// Quest-specific parameters (untagged enum for flexible deserialization)
+/// Quest type and its type-specific parameters
+///
+/// Adjacently tagged by the TOML `type` field, with the variant's fields read
+/// from the nested `params` table (`#[serde(tag = "type", content = "params")]`).
+/// This makes a `type`/`params` shape mismatch a deserialization error instead
+/// of a runtime validation concern.
 #[derive(Deserialize, Debug, Clone)]
-#[serde(untagged)]
-pub enum QuestParams {
+#[serde(tag = "type", content = "params", rename_all = "snake_case")]
+pub enum QuestSpec {
     CommandPractice {
         command: String,
         target: u32,
@@ -339,16 +333,16 @@ impl QuestLoader {
             ));
         }
 
-        // Validate that params match quest type
-        self.validate_params_match_type(quest)?;
+        // Validate spec parameter bounds
+        self.validate_spec(quest)?;
 
         Ok(())
     }
 
-    /// Validate that quest parameters match the quest type
-    fn validate_params_match_type(&self, quest: &QuestTemplate) -> Result<(), SecurityError> {
-        match (&quest.quest_type, &quest.params) {
-            (QuestTypeTag::CommandPractice, QuestParams::CommandPractice { command, target }) => {
+    /// Validate quest spec parameters are within bounds
+    fn validate_spec(&self, quest: &QuestTemplate) -> Result<(), SecurityError> {
+        match &quest.spec {
+            QuestSpec::CommandPractice { command, target } => {
                 if command.is_empty() || command.len() > 10 {
                     return Err(SecurityError::InvalidInput("Invalid command name".into()));
                 }
@@ -358,20 +352,17 @@ impl QuestLoader {
                     ));
                 }
             }
-            (QuestTypeTag::ScenarioCompletion, QuestParams::ScenarioCompletion { target }) => {
+            QuestSpec::ScenarioCompletion { target } => {
                 if *target == 0 || *target > MAX_QUEST_TARGET {
                     return Err(SecurityError::InvalidInput(
                         "Invalid scenario completion target".into(),
                     ));
                 }
             }
-            (
-                QuestTypeTag::SpeedRun,
-                QuestParams::SpeedRun {
-                    scenario_id,
-                    time_limit_seconds,
-                },
-            ) => {
+            QuestSpec::SpeedRun {
+                scenario_id,
+                time_limit_seconds,
+            } => {
                 if scenario_id.is_empty() || scenario_id.len() > 64 {
                     return Err(SecurityError::InvalidInput("Invalid scenario ID".into()));
                 }
@@ -381,24 +372,19 @@ impl QuestLoader {
                     ));
                 }
             }
-            (QuestTypeTag::TimeInvested, QuestParams::TimeInvested { target_minutes }) => {
+            QuestSpec::TimeInvested { target_minutes } => {
                 if *target_minutes == 0 || *target_minutes > MAX_QUEST_TARGET {
                     return Err(SecurityError::InvalidInput(
                         "Invalid time invested target".into(),
                     ));
                 }
             }
-            (QuestTypeTag::Exploration, QuestParams::Exploration { target_commands }) => {
+            QuestSpec::Exploration { target_commands } => {
                 if *target_commands == 0 || *target_commands > MAX_QUEST_TARGET {
                     return Err(SecurityError::InvalidInput(
                         "Invalid exploration target".into(),
                     ));
                 }
-            }
-            _ => {
-                return Err(SecurityError::InvalidInput(
-                    "Quest type does not match parameters".into(),
-                ));
             }
         }
 
@@ -423,7 +409,7 @@ impl QuestTemplate {
     pub fn to_quest(&self) -> crate::gamification::Quest {
         use crate::gamification::Quest;
 
-        let quest_type = self.params_to_quest_type();
+        let quest_type = self.spec_to_quest_type();
         let difficulty = self.difficulty_to_runtime();
 
         Quest::new(
@@ -434,32 +420,32 @@ impl QuestTemplate {
         )
     }
 
-    /// Convert template parameters to runtime QuestType
-    fn params_to_quest_type(&self) -> crate::gamification::QuestType {
+    /// Convert template spec to runtime QuestType
+    fn spec_to_quest_type(&self) -> crate::gamification::QuestType {
         use crate::gamification::QuestType;
 
-        match &self.params {
-            QuestParams::CommandPractice { command, target } => QuestType::CommandPractice {
+        match &self.spec {
+            QuestSpec::CommandPractice { command, target } => QuestType::CommandPractice {
                 command: command.clone(),
                 target: *target,
                 current: 0,
             },
-            QuestParams::ScenarioCompletion { target } => QuestType::ScenarioCompletion {
+            QuestSpec::ScenarioCompletion { target } => QuestType::ScenarioCompletion {
                 target: *target,
                 current: 0,
             },
-            QuestParams::SpeedRun {
+            QuestSpec::SpeedRun {
                 scenario_id,
                 time_limit_seconds,
             } => QuestType::SpeedRun {
                 scenario_id: scenario_id.clone(),
                 time_limit: std::time::Duration::from_secs(*time_limit_seconds),
             },
-            QuestParams::TimeInvested { target_minutes } => QuestType::TimeInvested {
+            QuestSpec::TimeInvested { target_minutes } => QuestType::TimeInvested {
                 target_minutes: *target_minutes,
                 current_minutes: 0,
             },
-            QuestParams::Exploration { target_commands } => QuestType::Exploration {
+            QuestSpec::Exploration { target_commands } => QuestType::Exploration {
                 target_commands: *target_commands,
                 commands_used: HashSet::new(),
             },

--- a/src/config/quests/tests.rs
+++ b/src/config/quests/tests.rs
@@ -65,20 +65,24 @@ fn test_validate_id_field_invalid_characters() {
 }
 
 #[test]
-fn test_quest_type_tag_deserialization() {
-    #[derive(Deserialize)]
-    struct Test {
-        #[serde(rename = "type")]
-        quest_type: QuestTypeTag,
-    }
+fn test_quest_spec_type_tag_deserialization() {
+    let valid = r#"
+type = "command_practice"
+[params]
+command = "x"
+target = 3
+"#;
+    let result: QuestSpec = toml::from_str(valid).unwrap();
+    assert!(matches!(result, QuestSpec::CommandPractice { .. }));
 
-    let valid = r#"type = "command_practice""#;
-    let result: Test = toml::from_str(valid).unwrap();
-    assert_eq!(result.quest_type, QuestTypeTag::CommandPractice);
-
-    let valid = r#"type = "speed_run""#;
-    let result: Test = toml::from_str(valid).unwrap();
-    assert_eq!(result.quest_type, QuestTypeTag::SpeedRun);
+    let valid = r#"
+type = "speed_run"
+[params]
+scenario_id = "delete_line_001"
+time_limit_seconds = 5
+"#;
+    let result: QuestSpec = toml::from_str(valid).unwrap();
+    assert!(matches!(result, QuestSpec::SpeedRun { .. }));
 }
 
 #[test]
@@ -102,52 +106,75 @@ fn test_quest_difficulty_deserialization() {
 }
 
 #[test]
-fn test_quest_params_command_practice() {
+fn test_quest_spec_command_practice() {
     let toml_str = r#"
+type = "command_practice"
+[params]
 command = "x"
 target = 3
 "#;
-    let params: QuestParams = toml::from_str(toml_str).unwrap();
-    match params {
-        QuestParams::CommandPractice { command, target } => {
+    let spec: QuestSpec = toml::from_str(toml_str).unwrap();
+    match spec {
+        QuestSpec::CommandPractice { command, target } => {
             assert_eq!(command, "x");
             assert_eq!(target, 3);
         }
-        _ => panic!("Wrong variant"),
+        other => panic!("Wrong variant: {:?}", other),
     }
 }
 
 #[test]
-fn test_quest_params_scenario_completion() {
+fn test_quest_spec_scenario_completion() {
     let toml_str = r#"
+type = "scenario_completion"
+[params]
 target = 5
 "#;
-    let params: QuestParams = toml::from_str(toml_str).unwrap();
-    match params {
-        QuestParams::ScenarioCompletion { target } => {
+    let spec: QuestSpec = toml::from_str(toml_str).unwrap();
+    match spec {
+        QuestSpec::ScenarioCompletion { target } => {
             assert_eq!(target, 5);
         }
-        _ => panic!("Wrong variant"),
+        other => panic!("Wrong variant: {:?}", other),
     }
 }
 
 #[test]
-fn test_quest_params_speed_run() {
+fn test_quest_spec_speed_run() {
     let toml_str = r#"
+type = "speed_run"
+[params]
 scenario_id = "delete_line_001"
 time_limit_seconds = 5
 "#;
-    let params: QuestParams = toml::from_str(toml_str).unwrap();
-    match params {
-        QuestParams::SpeedRun {
+    let spec: QuestSpec = toml::from_str(toml_str).unwrap();
+    match spec {
+        QuestSpec::SpeedRun {
             scenario_id,
             time_limit_seconds,
         } => {
             assert_eq!(scenario_id, "delete_line_001");
             assert_eq!(time_limit_seconds, 5);
         }
-        _ => panic!("Wrong variant"),
+        other => panic!("Wrong variant: {:?}", other),
     }
+}
+
+#[test]
+fn test_quest_spec_type_params_mismatch_is_deserialization_error() {
+    // `type` says speed_run but `params` is shaped like command_practice: this
+    // must fail to deserialize rather than silently picking a mismatched variant.
+    let toml_str = r#"
+type = "speed_run"
+[params]
+command = "x"
+target = 3
+"#;
+    let result: Result<QuestSpec, _> = toml::from_str(toml_str);
+    assert!(
+        result.is_err(),
+        "type/params mismatch should be a deserialization error"
+    );
 }
 
 #[test]
@@ -224,9 +251,8 @@ fn test_quest_template_to_quest_conversion() {
         id: "test_quest".to_string(),
         name: "Test Quest".to_string(),
         description: "Delete 3 lines".to_string(),
-        quest_type: QuestTypeTag::CommandPractice,
         difficulty: QuestDifficulty::Easy,
-        params: QuestParams::CommandPractice {
+        spec: QuestSpec::CommandPractice {
             command: "x".to_string(),
             target: 3,
         },
@@ -257,30 +283,34 @@ fn test_validate_id_field_empty() {
 }
 
 #[test]
-fn test_quest_params_time_invested() {
+fn test_quest_spec_time_invested() {
     let toml_str = r#"
+type = "time_invested"
+[params]
 target_minutes = 10
 "#;
-    let params: QuestParams = toml::from_str(toml_str).unwrap();
-    match params {
-        QuestParams::TimeInvested { target_minutes } => {
+    let spec: QuestSpec = toml::from_str(toml_str).unwrap();
+    match spec {
+        QuestSpec::TimeInvested { target_minutes } => {
             assert_eq!(target_minutes, 10);
         }
-        _ => panic!("Wrong variant"),
+        other => panic!("Wrong variant: {:?}", other),
     }
 }
 
 #[test]
-fn test_quest_params_exploration() {
+fn test_quest_spec_exploration() {
     let toml_str = r#"
+type = "exploration"
+[params]
 target_commands = 15
 "#;
-    let params: QuestParams = toml::from_str(toml_str).unwrap();
-    match params {
-        QuestParams::Exploration { target_commands } => {
+    let spec: QuestSpec = toml::from_str(toml_str).unwrap();
+    match spec {
+        QuestSpec::Exploration { target_commands } => {
             assert_eq!(target_commands, 15);
         }
-        _ => panic!("Wrong variant"),
+        other => panic!("Wrong variant: {:?}", other),
     }
 }
 
@@ -468,9 +498,10 @@ fn test_validate_all_quest_templates() {
             template.id
         );
 
-        // 4. Validate quest type matches parameters
-        match (&template.quest_type, &template.params) {
-            (QuestTypeTag::CommandPractice, QuestParams::CommandPractice { command, target }) => {
+        // 4. Validate quest spec parameters (type/params mismatch is unrepresentable
+        //    at the type level, so no wildcard arm is needed here)
+        match &template.spec {
+            QuestSpec::CommandPractice { command, target } => {
                 assert!(!command.is_empty(), "Empty command for ID: {}", template.id);
                 assert!(
                     command.len() <= 10,
@@ -485,7 +516,7 @@ fn test_validate_all_quest_templates() {
                 );
                 commands_used.insert(command.clone());
             }
-            (QuestTypeTag::ScenarioCompletion, QuestParams::ScenarioCompletion { target }) => {
+            QuestSpec::ScenarioCompletion { target } => {
                 assert!(*target > 0, "Target must be > 0 for ID: {}", template.id);
                 assert!(
                     *target <= 100,
@@ -493,13 +524,10 @@ fn test_validate_all_quest_templates() {
                     template.id
                 );
             }
-            (
-                QuestTypeTag::SpeedRun,
-                QuestParams::SpeedRun {
-                    scenario_id,
-                    time_limit_seconds,
-                },
-            ) => {
+            QuestSpec::SpeedRun {
+                scenario_id,
+                time_limit_seconds,
+            } => {
                 assert!(
                     !scenario_id.is_empty(),
                     "Empty scenario_id for ID: {}",
@@ -522,7 +550,7 @@ fn test_validate_all_quest_templates() {
                 );
                 scenario_ids_used.insert(scenario_id.clone());
             }
-            (QuestTypeTag::TimeInvested, QuestParams::TimeInvested { target_minutes }) => {
+            QuestSpec::TimeInvested { target_minutes } => {
                 assert!(
                     *target_minutes > 0,
                     "Target minutes must be > 0 for ID: {}",
@@ -534,7 +562,7 @@ fn test_validate_all_quest_templates() {
                     template.id
                 );
             }
-            (QuestTypeTag::Exploration, QuestParams::Exploration { target_commands }) => {
+            QuestSpec::Exploration { target_commands } => {
                 assert!(
                     *target_commands > 0,
                     "Target commands must be > 0 for ID: {}",
@@ -546,10 +574,6 @@ fn test_validate_all_quest_templates() {
                     template.id
                 );
             }
-            _ => panic!(
-                "Quest type {:?} does not match params for ID: {}",
-                template.quest_type, template.id
-            ),
         }
 
         // 5. Validate custom XP reward if present
@@ -574,6 +598,17 @@ fn test_validate_all_quest_templates() {
             "Too many required scenarios (max 20) for ID: {}",
             template.id
         );
+
+        // Spot-check that `conditions` (a sibling of the flattened `spec` field)
+        // deserializes correctly and isn't swallowed by the adjacent tagging.
+        if template.id == "speed_delete_hard" {
+            assert_eq!(
+                template.conditions.requires_scenarios,
+                vec!["delete_line_001".to_string()],
+                "requires_scenarios did not survive deserialization for ID: {}",
+                template.id
+            );
+        }
 
         // Collect scenario IDs from conditions
         for scenario_id in &template.conditions.requires_scenarios {

--- a/src/config/scenario_collection/tests.rs
+++ b/src/config/scenario_collection/tests.rs
@@ -1,7 +1,7 @@
 //! Tests for ScenarioCollection
 
 use super::*;
-use crate::config::{ScenarioMetadata, ScoringConfig, Setup, Solution, TargetState};
+use crate::config::{CursorSpec, ScenarioMetadata, ScoringConfig, Setup, Solution, TargetState};
 
 /// Helper to create a test scenario with metadata
 fn create_scenario(
@@ -17,17 +17,21 @@ fn create_scenario(
         description: "Test scenario".to_string(),
         setup: Setup {
             file_content: "test".to_string(),
-            cursor_position: Some((0, 0)),
-            selection: None,
-            cursors: None,
-            selections: None,
+            cursor: CursorSpec {
+                cursor_position: Some((0, 0)),
+                selection: None,
+                cursors: None,
+                selections: None,
+            },
         },
         target: TargetState {
             file_content: "test".to_string(),
-            cursor_position: Some((0, 0)),
-            selection: None,
-            cursors: None,
-            selections: None,
+            cursor: CursorSpec {
+                cursor_position: Some((0, 0)),
+                selection: None,
+                cursors: None,
+                selections: None,
+            },
         },
         solution: Solution {
             commands: vec!["test".to_string()],
@@ -594,17 +598,21 @@ fn test_scenarios_without_metadata() {
         description: "Test".to_string(),
         setup: Setup {
             file_content: "test".to_string(),
-            cursor_position: Some((0, 0)),
-            selection: None,
-            cursors: None,
-            selections: None,
+            cursor: CursorSpec {
+                cursor_position: Some((0, 0)),
+                selection: None,
+                cursors: None,
+                selections: None,
+            },
         },
         target: TargetState {
             file_content: "test".to_string(),
-            cursor_position: Some((0, 0)),
-            selection: None,
-            cursors: None,
-            selections: None,
+            cursor: CursorSpec {
+                cursor_position: Some((0, 0)),
+                selection: None,
+                cursors: None,
+                selections: None,
+            },
         },
         solution: Solution {
             commands: vec!["test".to_string()],

--- a/src/config/scenarios.rs
+++ b/src/config/scenarios.rs
@@ -98,7 +98,7 @@ pub struct Scenario {
     pub metadata: Option<ScenarioMetadata>,
 }
 
-/// Initial editor setup
+/// Cursor and selection configuration shared by [`Setup`] and [`TargetState`]
 ///
 /// Supports two formats:
 /// - Single cursor: `cursor_position = [row, col]` with optional `selection`
@@ -107,9 +107,7 @@ pub struct Scenario {
 /// INVARIANT: at least one of cursor_position/cursors/selections must be set,
 /// checked by `ScenarioLoader::validate_setup_or_target_config`.
 #[derive(Deserialize, Debug, Clone)]
-pub struct Setup {
-    pub file_content: String,
-
+pub struct CursorSpec {
     /// Single cursor position [row, col] - for simple scenarios
     #[serde(default)]
     pub cursor_position: Option<(usize, usize)>,
@@ -127,33 +125,22 @@ pub struct Setup {
     pub selections: Option<Vec<[usize; 4]>>,
 }
 
+/// Initial editor setup
+#[derive(Deserialize, Debug, Clone)]
+pub struct Setup {
+    pub file_content: String,
+
+    #[serde(flatten)]
+    pub cursor: CursorSpec,
+}
+
 /// Target state to achieve
-///
-/// Supports two formats:
-/// - Single cursor: `cursor_position = [row, col]` with optional `selection`
-/// - Multi-cursor: `cursors = [[row, col], ...]` or `selections = [[start_row, start_col, end_row, end_col], ...]`
-///
-/// INVARIANT: at least one of cursor_position/cursors/selections must be set,
-/// checked by `ScenarioLoader::validate_setup_or_target_config`.
 #[derive(Deserialize, Debug, Clone)]
 pub struct TargetState {
     pub file_content: String,
 
-    /// Single cursor position [row, col] - for simple scenarios
-    #[serde(default)]
-    pub cursor_position: Option<(usize, usize)>,
-
-    /// Single selection range [start_row, start_col, end_row, end_col]
-    #[serde(default)]
-    pub selection: Option<[usize; 4]>,
-
-    /// Multiple cursor positions [[row, col], ...] - for multi-cursor scenarios
-    #[serde(default)]
-    pub cursors: Option<Vec<[usize; 2]>>,
-
-    /// Multiple selection ranges [[start_row, start_col, end_row, end_col], ...]
-    #[serde(default)]
-    pub selections: Option<Vec<[usize; 4]>>,
+    #[serde(flatten)]
+    pub cursor: CursorSpec,
 }
 
 /// Optimal solution
@@ -179,7 +166,7 @@ pub struct ScoringConfig {
     pub tolerance: usize,
 }
 
-impl Setup {
+impl CursorSpec {
     /// Get effective cursor position (single cursor or first of multi-cursor).
     ///
     /// Prefers `cursor_position` for backward compatibility, but falls back to
@@ -238,88 +225,7 @@ impl Setup {
         None
     }
 
-    /// Check if this setup uses multi-cursor format.
-    pub fn is_multi_cursor(&self) -> bool {
-        self.cursors.is_some() || self.selections.is_some()
-    }
-
-    /// Get raw cursors reference without derivation.
-    ///
-    /// Returns the raw `cursors` field as a slice reference, or None if not set.
-    /// Use `all_cursors()` if you need derived values.
-    pub fn cursors_ref(&self) -> Option<&[[usize; 2]]> {
-        self.cursors.as_deref()
-    }
-
-    /// Get raw selections reference without derivation.
-    ///
-    /// Returns the raw `selections` field as a slice reference, or None if not set.
-    /// Use `all_selections()` if you need derived values.
-    pub fn selections_ref(&self) -> Option<&[[usize; 4]]> {
-        self.selections.as_deref()
-    }
-}
-
-impl TargetState {
-    /// Get effective cursor position (single cursor or first of multi-cursor).
-    ///
-    /// Prefers `cursor_position` for backward compatibility, but falls back to
-    /// first element of `cursors` if available.
-    pub fn effective_cursor_position(&self) -> (usize, usize) {
-        if let Some(pos) = self.cursor_position {
-            return pos;
-        }
-        if let Some(cursors) = &self.cursors
-            && let Some(first) = cursors.first()
-        {
-            return (first[0], first[1]);
-        }
-        if let Some(selections) = &self.selections
-            && let Some(first) = selections.first()
-        {
-            // For selections, cursor is at the end position (head)
-            return (first[2], first[3]);
-        }
-        // Default to (0, 0) if nothing specified
-        (0, 0)
-    }
-
-    /// Get all cursor positions for multi-cursor scenarios.
-    ///
-    /// Returns `cursors` if present, otherwise derives from `selections` or `cursor_position`.
-    pub fn all_cursors(&self) -> Vec<[usize; 2]> {
-        if let Some(cursors) = &self.cursors {
-            return cursors.clone();
-        }
-        if let Some(selections) = &self.selections {
-            // Each selection's end (head) position is a cursor
-            return selections.iter().map(|s| [s[2], s[3]]).collect();
-        }
-        // Single cursor fallback
-        let pos = self.effective_cursor_position();
-        vec![[pos.0, pos.1]]
-    }
-
-    /// Get all selections for multi-selection scenarios.
-    ///
-    /// Returns `selections` if present, otherwise derives from `selection`,
-    /// `cursors`, or `cursor_position`.
-    pub fn all_selections(&self) -> Option<Vec<[usize; 4]>> {
-        if let Some(selections) = &self.selections {
-            return Some(selections.clone());
-        }
-        if let Some(selection) = &self.selection {
-            return Some(vec![*selection]);
-        }
-        if let Some(cursors) = &self.cursors {
-            // Point selections from cursors
-            return Some(cursors.iter().map(|c| [c[0], c[1], c[0], c[1]]).collect());
-        }
-        // No selection
-        None
-    }
-
-    /// Check if this target uses multi-cursor format.
+    /// Check if this spec uses multi-cursor format.
     pub fn is_multi_cursor(&self) -> bool {
         self.cursors.is_some() || self.selections.is_some()
     }
@@ -630,20 +536,10 @@ impl ScenarioLoader {
         self.validate_content_size(&scenario.target.file_content)?;
 
         // Validate setup cursor/selection configuration
-        self.validate_setup_or_target_config(
-            &scenario.setup.cursor_position,
-            &scenario.setup.selection,
-            &scenario.setup.cursors,
-            &scenario.setup.selections,
-        )?;
+        self.validate_setup_or_target_config(&scenario.setup.cursor)?;
 
         // Validate target cursor/selection configuration
-        self.validate_setup_or_target_config(
-            &scenario.target.cursor_position,
-            &scenario.target.selection,
-            &scenario.target.cursors,
-            &scenario.target.selections,
-        )?;
+        self.validate_setup_or_target_config(&scenario.target.cursor)?;
 
         // Validate collection sizes
         if scenario.hints.len() > MAX_HINTS {
@@ -679,33 +575,27 @@ impl ScenarioLoader {
     /// Ensures that:
     /// - At least cursor_position, cursors, or selections is specified
     /// - All cursor positions are within bounds
-    fn validate_setup_or_target_config(
-        &self,
-        cursor_position: &Option<(usize, usize)>,
-        selection: &Option<[usize; 4]>,
-        cursors: &Option<Vec<[usize; 2]>>,
-        selections: &Option<Vec<[usize; 4]>>,
-    ) -> Result<(), SecurityError> {
+    fn validate_setup_or_target_config(&self, spec: &CursorSpec) -> Result<(), SecurityError> {
         // Must have at least one cursor specification
-        if cursor_position.is_none() && cursors.is_none() && selections.is_none() {
+        if spec.cursor_position.is_none() && spec.cursors.is_none() && spec.selections.is_none() {
             return Err(SecurityError::InvalidInput(
                 "Must specify cursor_position, cursors, or selections".to_string(),
             ));
         }
 
         // Validate single cursor_position
-        if let Some(pos) = cursor_position {
-            self.validate_cursor_position(*pos)?;
+        if let Some(pos) = spec.cursor_position {
+            self.validate_cursor_position(pos)?;
         }
 
         // Validate single selection
-        if let Some(sel) = selection {
+        if let Some(sel) = &spec.selection {
             self.validate_cursor_position((sel[0], sel[1]))?;
             self.validate_cursor_position((sel[2], sel[3]))?;
         }
 
         // Validate multi-cursor positions (with array length limit check)
-        if let Some(positions) = cursors {
+        if let Some(positions) = &spec.cursors {
             if positions.len() > MAX_CURSORS_PER_SCENARIO {
                 return Err(SecurityError::InvalidInput(format!(
                     "Too many cursors (max {}, got {})",
@@ -719,7 +609,7 @@ impl ScenarioLoader {
         }
 
         // Validate multi-selection ranges (with array length limit check)
-        if let Some(sels) = selections {
+        if let Some(sels) = &spec.selections {
             if sels.len() > MAX_SELECTIONS_PER_SCENARIO {
                 return Err(SecurityError::InvalidInput(format!(
                     "Too many selections (max {}, got {})",

--- a/src/config/scenarios/tests.rs
+++ b/src/config/scenarios/tests.rs
@@ -574,8 +574,8 @@ fn test_repeat_insert_scenario_loads_correctly() {
         .expect("Should find repeat_insert_001");
 
     // Verify cursor positions are within bounds
-    assert_eq!(scenario.setup.cursor_position, Some((0, 4)));
-    assert_eq!(scenario.target.cursor_position, Some((0, 8)));
+    assert_eq!(scenario.setup.cursor.cursor_position, Some((0, 4)));
+    assert_eq!(scenario.target.cursor.cursor_position, Some((0, 8)));
 
     // Verify content - realistic Rust code
     assert_eq!(scenario.setup.file_content, "fn f() {}");
@@ -751,7 +751,7 @@ tolerance = 0
 
     let scenarios = result.unwrap();
     assert_eq!(scenarios.len(), 1);
-    assert!(scenarios[0].setup.selection.is_some());
+    assert!(scenarios[0].setup.cursor.selection.is_some());
 }
 
 #[test]
@@ -995,8 +995,11 @@ tolerance = 0
 
     let scenarios = result.unwrap();
     assert_eq!(scenarios.len(), 1);
-    assert!(scenarios[0].target.cursors.is_some());
-    assert_eq!(scenarios[0].target.cursors.as_ref().unwrap().len(), 3);
+    assert!(scenarios[0].target.cursor.cursors.is_some());
+    assert_eq!(
+        scenarios[0].target.cursor.cursors.as_ref().unwrap().len(),
+        3
+    );
 }
 
 #[test]
@@ -1047,72 +1050,93 @@ tolerance = 0
 
     let scenarios = result.unwrap();
     assert_eq!(scenarios.len(), 1);
-    assert!(scenarios[0].target.selections.is_some());
-    assert_eq!(scenarios[0].target.selections.as_ref().unwrap().len(), 3);
+    assert!(scenarios[0].target.cursor.selections.is_some());
+    assert_eq!(
+        scenarios[0]
+            .target
+            .cursor
+            .selections
+            .as_ref()
+            .unwrap()
+            .len(),
+        3
+    );
 }
 
 #[test]
 fn test_setup_effective_cursor_position() {
     let setup = Setup {
         file_content: "test".to_string(),
-        cursor_position: Some((1, 5)),
-        selection: None,
-        cursors: None,
-        selections: None,
+        cursor: CursorSpec {
+            cursor_position: Some((1, 5)),
+            selection: None,
+            cursors: None,
+            selections: None,
+        },
     };
-    assert_eq!(setup.effective_cursor_position(), (1, 5));
+    assert_eq!(setup.cursor.effective_cursor_position(), (1, 5));
 
     let setup_multi = Setup {
         file_content: "test".to_string(),
-        cursor_position: None,
-        selection: None,
-        cursors: Some(vec![[2, 3], [4, 5]]),
-        selections: None,
+        cursor: CursorSpec {
+            cursor_position: None,
+            selection: None,
+            cursors: Some(vec![[2, 3], [4, 5]]),
+            selections: None,
+        },
     };
-    assert_eq!(setup_multi.effective_cursor_position(), (2, 3));
+    assert_eq!(setup_multi.cursor.effective_cursor_position(), (2, 3));
 }
 
 #[test]
 fn test_setup_all_cursors() {
     let setup = Setup {
         file_content: "test".to_string(),
-        cursor_position: Some((1, 5)),
-        selection: None,
-        cursors: None,
-        selections: None,
+        cursor: CursorSpec {
+            cursor_position: Some((1, 5)),
+            selection: None,
+            cursors: None,
+            selections: None,
+        },
     };
-    assert_eq!(setup.all_cursors(), vec![[1, 5]]);
+    assert_eq!(setup.cursor.all_cursors(), vec![[1, 5]]);
 
     let setup_multi = Setup {
         file_content: "test".to_string(),
-        cursor_position: None,
-        selection: None,
-        cursors: Some(vec![[2, 3], [4, 5]]),
-        selections: None,
+        cursor: CursorSpec {
+            cursor_position: None,
+            selection: None,
+            cursors: Some(vec![[2, 3], [4, 5]]),
+            selections: None,
+        },
     };
-    assert_eq!(setup_multi.all_cursors(), vec![[2, 3], [4, 5]]);
+    assert_eq!(setup_multi.cursor.all_cursors(), vec![[2, 3], [4, 5]]);
 }
 
 #[test]
 fn test_setup_all_selections() {
     let setup = Setup {
         file_content: "test".to_string(),
-        cursor_position: Some((0, 0)),
-        selection: Some([0, 0, 0, 5]),
-        cursors: None,
-        selections: None,
+        cursor: CursorSpec {
+            cursor_position: Some((0, 0)),
+            selection: Some([0, 0, 0, 5]),
+            cursors: None,
+            selections: None,
+        },
     };
-    assert_eq!(setup.all_selections(), Some(vec![[0, 0, 0, 5]]));
+    assert_eq!(setup.cursor.all_selections(), Some(vec![[0, 0, 0, 5]]));
 
     let setup_multi = Setup {
         file_content: "test".to_string(),
-        cursor_position: None,
-        selection: None,
-        cursors: None,
-        selections: Some(vec![[0, 0, 0, 5], [1, 0, 1, 5]]),
+        cursor: CursorSpec {
+            cursor_position: None,
+            selection: None,
+            cursors: None,
+            selections: Some(vec![[0, 0, 0, 5], [1, 0, 1, 5]]),
+        },
     };
     assert_eq!(
-        setup_multi.all_selections(),
+        setup_multi.cursor.all_selections(),
         Some(vec![[0, 0, 0, 5], [1, 0, 1, 5]])
     );
 }
@@ -1121,30 +1145,36 @@ fn test_setup_all_selections() {
 fn test_setup_is_multi_cursor() {
     let single = Setup {
         file_content: "test".to_string(),
-        cursor_position: Some((0, 0)),
-        selection: None,
-        cursors: None,
-        selections: None,
+        cursor: CursorSpec {
+            cursor_position: Some((0, 0)),
+            selection: None,
+            cursors: None,
+            selections: None,
+        },
     };
-    assert!(!single.is_multi_cursor());
+    assert!(!single.cursor.is_multi_cursor());
 
     let multi_cursors = Setup {
         file_content: "test".to_string(),
-        cursor_position: None,
-        selection: None,
-        cursors: Some(vec![[0, 0], [1, 0]]),
-        selections: None,
+        cursor: CursorSpec {
+            cursor_position: None,
+            selection: None,
+            cursors: Some(vec![[0, 0], [1, 0]]),
+            selections: None,
+        },
     };
-    assert!(multi_cursors.is_multi_cursor());
+    assert!(multi_cursors.cursor.is_multi_cursor());
 
     let multi_selections = Setup {
         file_content: "test".to_string(),
-        cursor_position: None,
-        selection: None,
-        cursors: None,
-        selections: Some(vec![[0, 0, 0, 5]]),
+        cursor: CursorSpec {
+            cursor_position: None,
+            selection: None,
+            cursors: None,
+            selections: Some(vec![[0, 0, 0, 5]]),
+        },
     };
-    assert!(multi_selections.is_multi_cursor());
+    assert!(multi_selections.cursor.is_multi_cursor());
 }
 
 #[test]
@@ -1235,13 +1265,15 @@ fn test_setup_effective_cursor_from_selections() {
     // When only selections are present, cursor is at first selection's head
     let setup = Setup {
         file_content: "test content".to_string(),
-        cursor_position: None,
-        selection: None,
-        cursors: None,
-        selections: Some(vec![[0, 2, 0, 5], [0, 8, 0, 12]]),
+        cursor: CursorSpec {
+            cursor_position: None,
+            selection: None,
+            cursors: None,
+            selections: Some(vec![[0, 2, 0, 5], [0, 8, 0, 12]]),
+        },
     };
     // First selection's end (head) is at (0, 5)
-    assert_eq!(setup.effective_cursor_position(), (0, 5));
+    assert_eq!(setup.cursor.effective_cursor_position(), (0, 5));
 }
 
 #[test]
@@ -1249,13 +1281,15 @@ fn test_setup_all_cursors_derived_from_selections() {
     // all_cursors should derive from selections when cursors is None
     let setup = Setup {
         file_content: "test".to_string(),
-        cursor_position: None,
-        selection: None,
-        cursors: None,
-        selections: Some(vec![[0, 0, 0, 3], [0, 5, 0, 8]]),
+        cursor: CursorSpec {
+            cursor_position: None,
+            selection: None,
+            cursors: None,
+            selections: Some(vec![[0, 0, 0, 3], [0, 5, 0, 8]]),
+        },
     };
     // Cursors are at selection ends (heads)
-    let cursors = setup.all_cursors();
+    let cursors = setup.cursor.all_cursors();
     assert_eq!(cursors.len(), 2);
     assert_eq!(cursors[0], [0, 3]);
     assert_eq!(cursors[1], [0, 8]);
@@ -1266,12 +1300,14 @@ fn test_setup_all_selections_derived_from_cursors() {
     // all_selections should create point selections from cursors
     let setup = Setup {
         file_content: "test".to_string(),
-        cursor_position: None,
-        selection: None,
-        cursors: Some(vec![[0, 2], [0, 5]]),
-        selections: None,
+        cursor: CursorSpec {
+            cursor_position: None,
+            selection: None,
+            cursors: Some(vec![[0, 2], [0, 5]]),
+            selections: None,
+        },
     };
-    let selections = setup.all_selections().unwrap();
+    let selections = setup.cursor.all_selections().unwrap();
     assert_eq!(selections.len(), 2);
     // Point selections: start == end
     assert_eq!(selections[0], [0, 2, 0, 2]);
@@ -1283,66 +1319,76 @@ fn test_setup_all_selections_none_when_no_selection_info() {
     // When no selection/selections/cursors, all_selections returns None
     let setup = Setup {
         file_content: "test".to_string(),
-        cursor_position: Some((0, 0)),
-        selection: None,
-        cursors: None,
-        selections: None,
+        cursor: CursorSpec {
+            cursor_position: Some((0, 0)),
+            selection: None,
+            cursors: None,
+            selections: None,
+        },
     };
-    assert!(setup.all_selections().is_none());
+    assert!(setup.cursor.all_selections().is_none());
 }
 
 #[test]
 fn test_setup_empty_cursors_array() {
     let setup = Setup {
         file_content: "test".to_string(),
-        cursor_position: Some((0, 2)),
-        selection: None,
-        cursors: Some(vec![]),
-        selections: None,
+        cursor: CursorSpec {
+            cursor_position: Some((0, 2)),
+            selection: None,
+            cursors: Some(vec![]),
+            selections: None,
+        },
     };
     // Empty cursors array: effective_cursor_position falls back to cursor_position
-    assert_eq!(setup.effective_cursor_position(), (0, 2));
+    assert_eq!(setup.cursor.effective_cursor_position(), (0, 2));
     // all_cursors returns empty vec
-    assert!(setup.all_cursors().is_empty());
+    assert!(setup.cursor.all_cursors().is_empty());
 }
 
 #[test]
 fn test_setup_empty_selections_array() {
     let setup = Setup {
         file_content: "test".to_string(),
-        cursor_position: Some((0, 2)),
-        selection: None,
-        cursors: None,
-        selections: Some(vec![]),
+        cursor: CursorSpec {
+            cursor_position: Some((0, 2)),
+            selection: None,
+            cursors: None,
+            selections: Some(vec![]),
+        },
     };
     // Empty selections array: effective_cursor_position falls back to cursor_position
-    assert_eq!(setup.effective_cursor_position(), (0, 2));
+    assert_eq!(setup.cursor.effective_cursor_position(), (0, 2));
     // all_selections returns Some(empty vec)
-    assert_eq!(setup.all_selections(), Some(vec![]));
+    assert_eq!(setup.cursor.all_selections(), Some(vec![]));
 }
 
 #[test]
 fn test_target_effective_cursor_from_selections() {
     let target = TargetState {
         file_content: "test content".to_string(),
-        cursor_position: None,
-        selection: None,
-        cursors: None,
-        selections: Some(vec![[0, 0, 0, 7]]),
+        cursor: CursorSpec {
+            cursor_position: None,
+            selection: None,
+            cursors: None,
+            selections: Some(vec![[0, 0, 0, 7]]),
+        },
     };
-    assert_eq!(target.effective_cursor_position(), (0, 7));
+    assert_eq!(target.cursor.effective_cursor_position(), (0, 7));
 }
 
 #[test]
 fn test_target_all_cursors_derived_from_selections() {
     let target = TargetState {
         file_content: "test".to_string(),
-        cursor_position: None,
-        selection: None,
-        cursors: None,
-        selections: Some(vec![[0, 0, 0, 4]]),
+        cursor: CursorSpec {
+            cursor_position: None,
+            selection: None,
+            cursors: None,
+            selections: Some(vec![[0, 0, 0, 4]]),
+        },
     };
-    let cursors = target.all_cursors();
+    let cursors = target.cursor.all_cursors();
     assert_eq!(cursors.len(), 1);
     assert_eq!(cursors[0], [0, 4]); // Head of selection
 }
@@ -1351,12 +1397,14 @@ fn test_target_all_cursors_derived_from_selections() {
 fn test_cursors_ref_returns_reference() {
     let setup = Setup {
         file_content: "test".to_string(),
-        cursor_position: None,
-        selection: None,
-        cursors: Some(vec![[0, 1], [0, 2]]),
-        selections: None,
+        cursor: CursorSpec {
+            cursor_position: None,
+            selection: None,
+            cursors: Some(vec![[0, 1], [0, 2]]),
+            selections: None,
+        },
     };
-    let ref_slice = setup.cursors_ref();
+    let ref_slice = setup.cursor.cursors_ref();
     assert!(ref_slice.is_some());
     assert_eq!(ref_slice.unwrap().len(), 2);
 }
@@ -1365,12 +1413,14 @@ fn test_cursors_ref_returns_reference() {
 fn test_selections_ref_returns_reference() {
     let setup = Setup {
         file_content: "test".to_string(),
-        cursor_position: None,
-        selection: None,
-        cursors: None,
-        selections: Some(vec![[0, 0, 0, 5]]),
+        cursor: CursorSpec {
+            cursor_position: None,
+            selection: None,
+            cursors: None,
+            selections: Some(vec![[0, 0, 0, 5]]),
+        },
     };
-    let ref_slice = setup.selections_ref();
+    let ref_slice = setup.cursor.selections_ref();
     assert!(ref_slice.is_some());
     assert_eq!(ref_slice.unwrap().len(), 1);
 }
@@ -1379,12 +1429,14 @@ fn test_selections_ref_returns_reference() {
 fn test_cursors_ref_none_when_not_set() {
     let setup = Setup {
         file_content: "test".to_string(),
-        cursor_position: Some((0, 0)),
-        selection: None,
-        cursors: None,
-        selections: None,
+        cursor: CursorSpec {
+            cursor_position: Some((0, 0)),
+            selection: None,
+            cursors: None,
+            selections: None,
+        },
     };
-    assert!(setup.cursors_ref().is_none());
+    assert!(setup.cursor.cursors_ref().is_none());
 }
 
 // ============================================================================

--- a/src/data_handling.rs
+++ b/src/data_handling.rs
@@ -126,7 +126,7 @@ pub fn handle_data_message(state: &mut AppState, msg: DataLoadMessage) -> Result
 mod tests {
     use super::*;
     use helix_trainer::{
-        config::{Scenario, ScoringConfig, Setup, Solution, TargetState},
+        config::{CursorSpec, Scenario, ScoringConfig, Setup, Solution, TargetState},
         gamification::ProfileStorage,
     };
 
@@ -159,17 +159,21 @@ mod tests {
             description: "Test scenario".to_string(),
             setup: Setup {
                 file_content: "line 1\nline 2\nline 3\n".to_string(),
-                cursor_position: Some((0, 0)),
-                selection: None,
-                cursors: None,
-                selections: None,
+                cursor: CursorSpec {
+                    cursor_position: Some((0, 0)),
+                    selection: None,
+                    cursors: None,
+                    selections: None,
+                },
             },
             target: TargetState {
                 file_content: "line 2\nline 3\n".to_string(),
-                cursor_position: Some((0, 0)),
-                selection: None,
-                cursors: None,
-                selections: None,
+                cursor: CursorSpec {
+                    cursor_position: Some((0, 0)),
+                    selection: None,
+                    cursors: None,
+                    selections: None,
+                },
             },
             solution: Solution {
                 commands: vec!["x".to_string(), "d".to_string()],

--- a/src/game/scenario_state.rs
+++ b/src/game/scenario_state.rs
@@ -44,19 +44,19 @@ impl ScenarioState {
         // Create initial snapshot from scenario setup
         let initial_snapshot = EditorSnapshot::from_scenario_config(
             scenario.setup.file_content.clone(),
-            scenario.setup.cursor_position,
-            scenario.setup.selection,
-            scenario.setup.cursors.as_deref(),
-            scenario.setup.selections.as_deref(),
+            scenario.setup.cursor.cursor_position,
+            scenario.setup.cursor.selection,
+            scenario.setup.cursor.cursors.as_deref(),
+            scenario.setup.cursor.selections.as_deref(),
         );
 
         // Create target snapshot for completion checking
         let target_snapshot = EditorSnapshot::from_scenario_config(
             scenario.target.file_content.clone(),
-            scenario.target.cursor_position,
-            scenario.target.selection,
-            scenario.target.cursors.as_deref(),
-            scenario.target.selections.as_deref(),
+            scenario.target.cursor.cursor_position,
+            scenario.target.cursor.selection,
+            scenario.target.cursor.cursors.as_deref(),
+            scenario.target.cursor.selections.as_deref(),
         );
 
         // Initialize Helix simulator from initial snapshot

--- a/src/game/session/mod.rs
+++ b/src/game/session/mod.rs
@@ -625,10 +625,10 @@ impl GameSession<Active> {
         // Recreate initial snapshot from scenario config and reset simulator
         let initial_snapshot = EditorSnapshot::from_scenario_config(
             self.scenario.setup.file_content.clone(),
-            self.scenario.setup.cursor_position,
-            self.scenario.setup.selection,
-            self.scenario.setup.cursors.as_deref(),
-            self.scenario.setup.selections.as_deref(),
+            self.scenario.setup.cursor.cursor_position,
+            self.scenario.setup.cursor.selection,
+            self.scenario.setup.cursor.cursors.as_deref(),
+            self.scenario.setup.cursor.selections.as_deref(),
         );
         self.simulator = AnyModeSimulator::from_snapshot(&initial_snapshot);
         self.user_actions.clear();

--- a/src/gamification/quests.rs
+++ b/src/gamification/quests.rs
@@ -542,12 +542,7 @@ impl QuestGenerator {
         // Filter to only exploration type quests
         let exploration_templates: Vec<_> = templates
             .into_iter()
-            .filter(|t| {
-                matches!(
-                    t.quest_type,
-                    crate::config::quests::QuestTypeTag::Exploration
-                )
-            })
+            .filter(|t| matches!(t.spec, crate::config::quests::QuestSpec::Exploration { .. }))
             .collect();
 
         assert!(

--- a/src/input/handlers.rs
+++ b/src/input/handlers.rs
@@ -844,7 +844,7 @@ mod tests {
 
         #[test]
         fn test_is_gameplay_insert_mode_on_task_screen_normal_mode() {
-            use crate::config::{ScoringConfig, Setup, Solution, TargetState};
+            use crate::config::{CursorSpec, ScoringConfig, Setup, Solution, TargetState};
 
             let mut state = create_test_app_state();
 
@@ -855,17 +855,21 @@ mod tests {
                 description: "Test scenario".to_string(),
                 setup: Setup {
                     file_content: "test".to_string(),
-                    cursor_position: Some((0, 0)),
-                    selection: None,
-                    cursors: None,
-                    selections: None,
+                    cursor: CursorSpec {
+                        cursor_position: Some((0, 0)),
+                        selection: None,
+                        cursors: None,
+                        selections: None,
+                    },
                 },
                 target: TargetState {
                     file_content: "test2".to_string(),
-                    cursor_position: Some((0, 0)),
-                    selection: None,
-                    cursors: None,
-                    selections: None,
+                    cursor: CursorSpec {
+                        cursor_position: Some((0, 0)),
+                        selection: None,
+                        cursors: None,
+                        selections: None,
+                    },
                 },
                 solution: Solution {
                     commands: vec!["x".to_string()],
@@ -1086,7 +1090,7 @@ mod tests {
 
         #[test]
         fn test_arrow_keys_ignored_by_default() {
-            use crate::config::{ScoringConfig, Setup, Solution, TargetState};
+            use crate::config::{CursorSpec, ScoringConfig, Setup, Solution, TargetState};
             use crate::ui::state::{ConfigState, screen::TaskData};
 
             let mut state = create_test_app_state();
@@ -1099,17 +1103,21 @@ mod tests {
                 description: "Test scenario".to_string(),
                 setup: Setup {
                     file_content: "test".to_string(),
-                    cursor_position: Some((0, 0)),
-                    cursors: None,
-                    selections: None,
-                    selection: None,
+                    cursor: CursorSpec {
+                        cursor_position: Some((0, 0)),
+                        selection: None,
+                        cursors: None,
+                        selections: None,
+                    },
                 },
                 target: TargetState {
                     file_content: "test2".to_string(),
-                    cursor_position: Some((0, 0)),
-                    cursors: None,
-                    selections: None,
-                    selection: None,
+                    cursor: CursorSpec {
+                        cursor_position: Some((0, 0)),
+                        selection: None,
+                        cursors: None,
+                        selections: None,
+                    },
                 },
                 solution: Solution {
                     commands: vec!["x".to_string()],
@@ -1143,7 +1151,7 @@ mod tests {
 
         #[test]
         fn test_arrow_keys_mapped_when_enabled() {
-            use crate::config::{ScoringConfig, Setup, Solution, TargetState};
+            use crate::config::{CursorSpec, ScoringConfig, Setup, Solution, TargetState};
             use crate::helix::commands::{
                 CMD_MOVE_DOWN, CMD_MOVE_LEFT, CMD_MOVE_RIGHT, CMD_MOVE_UP,
             };
@@ -1159,17 +1167,21 @@ mod tests {
                 description: "Test scenario".to_string(),
                 setup: Setup {
                     file_content: "test".to_string(),
-                    cursor_position: Some((0, 0)),
-                    selection: None,
-                    cursors: None,
-                    selections: None,
+                    cursor: CursorSpec {
+                        cursor_position: Some((0, 0)),
+                        selection: None,
+                        cursors: None,
+                        selections: None,
+                    },
                 },
                 target: TargetState {
                     file_content: "test2".to_string(),
-                    cursor_position: Some((0, 0)),
-                    selection: None,
-                    cursors: None,
-                    selections: None,
+                    cursor: CursorSpec {
+                        cursor_position: Some((0, 0)),
+                        selection: None,
+                        cursors: None,
+                        selections: None,
+                    },
                 },
                 solution: Solution {
                     commands: vec!["x".to_string()],
@@ -1234,7 +1246,7 @@ mod tests {
 
         #[test]
         fn test_arrow_keys_with_modifiers_not_mapped() {
-            use crate::config::{ScoringConfig, Setup, Solution, TargetState};
+            use crate::config::{CursorSpec, ScoringConfig, Setup, Solution, TargetState};
             use crate::ui::state::screen::TaskData;
 
             let mut state = create_test_app_state();
@@ -1247,17 +1259,21 @@ mod tests {
                 description: "Test scenario".to_string(),
                 setup: Setup {
                     file_content: "test".to_string(),
-                    cursor_position: Some((0, 0)),
-                    cursors: None,
-                    selections: None,
-                    selection: None,
+                    cursor: CursorSpec {
+                        cursor_position: Some((0, 0)),
+                        selection: None,
+                        cursors: None,
+                        selections: None,
+                    },
                 },
                 target: TargetState {
                     file_content: "test2".to_string(),
-                    cursor_position: Some((0, 0)),
-                    cursors: None,
-                    selections: None,
-                    selection: None,
+                    cursor: CursorSpec {
+                        cursor_position: Some((0, 0)),
+                        selection: None,
+                        cursors: None,
+                        selections: None,
+                    },
                 },
                 solution: Solution {
                     commands: vec!["x".to_string()],

--- a/src/minigame/scorer.rs
+++ b/src/minigame/scorer.rs
@@ -202,7 +202,7 @@ impl<'a> ScenarioScorer<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{ScoringConfig, Setup, Solution, TargetState};
+    use crate::config::{CursorSpec, ScoringConfig, Setup, Solution, TargetState};
     use chrono::Duration;
     use std::time::Duration as StdDuration;
 
@@ -214,17 +214,21 @@ mod tests {
             description: "A test scenario".to_string(),
             setup: Setup {
                 file_content: "test content".to_string(),
-                cursor_position: Some((0, 0)),
-                selection: None,
-                cursors: None,
-                selections: None,
+                cursor: CursorSpec {
+                    cursor_position: Some((0, 0)),
+                    selection: None,
+                    cursors: None,
+                    selections: None,
+                },
             },
             target: TargetState {
                 file_content: "target content".to_string(),
-                cursor_position: Some((0, 0)),
-                selection: None,
-                cursors: None,
-                selections: None,
+                cursor: CursorSpec {
+                    cursor_position: Some((0, 0)),
+                    selection: None,
+                    cursors: None,
+                    selections: None,
+                },
             },
             solution: Solution {
                 commands: commands.into_iter().map(String::from).collect(),

--- a/src/minigame/tests.rs
+++ b/src/minigame/tests.rs
@@ -4,7 +4,7 @@
 
 use super::*;
 use crate::config::{
-    Difficulty, Scenario, ScenarioMetadata, ScoringConfig, Setup, Solution, TargetState,
+    CursorSpec, Difficulty, Scenario, ScenarioMetadata, ScoringConfig, Setup, Solution, TargetState,
 };
 use std::sync::Arc;
 
@@ -15,17 +15,21 @@ fn create_simple_scenario(id: &str) -> Scenario {
         description: "Test scenario".to_string(),
         setup: Setup {
             file_content: "test".to_string(),
-            cursor_position: Some((0, 0)),
-            selection: None,
-            cursors: None,
-            selections: None,
+            cursor: CursorSpec {
+                cursor_position: Some((0, 0)),
+                selection: None,
+                cursors: None,
+                selections: None,
+            },
         },
         target: TargetState {
             file_content: "".to_string(),
-            cursor_position: Some((0, 0)),
-            selection: None,
-            cursors: None,
-            selections: None,
+            cursor: CursorSpec {
+                cursor_position: Some((0, 0)),
+                selection: None,
+                cursors: None,
+                selections: None,
+            },
         },
         solution: Solution {
             commands: vec!["x".to_string()],

--- a/src/testing/scenario.rs
+++ b/src/testing/scenario.rs
@@ -3,8 +3,8 @@
 //! Provides a fluent builder API for creating `Scenario` instances in tests.
 
 use crate::config::{
-    AlternativeSolution, Difficulty, Scenario, ScenarioCategory, ScenarioMetadata, ScoringConfig,
-    Setup, Solution, TargetState,
+    AlternativeSolution, CursorSpec, Difficulty, Scenario, ScenarioCategory, ScenarioMetadata,
+    ScoringConfig, Setup, Solution, TargetState,
 };
 use std::num::NonZeroUsize;
 
@@ -244,17 +244,21 @@ impl ScenarioBuilder {
             description: self.description,
             setup: Setup {
                 file_content: self.setup_content,
-                cursor_position: Some(self.setup_cursor),
-                selection: self.setup_selection,
-                cursors: None,
-                selections: None,
+                cursor: CursorSpec {
+                    cursor_position: Some(self.setup_cursor),
+                    selection: self.setup_selection,
+                    cursors: None,
+                    selections: None,
+                },
             },
             target: TargetState {
                 file_content: self.target_content,
-                cursor_position: Some(self.target_cursor),
-                selection: self.target_selection,
-                cursors: None,
-                selections: None,
+                cursor: CursorSpec {
+                    cursor_position: Some(self.target_cursor),
+                    selection: self.target_selection,
+                    cursors: None,
+                    selections: None,
+                },
             },
             solution: Solution {
                 commands: self.commands,

--- a/src/ui/state/screen.rs
+++ b/src/ui/state/screen.rs
@@ -605,7 +605,7 @@ mod tests {
 
     #[test]
     fn test_task_data_key_history() {
-        use crate::config::{Scenario, ScoringConfig, Setup, Solution, TargetState};
+        use crate::config::{CursorSpec, Scenario, ScoringConfig, Setup, Solution, TargetState};
 
         let scenario = Scenario {
             id: "test".to_string(),
@@ -613,17 +613,21 @@ mod tests {
             description: "Test scenario".to_string(),
             setup: Setup {
                 file_content: "test".to_string(),
-                cursor_position: Some((0, 0)),
-                selection: None,
-                cursors: None,
-                selections: None,
+                cursor: CursorSpec {
+                    cursor_position: Some((0, 0)),
+                    selection: None,
+                    cursors: None,
+                    selections: None,
+                },
             },
             target: TargetState {
                 file_content: "test".to_string(),
-                cursor_position: Some((0, 0)),
-                selection: None,
-                cursors: None,
-                selections: None,
+                cursor: CursorSpec {
+                    cursor_position: Some((0, 0)),
+                    selection: None,
+                    cursors: None,
+                    selections: None,
+                },
             },
             solution: Solution {
                 commands: vec!["x".to_string(), "d".to_string()],
@@ -658,7 +662,7 @@ mod tests {
 
     #[test]
     fn test_task_data_key_history_max_5() {
-        use crate::config::{Scenario, ScoringConfig, Setup, Solution, TargetState};
+        use crate::config::{CursorSpec, Scenario, ScoringConfig, Setup, Solution, TargetState};
 
         let scenario = Scenario {
             id: "test".to_string(),
@@ -666,17 +670,21 @@ mod tests {
             description: "Test scenario".to_string(),
             setup: Setup {
                 file_content: "test".to_string(),
-                cursor_position: Some((0, 0)),
-                selection: None,
-                cursors: None,
-                selections: None,
+                cursor: CursorSpec {
+                    cursor_position: Some((0, 0)),
+                    selection: None,
+                    cursors: None,
+                    selections: None,
+                },
             },
             target: TargetState {
                 file_content: "test".to_string(),
-                cursor_position: Some((0, 0)),
-                selection: None,
-                cursors: None,
-                selections: None,
+                cursor: CursorSpec {
+                    cursor_position: Some((0, 0)),
+                    selection: None,
+                    cursors: None,
+                    selections: None,
+                },
             },
             solution: Solution {
                 commands: vec!["x".to_string(), "d".to_string()],
@@ -707,7 +715,7 @@ mod tests {
 
     #[test]
     fn test_completed_or_abandoned_helpers() {
-        use crate::config::{Scenario, ScoringConfig, Setup, Solution, TargetState};
+        use crate::config::{CursorSpec, Scenario, ScoringConfig, Setup, Solution, TargetState};
 
         let scenario = Scenario {
             id: "test_123".to_string(),
@@ -715,17 +723,21 @@ mod tests {
             description: "Test scenario".to_string(),
             setup: Setup {
                 file_content: "test".to_string(),
-                cursor_position: Some((0, 0)),
-                selection: None,
-                cursors: None,
-                selections: None,
+                cursor: CursorSpec {
+                    cursor_position: Some((0, 0)),
+                    selection: None,
+                    cursors: None,
+                    selections: None,
+                },
             },
             target: TargetState {
                 file_content: "test".to_string(),
-                cursor_position: Some((0, 0)),
-                selection: None,
-                cursors: None,
-                selections: None,
+                cursor: CursorSpec {
+                    cursor_position: Some((0, 0)),
+                    selection: None,
+                    cursors: None,
+                    selections: None,
+                },
             },
             solution: Solution {
                 commands: vec!["x".to_string(), "d".to_string()],

--- a/tests/ui_multi_key_commands.rs
+++ b/tests/ui_multi_key_commands.rs
@@ -3,7 +3,7 @@
 //! These tests verify that the UI layer correctly handles multi-key commands
 //! like 'dd', 'gg', 'r<char>' through the typestate-based InputStateMachine.
 
-use helix_trainer::config::{Scenario, ScoringConfig, Setup, Solution, TargetState};
+use helix_trainer::config::{CursorSpec, Scenario, ScoringConfig, Setup, Solution, TargetState};
 use helix_trainer::game::PlayableScenario;
 use helix_trainer::gamification::{ProfileStorage, UserProfile};
 use helix_trainer::learning::PerformanceTracker;
@@ -33,17 +33,21 @@ fn create_test_scenario(
         description: "Test scenario for integration testing".to_string(),
         setup: Setup {
             file_content: setup_content.to_string(),
-            cursor_position: Some(setup_cursor),
-            selection: None,
-            cursors: None,
-            selections: None,
+            cursor: CursorSpec {
+                cursor_position: Some(setup_cursor),
+                selection: None,
+                cursors: None,
+                selections: None,
+            },
         },
         target: TargetState {
             file_content: target_content.to_string(),
-            cursor_position: Some(target_cursor),
-            selection: None,
-            cursors: None,
-            selections: None,
+            cursor: CursorSpec {
+                cursor_position: Some(target_cursor),
+                selection: None,
+                cursors: None,
+                selections: None,
+            },
         },
         solution: Solution {
             commands: vec!["test".to_string()],


### PR DESCRIPTION
## Summary
- Extract the duplicated cursor/selection fields and logic (`effective_cursor_position`, `all_cursors`, `all_selections`, `is_multi_cursor`, `cursors_ref`, `selections_ref`) shared by `Setup` and `TargetState` into a single `CursorSpec` type, composed via `#[serde(flatten)]`. Scenario TOML files are unaffected.
- Replace `QuestTemplate`'s separate `type` discriminator (`QuestTypeTag`) and untagged `params` enum (`QuestParams`) — which could silently disagree — with one adjacently-tagged `QuestSpec` enum (`#[serde(tag = "type", content = "params")]`), so a type/params mismatch is now a deserialization error instead of a runtime-only check (`validate_params_match_type` removed). Quest TOML files are unaffected.
- Removed the resulting dead `impl Setup`/`impl TargetState` delegating methods (zero production callers after the migration) so the duplication isn't just moved one level down.

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (1848/1848)
- [x] `cargo nextest run scenario` (228/228)
- [x] `cargo test --doc --all-features`
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] `cargo build --no-default-features`

Fixes #268
Fixes #274