### PR TITLE
refactor(game): unify PlayableScenario impl across session states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING**: Removed the now-unreachable `SecurityError::InvalidScoringConfig` variant (#277)
 - Unified scenario and quest ID validation into `security::validators::validate_id_field` (#275)
 - Consolidated scenario/quest TOML parsing, count-limit enforcement, and per-item validation into a shared `config::loader::parse_and_validate` pipeline (#276)
+- Collapsed the duplicated `PlayableScenario` trait implementations for `GameSession<Active>` and `GameSession<Completed>` into a single `impl<S: SessionState> PlayableScenario for GameSession<S>` block; the per-state `elapsed()` behavior is now dispatched through a new `SessionState::session_elapsed` associated function (#280)
 
 ## [0.5.12] - 2026-07-27
 

--- a/src/game/session/mod.rs
+++ b/src/game/session/mod.rs
@@ -787,8 +787,10 @@ impl GameSession<Abandoned> {
 /// Typestate pattern markers for compile-time state machine enforcement
 pub mod typestate;
 
-// Implement PlayableScenario trait for GameSession<Active>
-impl super::PlayableScenario for GameSession<Active> {
+// Implement PlayableScenario trait for GameSession in any state.
+// Shared logic lives here; only `elapsed()` differs per state, delegated to
+// `SessionState::session_elapsed`.
+impl<S: SessionState> super::PlayableScenario for GameSession<S> {
     fn current_content(&self) -> String {
         self.simulator.display().content()
     }
@@ -814,83 +816,15 @@ impl super::PlayableScenario for GameSession<Active> {
     }
 
     fn action_count(&self) -> usize {
-        self.user_actions.len()
+        self.action_count()
     }
 
     fn is_insert_mode(&self) -> bool {
-        self.simulator.mode() == crate::helix::Mode::Insert
+        self.is_insert_mode()
     }
 
-    fn elapsed(&self) -> std::time::Duration {
-        self.started_at.elapsed()
-    }
-
-    fn all_cursors(&self) -> Vec<(usize, usize)> {
-        self.simulator.display().all_cursor_positions()
-    }
-
-    fn all_selections(&self) -> Vec<crate::helix::SelectionBounds> {
-        self.simulator
-            .display()
-            .all_selection_bounds()
-            .into_iter()
-            .map(|((sr, sc), (er, ec))| crate::helix::SelectionBounds::new(sr, sc, er, ec))
-            .collect()
-    }
-
-    fn all_target_cursors(&self) -> Vec<(usize, usize)> {
-        with_target_display(&self.target_snapshot, |d| d.all_cursor_positions())
-    }
-
-    fn all_target_selections(&self) -> Vec<crate::helix::SelectionBounds> {
-        with_target_display(&self.target_snapshot, |d| {
-            d.all_selection_bounds()
-                .into_iter()
-                .map(|((sr, sc), (er, ec))| crate::helix::SelectionBounds::new(sr, sc, er, ec))
-                .collect()
-        })
-    }
-}
-
-// Implement PlayableScenario trait for GameSession<Completed>
-impl super::PlayableScenario for GameSession<Completed> {
-    fn current_content(&self) -> String {
-        self.simulator.display().content()
-    }
-
-    fn target_content(&self) -> String {
-        self.target_snapshot.content.clone()
-    }
-
-    fn current_cursor(&self) -> (usize, usize) {
-        self.simulator.display().cursor_position()
-    }
-
-    fn target_cursor(&self) -> (usize, usize) {
-        with_target_display(&self.target_snapshot, |d| d.cursor_position())
-    }
-
-    fn current_selection(&self) -> Option<crate::helix::SelectionBounds> {
-        self.simulator.display().selection()
-    }
-
-    fn target_selection(&self) -> Option<crate::helix::SelectionBounds> {
-        with_target_display(&self.target_snapshot, |d| d.selection())
-    }
-
-    fn action_count(&self) -> usize {
-        self.user_actions.len()
-    }
-
-    fn is_insert_mode(&self) -> bool {
-        self.simulator.mode() == crate::helix::Mode::Insert
-    }
-
-    fn elapsed(&self) -> std::time::Duration {
-        // For completed sessions, return duration from start to completion
-        self.completed_at
-            .map(|end| end.duration_since(self.started_at))
-            .unwrap_or_else(|| self.started_at.elapsed())
+    fn elapsed(&self) -> Duration {
+        S::session_elapsed(self.started_at, self.completed_at)
     }
 
     fn all_cursors(&self) -> Vec<(usize, usize)> {

--- a/src/game/session/tests.rs
+++ b/src/game/session/tests.rs
@@ -317,3 +317,38 @@ fn test_timer_fixed_on_completion() {
         }
     }
 }
+
+#[test]
+fn test_playable_scenario_elapsed_fixed_after_completion() {
+    // Regression test for the PlayableScenario trait impl specifically: called
+    // via UFCS so it can't silently resolve to the inherent `elapsed()` method,
+    // which method-call syntax would otherwise prefer.
+    use crate::game::PlayableScenario;
+
+    let scenario = create_test_scenario();
+    let session = GameSession::new(scenario).unwrap();
+
+    let result = session.record_action("x".to_string()).unwrap();
+    let session = match result {
+        SessionAfterAction::StillActive(s) => s,
+        SessionAfterAction::Completed(_) => panic!("Should not complete after just 'x'"),
+    };
+    let result = session.record_action("d".to_string()).unwrap();
+
+    match result {
+        SessionAfterAction::Completed(completed) => {
+            let elapsed1 = PlayableScenario::elapsed(&completed);
+
+            std::thread::sleep(std::time::Duration::from_millis(50));
+
+            let elapsed2 = PlayableScenario::elapsed(&completed);
+            assert_eq!(
+                elapsed1, elapsed2,
+                "PlayableScenario::elapsed() should be frozen once the session is completed"
+            );
+        }
+        SessionAfterAction::StillActive(_) => {
+            panic!("Session should be completed after 'x' + 'd' commands");
+        }
+    }
+}

--- a/src/game/session/typestate.rs
+++ b/src/game/session/typestate.rs
@@ -27,6 +27,8 @@
 //!     [Completed]
 //! ```
 
+use std::time::{Duration, Instant};
+
 /// State marker for active game session
 ///
 /// Sessions in this state can record actions, get hints, and check for completion.
@@ -59,16 +61,43 @@ mod private {
 ///
 /// This is a sealed trait - only `Active`, `Completed`, and `Abandoned` can implement it.
 /// This ensures type safety and allows us to add methods in the future without breaking changes.
-pub trait SessionState: private::Sealed {}
+pub trait SessionState: private::Sealed {
+    /// Compute a session's elapsed time given its start and completion timestamps.
+    ///
+    /// Each state defines how "elapsed" is measured: states without a fixed
+    /// end point (`Active`, `Abandoned`) measure time up to now, while
+    /// `Completed` measures the fixed duration up to `completed_at`.
+    ///
+    /// Internal dispatch helper for `PlayableScenario::elapsed()`; hidden
+    /// because the trait is sealed and has no external implementors.
+    #[doc(hidden)]
+    fn session_elapsed(started_at: Instant, completed_at: Option<Instant>) -> Duration;
+}
 
 // Implement sealed trait for our state markers
 impl private::Sealed for Active {}
 impl private::Sealed for Completed {}
 impl private::Sealed for Abandoned {}
 
-impl SessionState for Active {}
-impl SessionState for Completed {}
-impl SessionState for Abandoned {}
+impl SessionState for Active {
+    fn session_elapsed(started_at: Instant, _completed_at: Option<Instant>) -> Duration {
+        started_at.elapsed()
+    }
+}
+
+impl SessionState for Completed {
+    fn session_elapsed(started_at: Instant, completed_at: Option<Instant>) -> Duration {
+        completed_at
+            .map(|end| end.duration_since(started_at))
+            .unwrap_or_else(|| started_at.elapsed())
+    }
+}
+
+impl SessionState for Abandoned {
+    fn session_elapsed(started_at: Instant, _completed_at: Option<Instant>) -> Duration {
+        started_at.elapsed()
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -80,5 +109,42 @@ mod tests {
         let _active = format!("{:?}", Active);
         let _completed = format!("{:?}", Completed);
         let _abandoned = format!("{:?}", Abandoned);
+    }
+
+    #[test]
+    fn test_active_session_elapsed_measures_since_start() {
+        let started_at = Instant::now() - Duration::from_millis(50);
+        let elapsed = Active::session_elapsed(started_at, None);
+        assert!(elapsed >= Duration::from_millis(50));
+    }
+
+    #[test]
+    fn test_active_session_elapsed_ignores_completed_at() {
+        let started_at = Instant::now() - Duration::from_millis(50);
+        let completed_at = Some(Instant::now());
+        let elapsed = Active::session_elapsed(started_at, completed_at);
+        assert!(elapsed >= Duration::from_millis(50));
+    }
+
+    #[test]
+    fn test_completed_session_elapsed_uses_fixed_duration() {
+        let started_at = Instant::now();
+        let completed_at = started_at + Duration::from_millis(30);
+        let elapsed = Completed::session_elapsed(started_at, Some(completed_at));
+        assert_eq!(elapsed, Duration::from_millis(30));
+    }
+
+    #[test]
+    fn test_completed_session_elapsed_falls_back_to_now_when_missing() {
+        let started_at = Instant::now() - Duration::from_millis(20);
+        let elapsed = Completed::session_elapsed(started_at, None);
+        assert!(elapsed >= Duration::from_millis(20));
+    }
+
+    #[test]
+    fn test_abandoned_session_elapsed_measures_since_start() {
+        let started_at = Instant::now() - Duration::from_millis(20);
+        let elapsed = Abandoned::session_elapsed(started_at, None);
+        assert!(elapsed >= Duration::from_millis(20));
     }
 }


### PR DESCRIPTION
## Summary
- Collapsed the duplicated `PlayableScenario` trait impls for `GameSession<Active>` and `GameSession<Completed>` (~65 near-identical lines each) into a single `impl<S: SessionState> PlayableScenario for GameSession<S>` block.
- The one method that genuinely differed per state (`elapsed()`) is now dispatched through a new `SessionState::session_elapsed` associated function, implemented per marker type (Active, Completed, Abandoned).
- `action_count`/`is_insert_mode` now delegate to the existing inherent methods instead of duplicating their logic.
- As a side effect of genericizing the impl, `GameSession<Abandoned>` now also implements `PlayableScenario`, matching the issue's suggested signature; nothing in the codebase relies on its prior absence.

Fixes #280

## Test plan
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (1850 passed, 0 failed)
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] Added 5 direct unit tests for `SessionState::session_elapsed` (one per marker: Active, Completed, Abandoned)
- [x] Added a UFCS-based regression test (`PlayableScenario::elapsed(&completed)`) proving the `Completed` duration is frozen and not silently re-testing the inherent method