### PR TITLE
refactor(minigame): dedupe streak/multiplier tier table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Setup` and `TargetState` now share their cursor/selection fields and logic through a single `CursorSpec` type (`#[serde(flatten)]`) instead of duplicating both; scenario TOML files are unaffected (#268)
 - Quest templates now use a single adjacently-tagged `QuestSpec` enum instead of a separate `type` discriminator and untagged `params` enum, making a `type`/`params` mismatch a deserialization error instead of a runtime-only check; quest TOML files are unaffected (#274)
+- **BREAKING**: `MiniGameStats` now embeds `MultiplierState` as its sole owner of the streak/multiplier tier table instead of duplicating it; the `multiplier`, `streak`, and `best_streak` fields are removed (read them via the new `multiplier()`, `streak()`, `best_streak()` accessors), and `lives`/`level` are now private with `lives()`/`level()` accessors. `MiniGameStats`'s `Serialize`/`Deserialize` wire format changes accordingly (three scalar fields become a nested `multiplier_state` object); nothing in-tree persists `MiniGameStats` today. `MiniGameStats::increase_streak`/`reset_streak`/`calculate_multiplier` and `MiniGameSession::multiplier_state`/`streak_for_next_tier` are removed as dead duplicate paths (#259)
 
 ### Fixed
 

--- a/src/minigame/session.rs
+++ b/src/minigame/session.rs
@@ -10,7 +10,7 @@ use crate::helix::{AnyModeSimulator, EditorSnapshot};
 use crate::learning::PerformanceTracker;
 use crate::minigame::{
     DifficultyController, LevelChange, MiniGameMode, MiniGameState, MiniGameStats,
-    MultiplierChange, MultiplierState, PerformancePoint, ScoreBreakdown, ScoreCalculator,
+    MultiplierChange, PerformancePoint, ScoreBreakdown, ScoreCalculator,
     select_challenge_scenarios,
 };
 use crate::security::UserError;
@@ -253,9 +253,6 @@ pub struct MiniGameSession {
     /// Score calculator with combo tracking
     score_calculator: ScoreCalculator,
 
-    /// Multiplier state with grace mechanics
-    multiplier_state: MultiplierState,
-
     /// Last score breakdown (for UI display)
     last_score_breakdown: Option<ScoreBreakdown>,
 
@@ -335,7 +332,7 @@ impl MiniGameSession {
     /// // Create Survival mode session
     /// let mode = MiniGameMode::Survival(SurvivalConfig::default());
     /// let session = MiniGameSession::with_mode(scenarios, None, mode);
-    /// assert_eq!(session.stats().lives, 1); // Survival mode has 1 life
+    /// assert_eq!(session.stats().lives(), 1); // Survival mode has 1 life
     /// ```
     pub fn with_mode(
         scenarios: Arc<Vec<Scenario>>,
@@ -356,7 +353,6 @@ impl MiniGameSession {
             stats: MiniGameStats::new_with_lives(starting_lives),
             difficulty: DifficultyController::new(),
             score_calculator: ScoreCalculator::new(),
-            multiplier_state: MultiplierState::new(),
             last_score_breakdown: None,
             state: MiniGameState::default(),
             scenarios,
@@ -503,13 +499,9 @@ impl MiniGameSession {
                 .and_then(|m| m.difficulty)
                 .unwrap_or(Difficulty::Beginner);
 
-            // Update multiplier state (handles streak, grace, milestones)
-            self.multiplier_state.record_success();
-
-            // Sync multiplier to stats for scoring and display
-            self.stats.multiplier = self.multiplier_state.current();
-            self.stats.streak = self.multiplier_state.streak();
-            self.stats.best_streak = self.multiplier_state.best_streak();
+            // Update completion counter and multiplier state (streak, grace, milestones).
+            // Must precede scoring: the new multiplier feeds `calculate` and `add_score`.
+            self.stats.record_completion();
 
             // Calculate score using enhanced ScoreCalculator
             let base_points = self.base_points_for(scenario);
@@ -518,7 +510,7 @@ impl MiniGameSession {
                 time_ratio,
                 efficiency,
                 scenario_difficulty,
-                self.multiplier_state.current(),
+                self.stats.multiplier(),
             );
 
             // Store breakdown for UI display
@@ -526,9 +518,6 @@ impl MiniGameSession {
 
             // Award points (total already includes difficulty multiplier)
             self.stats.add_score(breakdown.total);
-
-            // Update completion counter
-            self.stats.record_completion();
 
             // Create performance point with full data
             let performance_point =
@@ -593,18 +582,11 @@ impl MiniGameSession {
     /// session.handle_timeout();
     /// ```
     pub fn handle_timeout(&mut self) {
-        // Update multiplier state (handles grace mechanics)
-        self.multiplier_state.record_failure();
-
-        // Sync multiplier to stats
-        self.stats.multiplier = self.multiplier_state.current();
-        self.stats.streak = self.multiplier_state.streak();
+        // Update multiplier state (handles grace mechanics) and failure counter
+        self.stats.record_failure();
 
         // Lose life
         let has_lives = self.stats.lose_life();
-
-        // Update statistics
-        self.stats.record_failure();
 
         // Reset combo via score calculator
         let breakdown = self.score_calculator.calculate_failure();
@@ -806,28 +788,16 @@ impl MiniGameSession {
         self.score_calculator.best_combo()
     }
 
-    /// Get reference to multiplier state
-    pub fn multiplier_state(&self) -> &MultiplierState {
-        &self.multiplier_state
-    }
-
     /// Take multiplier change event (for UI animations)
     ///
     /// Returns the change event if one occurred since last call.
     pub fn take_multiplier_change(&mut self) -> Option<MultiplierChange> {
-        self.multiplier_state.take_change()
-    }
-
-    /// Get streak count needed for next multiplier tier
-    ///
-    /// Returns None if already at maximum tier.
-    pub fn streak_for_next_tier(&self) -> Option<u32> {
-        self.multiplier_state.streak_for_next_tier()
+        self.stats.take_multiplier_change()
     }
 
     /// Get grace failures remaining
     pub fn grace_remaining(&self) -> u8 {
-        self.multiplier_state.grace_remaining()
+        self.stats.grace_remaining()
     }
 
     /// Record commands from completed scenario for FSRS learning
@@ -993,11 +963,11 @@ impl MiniGameSession {
         match &self.mode {
             MiniGameMode::Arcade(_) | MiniGameMode::Survival(_) => {
                 // Lives depleted
-                self.stats.lives == 0
+                self.stats.is_game_over()
             }
             MiniGameMode::Challenge(config) => {
                 // Lives depleted or all scenarios completed
-                self.stats.lives == 0
+                self.stats.is_game_over()
                     || self.stats.scenarios_completed >= config.scenario_count as u32
             }
         }
@@ -1052,7 +1022,7 @@ mod tests {
 
         let session = MiniGameSession::new(scenarios, None);
 
-        assert_eq!(session.stats.lives, 3);
+        assert_eq!(session.stats.lives(), 3);
         assert_eq!(session.stats.score, 0);
         assert!(session.state.is_countdown());
         assert_eq!(session.queue.len(), QUEUE_SIZE);
@@ -1083,16 +1053,16 @@ mod tests {
         session.state = MiniGameState::Playing;
         let _ = session.load_next_scenario();
 
-        assert_eq!(session.stats.lives, 3);
+        assert_eq!(session.stats.lives(), 3);
 
         session.handle_timeout();
-        assert_eq!(session.stats.lives, 2);
+        assert_eq!(session.stats.lives(), 2);
 
         session.handle_timeout();
-        assert_eq!(session.stats.lives, 1);
+        assert_eq!(session.stats.lives(), 1);
 
         session.handle_timeout();
-        assert_eq!(session.stats.lives, 0);
+        assert_eq!(session.stats.lives(), 0);
         assert!(session.state.is_game_over());
     }
 
@@ -1216,13 +1186,12 @@ mod tests {
         let mut stats = MiniGameStats::new();
 
         assert_eq!(stats.scenarios_completed, 0);
-        assert_eq!(stats.streak, 0);
+        assert_eq!(stats.streak(), 0);
 
         stats.record_completion();
-        stats.increase_streak();
 
         assert_eq!(stats.scenarios_completed, 1);
-        assert_eq!(stats.streak, 1);
+        assert_eq!(stats.streak(), 1);
     }
 
     #[test]
@@ -1239,11 +1208,13 @@ mod tests {
         session.tick_countdown();
         session.tick_countdown();
 
-        // Manually set streak high
-        session.stats.streak = 5;
+        // Build up a real streak
+        for _ in 0..5 {
+            session.stats.record_completion();
+        }
         session.handle_timeout();
 
-        assert_eq!(session.stats().streak, 0);
+        assert_eq!(session.stats().streak(), 0);
     }
 
     #[test]
@@ -1325,7 +1296,7 @@ mod tests {
         let mode = MiniGameMode::Survival(SurvivalConfig::default());
         let session = MiniGameSession::with_mode(scenarios, None, mode);
 
-        assert_eq!(session.stats().lives, 1);
+        assert_eq!(session.stats().lives(), 1);
         assert!(session.mode().is_survival());
     }
 
@@ -1347,7 +1318,7 @@ mod tests {
         // Single timeout should end the game
         session.handle_timeout();
 
-        assert_eq!(session.stats().lives, 0);
+        assert_eq!(session.stats().lives(), 0);
         assert!(session.state().is_game_over());
     }
 
@@ -1361,7 +1332,7 @@ mod tests {
         let mode = MiniGameMode::Challenge(ChallengeConfig::for_today());
         let session = MiniGameSession::with_mode(scenarios, None, mode);
 
-        assert_eq!(session.stats().lives, 3);
+        assert_eq!(session.stats().lives(), 3);
         assert!(session.mode().is_challenge());
     }
 
@@ -1391,7 +1362,7 @@ mod tests {
         // Default constructor uses Arcade mode
         let session = MiniGameSession::new(scenarios, None);
 
-        assert_eq!(session.stats().lives, 3);
+        assert_eq!(session.stats().lives(), 3);
         assert!(session.mode().is_arcade());
         assert!(session.mode().has_session_timer());
     }
@@ -1416,7 +1387,7 @@ mod tests {
         assert!(!session.check_game_over());
 
         // Game over when lives depleted
-        session.stats.lives = 0;
+        while session.stats.lose_life() {}
         assert!(session.check_game_over());
     }
 
@@ -1439,7 +1410,7 @@ mod tests {
 
         // Also game over when lives depleted
         session.stats.scenarios_completed = 5;
-        session.stats.lives = 0;
+        while session.stats.lose_life() {}
         assert!(session.check_game_over());
         assert!(!session.is_challenge_complete());
     }

--- a/src/minigame/stats.rs
+++ b/src/minigame/stats.rs
@@ -173,23 +173,20 @@ impl Default for MultiplierState {
 /// Game statistics for mini-game mode
 ///
 /// Tracks all metrics needed for arcade-style gameplay including score,
-/// lives, combo multiplier, and streak tracking.
+/// lives, combo multiplier, and streak tracking. The multiplier/streak
+/// tier table lives solely in [`MultiplierState`], embedded here as the
+/// single source of truth — read it through the `multiplier()`, `streak()`,
+/// `best_streak()`, and `grace_remaining()` accessors.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MiniGameStats {
     /// Current score
     pub score: u64,
 
     /// Remaining lives (0-5)
-    pub lives: u8,
-
-    /// Current score multiplier (1.0 to 5.0)
-    pub multiplier: f64,
-
-    /// Current consecutive completions streak
-    pub streak: u32,
+    lives: u8,
 
     /// Current difficulty level (1-10)
-    pub level: u32,
+    level: u32,
 
     /// Total scenarios completed this session
     pub scenarios_completed: u32,
@@ -197,8 +194,8 @@ pub struct MiniGameStats {
     /// Total scenarios failed this session
     pub scenarios_failed: u32,
 
-    /// Best streak achieved this session
-    pub best_streak: u32,
+    /// Multiplier/streak tier table (sole owner of streak state)
+    multiplier_state: MultiplierState,
 }
 
 impl MiniGameStats {
@@ -216,8 +213,8 @@ impl MiniGameStats {
     /// use helix_trainer::minigame::MiniGameStats;
     ///
     /// let stats = MiniGameStats::new();
-    /// assert_eq!(stats.lives, 3);
-    /// assert_eq!(stats.multiplier, 1.0);
+    /// assert_eq!(stats.lives(), 3);
+    /// assert_eq!(stats.multiplier(), 1.0);
     /// ```
     pub fn new() -> Self {
         Self::default()
@@ -236,14 +233,51 @@ impl MiniGameStats {
     /// use helix_trainer::minigame::MiniGameStats;
     ///
     /// let stats = MiniGameStats::new_with_lives(1);
-    /// assert_eq!(stats.lives, 1);
-    /// assert_eq!(stats.multiplier, 1.0);
+    /// assert_eq!(stats.lives(), 1);
+    /// assert_eq!(stats.multiplier(), 1.0);
     /// ```
     pub fn new_with_lives(lives: u8) -> Self {
         Self {
             lives,
             ..Self::default()
         }
+    }
+
+    /// Get remaining lives
+    pub fn lives(&self) -> u8 {
+        self.lives
+    }
+
+    /// Get current difficulty level
+    pub fn level(&self) -> u32 {
+        self.level
+    }
+
+    /// Get current score multiplier
+    pub fn multiplier(&self) -> f64 {
+        self.multiplier_state.current()
+    }
+
+    /// Get current consecutive completions streak
+    pub fn streak(&self) -> u32 {
+        self.multiplier_state.streak()
+    }
+
+    /// Get best streak achieved this session
+    pub fn best_streak(&self) -> u32 {
+        self.multiplier_state.best_streak()
+    }
+
+    /// Get remaining grace failures (protects the multiplier from resetting)
+    pub fn grace_remaining(&self) -> u8 {
+        self.multiplier_state.grace_remaining()
+    }
+
+    /// Take the recent multiplier change event (consumes it)
+    ///
+    /// Returns the change event if one occurred since last call.
+    pub fn take_multiplier_change(&mut self) -> Option<MultiplierChange> {
+        self.multiplier_state.take_change()
     }
 
     /// Increase score by points with current multiplier applied
@@ -254,96 +288,15 @@ impl MiniGameStats {
     /// use helix_trainer::minigame::MiniGameStats;
     ///
     /// let mut stats = MiniGameStats::new();
-    /// stats.multiplier = 2.0;
+    /// for _ in 0..6 {
+    ///     stats.record_completion();
+    /// }
     /// stats.add_score(100);
     /// assert_eq!(stats.score, 200);
     /// ```
     pub fn add_score(&mut self, points: u64) {
-        let multiplied = (points as f64 * self.multiplier) as u64;
+        let multiplied = (points as f64 * self.multiplier_state.current()) as u64;
         self.score = self.score.saturating_add(multiplied);
-    }
-
-    /// Increase streak and update multiplier
-    ///
-    /// Multiplier tiers:
-    /// - 0-2: 1.0x
-    /// - 3-5: 1.5x
-    /// - 6-9: 2.0x
-    /// - 10-14: 2.5x
-    /// - 15-24: 3.0x
-    /// - 25-39: 4.0x
-    /// - 40+: 5.0x (max)
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use helix_trainer::minigame::MiniGameStats;
-    ///
-    /// let mut stats = MiniGameStats::new();
-    /// stats.increase_streak();
-    /// assert_eq!(stats.streak, 1);
-    /// assert_eq!(stats.multiplier, 1.0);
-    ///
-    /// for _ in 0..5 {
-    ///     stats.increase_streak();
-    /// }
-    /// assert_eq!(stats.streak, 6);
-    /// assert_eq!(stats.multiplier, 2.0);
-    /// ```
-    pub fn increase_streak(&mut self) {
-        self.streak = self.streak.saturating_add(1);
-        if self.streak > self.best_streak {
-            self.best_streak = self.streak;
-        }
-        self.update_multiplier();
-    }
-
-    /// Reset streak and multiplier (on failure/timeout)
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use helix_trainer::minigame::MiniGameStats;
-    ///
-    /// let mut stats = MiniGameStats::new();
-    /// stats.streak = 10;
-    /// stats.multiplier = 2.5;
-    /// stats.reset_streak();
-    /// assert_eq!(stats.streak, 0);
-    /// assert_eq!(stats.multiplier, 1.0);
-    /// ```
-    pub fn reset_streak(&mut self) {
-        self.streak = 0;
-        self.multiplier = 1.0;
-    }
-
-    /// Update multiplier based on current streak
-    fn update_multiplier(&mut self) {
-        self.multiplier = Self::calculate_multiplier(self.streak);
-    }
-
-    /// Calculate multiplier based on streak
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use helix_trainer::minigame::MiniGameStats;
-    ///
-    /// assert_eq!(MiniGameStats::calculate_multiplier(0), 1.0);
-    /// assert_eq!(MiniGameStats::calculate_multiplier(3), 1.5);
-    /// assert_eq!(MiniGameStats::calculate_multiplier(10), 2.5);
-    /// assert_eq!(MiniGameStats::calculate_multiplier(40), 5.0);
-    /// ```
-    pub fn calculate_multiplier(streak: u32) -> f64 {
-        match streak {
-            0..=2 => 1.0,
-            3..=5 => 1.5,
-            6..=9 => 2.0,
-            10..=14 => 2.5,
-            15..=24 => 3.0,
-            25..=39 => 4.0,
-            _ => 5.0, // 40+ is max
-        }
     }
 
     /// Lose a life
@@ -378,7 +331,7 @@ impl MiniGameStats {
     ///
     /// let mut stats = MiniGameStats::new();
     /// stats.gain_life();
-    /// assert_eq!(stats.lives, 4);
+    /// assert_eq!(stats.lives(), 4);
     /// ```
     pub fn gain_life(&mut self) {
         if self.lives < 5 {
@@ -395,7 +348,7 @@ impl MiniGameStats {
     ///
     /// let mut stats = MiniGameStats::new();
     /// assert!(!stats.is_game_over());
-    /// stats.lives = 0;
+    /// while stats.lose_life() {}
     /// assert!(stats.is_game_over());
     /// ```
     pub fn is_game_over(&self) -> bool {
@@ -403,6 +356,9 @@ impl MiniGameStats {
     }
 
     /// Record a scenario completion
+    ///
+    /// Advances the multiplier/streak tier table (see [`MultiplierState::record_success`])
+    /// and increments the completion counter.
     ///
     /// # Examples
     ///
@@ -412,12 +368,17 @@ impl MiniGameStats {
     /// let mut stats = MiniGameStats::new();
     /// stats.record_completion();
     /// assert_eq!(stats.scenarios_completed, 1);
+    /// assert_eq!(stats.streak(), 1);
     /// ```
     pub fn record_completion(&mut self) {
+        self.multiplier_state.record_success();
         self.scenarios_completed = self.scenarios_completed.saturating_add(1);
     }
 
     /// Record a scenario failure
+    ///
+    /// Consumes grace if available, otherwise resets the streak/multiplier
+    /// (see [`MultiplierState::record_failure`]), and increments the failure counter.
     ///
     /// # Examples
     ///
@@ -429,6 +390,7 @@ impl MiniGameStats {
     /// assert_eq!(stats.scenarios_failed, 1);
     /// ```
     pub fn record_failure(&mut self) {
+        self.multiplier_state.record_failure();
         self.scenarios_failed = self.scenarios_failed.saturating_add(1);
     }
 
@@ -443,7 +405,7 @@ impl MiniGameStats {
     ///
     /// let mut stats = MiniGameStats::new();
     /// stats.increase_level();
-    /// assert_eq!(stats.level, 2);
+    /// assert_eq!(stats.level(), 2);
     /// ```
     pub fn increase_level(&mut self) {
         if self.level < 10 {
@@ -461,9 +423,12 @@ impl MiniGameStats {
     /// use helix_trainer::minigame::MiniGameStats;
     ///
     /// let mut stats = MiniGameStats::new();
-    /// stats.level = 5;
+    /// stats.increase_level();
+    /// stats.increase_level();
+    /// stats.increase_level();
+    /// stats.increase_level();
     /// stats.decrease_level();
-    /// assert_eq!(stats.level, 4);
+    /// assert_eq!(stats.level(), 4);
     /// ```
     pub fn decrease_level(&mut self) {
         if self.level > 1 {
@@ -477,12 +442,10 @@ impl Default for MiniGameStats {
         Self {
             score: 0,
             lives: 3,
-            multiplier: 1.0,
-            streak: 0,
             level: 1,
             scenarios_completed: 0,
             scenarios_failed: 0,
-            best_streak: 0,
+            multiplier_state: MultiplierState::new(),
         }
     }
 }
@@ -495,10 +458,10 @@ mod tests {
     fn test_new_stats() {
         let stats = MiniGameStats::new();
         assert_eq!(stats.score, 0);
-        assert_eq!(stats.lives, 3);
-        assert_eq!(stats.multiplier, 1.0);
-        assert_eq!(stats.streak, 0);
-        assert_eq!(stats.level, 1);
+        assert_eq!(stats.lives(), 3);
+        assert_eq!(stats.multiplier(), 1.0);
+        assert_eq!(stats.streak(), 0);
+        assert_eq!(stats.level(), 1);
     }
 
     #[test]
@@ -507,101 +470,44 @@ mod tests {
         stats.add_score(100);
         assert_eq!(stats.score, 100);
 
-        stats.multiplier = 2.0;
+        for _ in 0..6 {
+            stats.record_completion();
+        }
+        assert_eq!(stats.multiplier(), 2.0);
         stats.add_score(100);
         assert_eq!(stats.score, 300); // 100 + (100 * 2.0)
     }
 
     #[test]
-    fn test_streak_increases_multiplier() {
-        let mut stats = MiniGameStats::new();
-
-        // 0-2: 1.0x
-        assert_eq!(stats.multiplier, 1.0);
-
-        // 3-5: 1.5x
-        for _ in 0..3 {
-            stats.increase_streak();
-        }
-        assert_eq!(stats.streak, 3);
-        assert_eq!(stats.multiplier, 1.5);
-
-        // 6-9: 2.0x
-        for _ in 0..3 {
-            stats.increase_streak();
-        }
-        assert_eq!(stats.streak, 6);
-        assert_eq!(stats.multiplier, 2.0);
-
-        // 10-14: 2.5x
-        for _ in 0..4 {
-            stats.increase_streak();
-        }
-        assert_eq!(stats.streak, 10);
-        assert_eq!(stats.multiplier, 2.5);
-    }
-
-    #[test]
-    fn test_reset_streak() {
-        let mut stats = MiniGameStats::new();
-        stats.streak = 10;
-        stats.multiplier = 2.5;
-        stats.best_streak = 10;
-
-        stats.reset_streak();
-        assert_eq!(stats.streak, 0);
-        assert_eq!(stats.multiplier, 1.0);
-        assert_eq!(stats.best_streak, 10); // Best streak preserved
-    }
-
-    #[test]
     fn test_lose_life() {
         let mut stats = MiniGameStats::new();
-        assert_eq!(stats.lives, 3);
+        assert_eq!(stats.lives(), 3);
 
         assert!(stats.lose_life()); // 2 remain
-        assert_eq!(stats.lives, 2);
+        assert_eq!(stats.lives(), 2);
 
         assert!(stats.lose_life()); // 1 remains
-        assert_eq!(stats.lives, 1);
+        assert_eq!(stats.lives(), 1);
 
         assert!(!stats.lose_life()); // 0 remain, game over
-        assert_eq!(stats.lives, 0);
+        assert_eq!(stats.lives(), 0);
         assert!(stats.is_game_over());
     }
 
     #[test]
     fn test_gain_life() {
         let mut stats = MiniGameStats::new();
-        stats.lives = 2;
+        assert!(stats.lose_life()); // 3 -> 2
 
         stats.gain_life();
-        assert_eq!(stats.lives, 3);
+        assert_eq!(stats.lives(), 3);
 
         stats.gain_life();
         stats.gain_life();
-        assert_eq!(stats.lives, 5); // Max 5
+        assert_eq!(stats.lives(), 5); // Max 5
 
         stats.gain_life();
-        assert_eq!(stats.lives, 5); // Still 5
-    }
-
-    #[test]
-    fn test_calculate_multiplier() {
-        assert_eq!(MiniGameStats::calculate_multiplier(0), 1.0);
-        assert_eq!(MiniGameStats::calculate_multiplier(2), 1.0);
-        assert_eq!(MiniGameStats::calculate_multiplier(3), 1.5);
-        assert_eq!(MiniGameStats::calculate_multiplier(5), 1.5);
-        assert_eq!(MiniGameStats::calculate_multiplier(6), 2.0);
-        assert_eq!(MiniGameStats::calculate_multiplier(9), 2.0);
-        assert_eq!(MiniGameStats::calculate_multiplier(10), 2.5);
-        assert_eq!(MiniGameStats::calculate_multiplier(14), 2.5);
-        assert_eq!(MiniGameStats::calculate_multiplier(15), 3.0);
-        assert_eq!(MiniGameStats::calculate_multiplier(24), 3.0);
-        assert_eq!(MiniGameStats::calculate_multiplier(25), 4.0);
-        assert_eq!(MiniGameStats::calculate_multiplier(39), 4.0);
-        assert_eq!(MiniGameStats::calculate_multiplier(40), 5.0);
-        assert_eq!(MiniGameStats::calculate_multiplier(100), 5.0);
+        assert_eq!(stats.lives(), 5); // Still 5
     }
 
     #[test]
@@ -610,64 +516,43 @@ mod tests {
 
         stats.record_completion();
         assert_eq!(stats.scenarios_completed, 1);
+        assert_eq!(stats.streak(), 1);
 
         stats.record_failure();
         assert_eq!(stats.scenarios_failed, 1);
+        assert_eq!(stats.streak(), 0);
     }
 
     #[test]
     fn test_level_adjustment() {
         let mut stats = MiniGameStats::new();
-        assert_eq!(stats.level, 1);
+        assert_eq!(stats.level(), 1);
 
         stats.increase_level();
-        assert_eq!(stats.level, 2);
+        assert_eq!(stats.level(), 2);
 
         stats.decrease_level();
-        assert_eq!(stats.level, 1);
+        assert_eq!(stats.level(), 1);
 
         stats.decrease_level();
-        assert_eq!(stats.level, 1); // Min 1
+        assert_eq!(stats.level(), 1); // Min 1
 
         for _ in 0..20 {
             stats.increase_level();
         }
-        assert_eq!(stats.level, 10); // Max 10
-    }
-
-    #[test]
-    fn test_best_streak_tracking() {
-        let mut stats = MiniGameStats::new();
-
-        for _ in 0..5 {
-            stats.increase_streak();
-        }
-        assert_eq!(stats.best_streak, 5);
-
-        stats.reset_streak();
-        assert_eq!(stats.best_streak, 5);
-
-        for _ in 0..3 {
-            stats.increase_streak();
-        }
-        assert_eq!(stats.best_streak, 5); // Still 5
-
-        for _ in 0..3 {
-            stats.increase_streak();
-        }
-        assert_eq!(stats.best_streak, 6); // New record
+        assert_eq!(stats.level(), 10); // Max 10
     }
 
     #[test]
     fn test_new_with_lives() {
         let stats = MiniGameStats::new_with_lives(1);
-        assert_eq!(stats.lives, 1);
+        assert_eq!(stats.lives(), 1);
         assert_eq!(stats.score, 0);
-        assert_eq!(stats.multiplier, 1.0);
-        assert_eq!(stats.level, 1);
+        assert_eq!(stats.multiplier(), 1.0);
+        assert_eq!(stats.level(), 1);
 
         let stats = MiniGameStats::new_with_lives(5);
-        assert_eq!(stats.lives, 5);
+        assert_eq!(stats.lives(), 5);
     }
 
     // CR-009: Test new_with_lives boundary values
@@ -675,17 +560,17 @@ mod tests {
     fn test_new_with_lives_boundary_values() {
         // Zero lives - immediately game over
         let stats_zero = MiniGameStats::new_with_lives(0);
-        assert_eq!(stats_zero.lives, 0);
+        assert_eq!(stats_zero.lives(), 0);
         assert!(stats_zero.is_game_over());
 
         // Default arcade lives
         let stats_three = MiniGameStats::new_with_lives(3);
-        assert_eq!(stats_three.lives, 3);
+        assert_eq!(stats_three.lives(), 3);
         assert!(!stats_three.is_game_over());
 
         // Maximum u8 value
         let stats_max = MiniGameStats::new_with_lives(u8::MAX);
-        assert_eq!(stats_max.lives, u8::MAX);
+        assert_eq!(stats_max.lives(), u8::MAX);
         assert!(!stats_max.is_game_over());
     }
 
@@ -736,7 +621,12 @@ mod tests {
             state.record_failure();
             assert_eq!(state.best_streak(), 5);
 
-            for _ in 0..6 {
+            for _ in 0..3 {
+                state.record_success();
+            }
+            assert_eq!(state.best_streak(), 5); // Shorter rebuild does not overwrite
+
+            for _ in 0..3 {
                 state.record_success();
             }
             assert_eq!(state.best_streak(), 6);

--- a/src/minigame/tests.rs
+++ b/src/minigame/tests.rs
@@ -105,19 +105,64 @@ fn test_difficulty_adapts_to_performance() {
 }
 
 #[test]
-fn test_streak_increases_multiplier() {
-    let mut stats = MiniGameStats::new();
+fn test_advance_to_next_drives_streak_and_multiplier() {
+    let scenarios = Arc::new(vec![
+        create_simple_scenario("s1"),
+        create_simple_scenario("s2"),
+        create_simple_scenario("s3"),
+    ]);
 
-    // Initially 1.0x
-    assert_eq!(stats.multiplier, 1.0);
+    let mut session = MiniGameSession::new(scenarios, None);
 
-    // Build streak
-    for i in 1..=6 {
-        stats.increase_streak();
-        if i >= 6 {
-            assert_eq!(stats.multiplier, 2.0);
-        }
+    session.start();
+    session.tick_countdown();
+    session.tick_countdown();
+    session.tick_countdown();
+
+    // Drive real completions through the production path (advance_to_next +
+    // complete_transition), not direct MiniGameStats writes, to prove the
+    // deleted session-level sync is no longer needed for the streak/
+    // multiplier tier table to advance correctly.
+    for _ in 0..6 {
+        session.advance_to_next();
+        let _ = session.complete_transition();
     }
+
+    assert_eq!(session.stats().streak(), 6);
+    assert_eq!(session.stats().best_streak(), 6);
+    assert!((session.stats().multiplier() - 2.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn test_handle_timeout_after_real_streak_uses_grace() {
+    let scenarios = Arc::new(vec![
+        create_simple_scenario("s1"),
+        create_simple_scenario("s2"),
+        create_simple_scenario("s3"),
+    ]);
+
+    let mut session = MiniGameSession::new(scenarios, None);
+
+    session.start();
+    session.tick_countdown();
+    session.tick_countdown();
+    session.tick_countdown();
+
+    // Reach the streak-10 milestone through the real advance_to_next path so
+    // grace is granted by MultiplierState, then fail immediately: grace
+    // should protect the streak instead of resetting it.
+    for _ in 0..10 {
+        session.advance_to_next();
+        let _ = session.complete_transition();
+    }
+    assert_eq!(session.stats().grace_remaining(), 1);
+    let multiplier_before = session.stats().multiplier();
+
+    session.handle_timeout();
+
+    assert_eq!(session.stats().streak(), 10);
+    assert_eq!(session.stats().grace_remaining(), 0);
+    assert!((session.stats().multiplier() - multiplier_before).abs() < f64::EPSILON);
 }
 
 #[test]
@@ -137,7 +182,7 @@ fn test_game_over_when_lives_depleted() {
     }
 
     assert!(session.state().is_game_over());
-    assert_eq!(session.stats().lives, 0);
+    assert_eq!(session.stats().lives(), 0);
 }
 
 #[test]
@@ -185,12 +230,12 @@ fn test_pause_and_resume() {
 fn test_stats_initial_values() {
     let stats = MiniGameStats::new();
     assert_eq!(stats.score, 0);
-    assert_eq!(stats.lives, 3);
-    assert_eq!(stats.streak, 0);
-    assert_eq!(stats.best_streak, 0);
+    assert_eq!(stats.lives(), 3);
+    assert_eq!(stats.streak(), 0);
+    assert_eq!(stats.best_streak(), 0);
     assert_eq!(stats.scenarios_completed, 0);
     assert_eq!(stats.scenarios_failed, 0);
-    assert_eq!(stats.multiplier, 1.0);
+    assert_eq!(stats.multiplier(), 1.0);
 }
 
 #[test]
@@ -206,51 +251,20 @@ fn test_stats_add_score() {
 #[test]
 fn test_stats_lose_life() {
     let mut stats = MiniGameStats::new();
-    assert_eq!(stats.lives, 3);
+    assert_eq!(stats.lives(), 3);
 
     assert!(stats.lose_life()); // Still has lives
-    assert_eq!(stats.lives, 2);
+    assert_eq!(stats.lives(), 2);
 
     assert!(stats.lose_life()); // Still has lives
-    assert_eq!(stats.lives, 1);
+    assert_eq!(stats.lives(), 1);
 
     assert!(!stats.lose_life()); // Game over
-    assert_eq!(stats.lives, 0);
+    assert_eq!(stats.lives(), 0);
 
     // Can't go below 0
     assert!(!stats.lose_life());
-    assert_eq!(stats.lives, 0);
-}
-
-#[test]
-fn test_stats_max_streak_tracking() {
-    let mut stats = MiniGameStats::new();
-
-    // Build streak
-    for _ in 0..5 {
-        stats.increase_streak();
-    }
-    assert_eq!(stats.streak, 5);
-    assert_eq!(stats.best_streak, 5);
-
-    // Reset streak (not from lose_life, using reset_streak)
-    stats.reset_streak();
-    assert_eq!(stats.streak, 0);
-    assert_eq!(stats.best_streak, 5); // Max preserved
-
-    // Build new streak
-    for _ in 0..3 {
-        stats.increase_streak();
-    }
-    assert_eq!(stats.streak, 3);
-    assert_eq!(stats.best_streak, 5); // Max still preserved
-
-    // Exceeding best_streak updates it
-    for _ in 0..5 {
-        stats.increase_streak();
-    }
-    assert_eq!(stats.streak, 8);
-    assert_eq!(stats.best_streak, 8); // Updated
+    assert_eq!(stats.lives(), 0);
 }
 
 #[test]
@@ -323,19 +337,6 @@ fn test_session_with_empty_scenarios() {
 
     // Should handle empty scenario list gracefully
     assert!(session.current_scenario().is_none());
-}
-
-#[test]
-fn test_multiplier_capped_at_max() {
-    let mut stats = MiniGameStats::new();
-
-    // Build streak way beyond cap
-    for _ in 0..100 {
-        stats.increase_streak();
-    }
-
-    // Multiplier should be capped at 5.0 (based on the actual implementation)
-    assert_eq!(stats.multiplier, 5.0);
 }
 
 #[test]

--- a/src/ui/render/minigame.rs
+++ b/src/ui/render/minigame.rs
@@ -267,7 +267,7 @@ fn render_stats_bar(frame: &mut Frame, area: Rect, session: &crate::minigame::Mi
 
     // Lives as hearts
     let lives_str: String = (0..5)
-        .map(|i| if i < stats.lives { '♥' } else { '♡' })
+        .map(|i| if i < stats.lives() { '♥' } else { '♡' })
         .collect();
 
     // Grace indicator (shield when available)
@@ -275,7 +275,7 @@ fn render_stats_bar(frame: &mut Frame, area: Rect, session: &crate::minigame::Mi
     let grace_str = if grace > 0 { " [G]" } else { "" };
 
     // Multiplier color based on value
-    let mult_color = match stats.multiplier as u32 {
+    let mult_color = match stats.multiplier() as u32 {
         0..=1 => Color::Gray,
         2 => Color::Green,
         3 => Color::Yellow,
@@ -297,7 +297,7 @@ fn render_stats_bar(frame: &mut Frame, area: Rect, session: &crate::minigame::Mi
         Span::raw("  "),
         Span::styled("MULT: ", Style::default().fg(Color::Gray)),
         Span::styled(
-            format!("x{:.1}", stats.multiplier),
+            format!("x{:.1}", stats.multiplier()),
             Style::default().fg(mult_color).add_modifier(Modifier::BOLD),
         ),
         Span::styled(grace_str, Style::default().fg(Color::Cyan)),
@@ -322,7 +322,7 @@ fn render_stats_bar(frame: &mut Frame, area: Rect, session: &crate::minigame::Mi
         Span::raw("  "),
         Span::styled("STREAK: ", Style::default().fg(Color::Gray)),
         Span::styled(
-            format!("{:>2}", stats.streak),
+            format!("{:>2}", stats.streak()),
             Style::default()
                 .fg(Color::Green)
                 .add_modifier(Modifier::BOLD),
@@ -336,7 +336,7 @@ fn render_stats_bar(frame: &mut Frame, area: Rect, session: &crate::minigame::Mi
         Span::raw("  "),
         Span::styled("BEST: ", Style::default().fg(Color::Gray)),
         Span::styled(
-            format!("{}", stats.best_streak),
+            format!("{}", stats.best_streak()),
             Style::default().fg(Color::Green),
         ),
     ]);
@@ -484,7 +484,7 @@ fn render_game_over(frame: &mut Frame, area: Rect, session: &crate::minigame::Mi
         Line::from(vec![
             Span::styled("Best Streak: ", Style::default().fg(Color::Gray)),
             Span::styled(
-                format!("{}", stats.best_streak),
+                format!("{}", stats.best_streak()),
                 Style::default()
                     .fg(Color::Cyan)
                     .add_modifier(Modifier::BOLD),

--- a/src/ui/state/handlers/minigame.rs
+++ b/src/ui/state/handlers/minigame.rs
@@ -147,7 +147,7 @@ fn execute_minigame_command(state: &mut AppState, command: &str) -> Result<(), U
             .play(SoundEffect::ScenarioComplete);
 
         // Get current streak before advancing
-        let current_streak = session.stats().streak;
+        let current_streak = session.stats().streak();
 
         // Record to FSRS before advancing (only if we have actions)
         if let Some(scenario) = session.current_scenario() {
@@ -361,7 +361,7 @@ pub(in crate::ui::state) fn handle_minigame_game_over(
 
         // 2. Calculate XP earned
         use crate::gamification::XPCalculator;
-        let xp = XPCalculator::minigame_xp(stats.score, stats.level, stats.best_streak);
+        let xp = XPCalculator::minigame_xp(stats.score, stats.level(), stats.best_streak());
 
         // 3. Update profile with XP and high scores
         let profile = &mut state.progress.profile;
@@ -374,8 +374,8 @@ pub(in crate::ui::state) fn handle_minigame_game_over(
             new_high_score = true;
         }
 
-        if stats.best_streak > profile.minigame_best_streak {
-            profile.minigame_best_streak = stats.best_streak;
+        if stats.best_streak() > profile.minigame_best_streak {
+            profile.minigame_best_streak = stats.best_streak();
         }
 
         // Increment total games played counter
@@ -385,8 +385,8 @@ pub(in crate::ui::state) fn handle_minigame_game_over(
         tracing::info!(
             xp_earned = xp,
             score = stats.score,
-            level = stats.level,
-            streak = stats.best_streak,
+            level = stats.level(),
+            streak = stats.best_streak(),
             leveled_up = leveled_up,
             new_high_score = new_high_score,
             "Mini-game session completed"
@@ -694,8 +694,11 @@ mod tests {
         if let Some(ref mut session) = state.game.minigame_session {
             // Simulate game progress
             session.stats.score = 5000;
-            session.stats.level = 3;
-            session.stats.best_streak = 10;
+            session.stats.increase_level();
+            session.stats.increase_level();
+            for _ in 0..10 {
+                session.stats.record_completion();
+            }
         }
 
         // Trigger game over
@@ -1290,7 +1293,9 @@ mod tests {
             session.tick_countdown();
             session.tick_countdown();
             session.tick_countdown();
-            session.stats.best_streak = 15;
+            for _ in 0..15 {
+                session.stats.record_completion();
+            }
         }
 
         handle_minigame_game_over(&mut state).unwrap();

--- a/src/ui/state/handlers/mode_selection.rs
+++ b/src/ui/state/handlers/mode_selection.rs
@@ -422,7 +422,10 @@ mod tests {
 
         // Verify session is created with 1 life
         assert!(ctx.game.minigame_session.is_some());
-        assert_eq!(ctx.game.minigame_session.as_ref().unwrap().stats().lives, 1);
+        assert_eq!(
+            ctx.game.minigame_session.as_ref().unwrap().stats().lives(),
+            1
+        );
     }
 
     #[test]
@@ -441,7 +444,10 @@ mod tests {
 
         // Verify session is created with 3 lives
         assert!(ctx.game.minigame_session.is_some());
-        assert_eq!(ctx.game.minigame_session.as_ref().unwrap().stats().lives, 3);
+        assert_eq!(
+            ctx.game.minigame_session.as_ref().unwrap().stats().lives(),
+            3
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `MultiplierState` becomes the single source of truth for the streak/multiplier/best_streak tier table and grace/milestone mechanics, embedded as a private field of `MiniGameStats` instead of a byte-for-byte duplicate copy.
- `MiniGameSession` no longer holds a separate `multiplier_state` field or manually syncs it into `stats` after every turn; `advance_to_next`/`handle_timeout` now call `stats.record_completion()`/`stats.record_failure()` directly.
- `MiniGameStats.lives`/`.level` are now private with `lives()`/`level()` accessors, matching the same encapsulation as the multiplier state (documented bounds are now enforced by field privacy, not just by convention).
- Dead duplicate methods removed: `MiniGameStats::calculate_multiplier`/`update_multiplier`/`increase_streak`/`reset_streak`, and the now-unused `MiniGameSession::multiplier_state()`/`streak_for_next_tier()` accessors.
- Added two integration tests driving the real `advance_to_next()`/`handle_timeout()` path end-to-end (previously all coverage went through `MiniGameStats` directly, so nothing exercised the removed sync path).

This is a behavior-preserving refactor; production already drove gameplay exclusively through `MultiplierState`, so the only functional change is that the dead legacy field trio can no longer silently drift from it. `MiniGameStats` is a `pub` re-exported type, so this is a documented breaking change in `CHANGELOG.md`.

Fixes #259

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (1843/1843 passed)
- [x] `cargo test --doc`
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`