### PR TITLE
refactor: introduce Clock abstraction for deterministic time-dependent tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `src/time.rs` module: `Clock` trait abstraction over the current time, with a `SystemClock` production implementation and a `FakeClock` for deterministic tests (#269)
+
 ### Changed
 
+- **BREAKING**: Introduced a `Clock` abstraction (`helix_trainer::time::Clock`/`SystemClock`/`FakeClock`) so day-boundary and scheduling logic no longer calls `chrono::Utc::now()` directly, enabling deterministic tests (#269):
+  - `PerformanceTracker` and `Scheduler` now hold an injected `clock: Arc<dyn Clock>`; `new()` defaults to `SystemClock`, `with_clock()` accepts an explicit clock. `PerformanceTracker::from_stats_with_clock` added alongside `from_stats`; `PerformanceTracker::set_clock` added so an existing tracker can be re-pointed at a shared clock.
+  - `ProgressState` gained a private `clock: Arc<dyn Clock>` field (accessed via `now()`/`today()`/`clock()`, not exposed directly — reassigning it post-construction would not re-point `performance_tracker`/`scheduler`) and a `with_clock()` constructor that propagates the same clock instance to both; `AppState::with_clock` and `TestAppStateBuilder::with_clock` plumb it through from the composition root.
+  - The following now take a mandatory trailing `now: DateTime<Utc>` (or `today: NaiveDate`) parameter instead of reading the system clock internally: `StreakManager::update_streak`, `UserProfile::reset_daily_quests`, `Achievement::unlock`, `QuestGenerator::generate_quests`, `ScenarioCompletion::new`/`record_attempt`, `ScenarioHistory::record_completion`, `Analytics::get_progress_over_time`, `ChallengeProgress::{can_attempt, attempts_remaining, start_attempt, is_today}`, `ChallengeConfig::is_today`, `ScenarioCompletionService::record_and_scale_xp`.
+  - `ChallengeConfig::for_today()` and `impl Default for ChallengeConfig` were removed; use `ChallengeConfig::for_date(today)` instead.
+  - `UserProfile::new()` is unchanged (still the one sanctioned `Utc::now()` call site); added `UserProfile::new_at(now)`.
+  - As part of this refactor, `PerformanceTracker::record_attempt`, `ScenarioCompletion::record_attempt`/`check_and_reset_daily`, and the profile-load streak/quest-refresh checks in `data_handling.rs` now read the clock once per operation instead of twice (or more) independently — a deliberate fix for latent midnight-boundary races, not just a mechanical rename.
+  - Monotonic/`Instant`-based timing (arcade/survival countdowns, notification durations) is unaffected and deferred to a follow-up issue.
 - `Setup` and `TargetState` now share their cursor/selection fields and logic through a single `CursorSpec` type (`#[serde(flatten)]`) instead of duplicating both; scenario TOML files are unaffected (#268)
 - Quest templates now use a single adjacently-tagged `QuestSpec` enum instead of a separate `type` discriminator and untagged `params` enum, making a `type`/`params` mismatch a deserialization error instead of a runtime-only check; quest TOML files are unaffected (#274)
 - **BREAKING**: `MiniGameStats` now embeds `MultiplierState` as its sole owner of the streak/multiplier tier table instead of duplicating it; the `multiplier`, `streak`, and `best_streak` fields are removed (read them via the new `multiplier()`, `streak()`, `best_streak()` accessors), and `lives`/`level` are now private with `lives()`/`level()` accessors. `MiniGameStats`'s `Serialize`/`Deserialize` wire format changes accordingly (three scalar fields become a nested `multiplier_state` object); nothing in-tree persists `MiniGameStats` today. `MiniGameStats::increase_streak`/`reset_streak`/`calculate_multiplier` and `MiniGameSession::multiplier_state`/`streak_for_next_tier` are removed as dead duplicate paths (#259)

--- a/benches/filtering_sorting.rs
+++ b/benches/filtering_sorting.rs
@@ -108,7 +108,7 @@ fn create_profile_with_completions(scenario_ids: &[String]) -> UserProfile {
             // Complete ~33% of scenarios
             profile
                 .scenario_history
-                .record_completion(scenario_id, 100, 50);
+                .record_completion(scenario_id, 100, 50, chrono::Utc::now());
         }
     }
 

--- a/src/data_handling.rs
+++ b/src/data_handling.rs
@@ -40,19 +40,25 @@ pub fn handle_data_message(state: &mut AppState, msg: DataLoadMessage) -> Result
         }
 
         DataLoadMessage::ProfileReady(profile) => {
+            // Single `now` read shared by every day-boundary decision below (streak,
+            // quest refresh, daily reset). Previously each check called Utc::now()
+            // independently, which could straddle a midnight boundary; this also fixes
+            // a latent race where the streak and quest-refresh checks could disagree
+            // about what day it is.
+            let now = state.progress.now();
+
             // Update streak and refresh quests if needed
             let mut updated_profile = profile;
-            let streak_change = StreakManager::update_streak(&mut updated_profile);
+            let streak_change = StreakManager::update_streak(&mut updated_profile, now);
             tracing::debug!("Streak status: {:?}", streak_change);
 
             // Check if we need to refresh daily quests
-            let now = Utc::now();
             if should_refresh_quests(&updated_profile, now)
                 || updated_profile.daily_quests.is_empty()
             {
                 tracing::info!("Refreshing daily quests for new day");
                 let tracker = PerformanceTracker::new();
-                updated_profile.reset_daily_quests();
+                updated_profile.reset_daily_quests(now);
 
                 // Load quest registry synchronously
                 let quest_registry = QuestTemplateRegistry::load_from_default_path("en")
@@ -64,12 +70,18 @@ pub fn handle_data_message(state: &mut AppState, msg: DataLoadMessage) -> Result
                         QuestTemplateRegistry::new()
                     });
 
-                updated_profile.daily_quests =
-                    QuestGenerator::generate_quests(&updated_profile, &tracker, &quest_registry);
+                updated_profile.daily_quests = QuestGenerator::generate_quests(
+                    &updated_profile,
+                    &tracker,
+                    &quest_registry,
+                    now.date_naive(),
+                );
             }
 
-            state.progress.performance_tracker =
-                PerformanceTracker::from_stats(updated_profile.performance_data.clone());
+            state.progress.performance_tracker = PerformanceTracker::from_stats_with_clock(
+                updated_profile.performance_data.clone(),
+                state.progress.clock(),
+            );
             state.progress.profile = updated_profile;
 
             // Streak (and possibly quest history) may have just changed above;
@@ -247,12 +259,27 @@ mod tests {
     #[test]
     fn test_handle_profile_ready_unlocks_streak_achievement() {
         use helix_trainer::gamification::AchievementId;
+        use helix_trainer::time::{Clock, FakeClock};
+        use helix_trainer::ui::state::{AppState, ConfigState};
+        use std::sync::Arc;
 
-        let mut state = empty_test_app_state();
-        let mut profile = UserProfile::new();
+        // Construct AppState via with_clock directly (rather than building it with the
+        // default SystemClock and reassigning `progress.clock` afterward) so the injected
+        // clock is shared by every clock-consuming field from the start, not just read back.
+        let clock = Arc::new(FakeClock::at("2026-01-15T12:00:00Z"));
+        let mut state = AppState::with_clock(
+            vec![],
+            UserProfile::new(),
+            test_profile_storage(),
+            PerformanceTracker::new(),
+            ConfigState::default(),
+            clock.clone(),
+        );
+
+        let mut profile = UserProfile::new_at(clock.now());
         profile.current_streak = 6;
         profile.completed_quests_today.insert("quest_0".to_string());
-        profile.last_activity = Utc::now() - chrono::Duration::days(1);
+        clock.advance_days(1);
 
         let result = handle_data_message(&mut state, DataLoadMessage::ProfileReady(profile));
 

--- a/src/game/services/scenario_completion.rs
+++ b/src/game/services/scenario_completion.rs
@@ -5,6 +5,7 @@
 use crate::game::Feedback;
 use crate::gamification::UserProfile;
 use crate::learning::{PerformanceTracker, ScenarioMastery, Scheduler};
+use chrono::{DateTime, Utc};
 use std::time::Duration;
 
 /// Components of XP calculation before mastery scaling
@@ -59,6 +60,7 @@ impl ScenarioCompletionService {
         scenario_id: &str,
         score: u32,
         base_xp: u64,
+        now: DateTime<Utc>,
     ) -> (u64, ScenarioMastery, f64, f64, f64) {
         // Capture multipliers BEFORE recording (what will be applied)
         let (_pre_mastery_level, pre_mastery_factor, pre_repeat_penalty) = profile
@@ -67,9 +69,10 @@ impl ScenarioCompletionService {
             .map(|c| (c.mastery_level, c.mastery_factor(), c.repeat_penalty()))
             .unwrap_or((ScenarioMastery::Learning, 1.0, 1.0));
 
-        let actual_xp = profile
-            .scenario_history
-            .record_completion(scenario_id, score, base_xp);
+        let actual_xp =
+            profile
+                .scenario_history
+                .record_completion(scenario_id, score, base_xp, now);
 
         // Get post-recording mastery level (may have changed due to this completion)
         let post_mastery_level = profile
@@ -309,7 +312,13 @@ mod tests {
     fn test_record_and_scale_xp_first_completion() {
         let mut profile = UserProfile::new();
         let (actual_xp, mastery, multiplier, mastery_factor, repeat_penalty) =
-            ScenarioCompletionService::record_and_scale_xp(&mut profile, "test_scenario", 100, 50);
+            ScenarioCompletionService::record_and_scale_xp(
+                &mut profile,
+                "test_scenario",
+                100,
+                50,
+                Utc::now(),
+            );
 
         // First completion gets full XP (no penalty)
         assert_eq!(actual_xp, 50);
@@ -330,6 +339,7 @@ mod tests {
                 "test_scenario",
                 100,
                 50,
+                Utc::now(),
             );
         }
 

--- a/src/gamification/achievements.rs
+++ b/src/gamification/achievements.rs
@@ -131,8 +131,8 @@ impl Achievement {
     }
 
     /// Mark achievement as unlocked
-    pub fn unlock(&mut self) {
-        self.unlocked_at = Some(Utc::now());
+    pub fn unlock(&mut self, now: DateTime<Utc>) {
+        self.unlocked_at = Some(now);
     }
 
     /// Check if unlocked
@@ -378,7 +378,7 @@ mod tests {
         let mut achievement = Achievement::new(AchievementId::FirstPerfect);
         assert!(!achievement.is_unlocked());
 
-        achievement.unlock();
+        achievement.unlock(Utc::now());
         assert!(achievement.is_unlocked());
         assert!(achievement.unlocked_at.is_some());
     }

--- a/src/gamification/profile.rs
+++ b/src/gamification/profile.rs
@@ -125,7 +125,21 @@ impl UserProfile {
     /// assert_eq!(profile.current_streak, 0);
     /// ```
     pub fn new() -> Self {
-        let now = Utc::now();
+        Self::new_at(Utc::now())
+    }
+
+    /// Create a new user profile with an explicit creation timestamp
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use chrono::Utc;
+    /// use helix_trainer::gamification::UserProfile;
+    ///
+    /// let profile = UserProfile::new_at(Utc::now());
+    /// assert_eq!(profile.level, 1);
+    /// ```
+    pub fn new_at(now: DateTime<Utc>) -> Self {
         Self {
             level: 1,
             total_xp: 0,
@@ -229,10 +243,10 @@ impl UserProfile {
     }
 
     /// Reset daily quest state (called at midnight)
-    pub fn reset_daily_quests(&mut self) {
+    pub fn reset_daily_quests(&mut self, now: DateTime<Utc>) {
         self.completed_quests_today.clear();
         self.daily_quests.clear();
-        self.last_quest_refresh = Utc::now();
+        self.last_quest_refresh = now;
     }
 }
 
@@ -571,7 +585,7 @@ mod tests {
         profile.complete_quest("quest_1".to_string());
         assert!(profile.is_quest_completed("quest_1"));
 
-        profile.reset_daily_quests();
+        profile.reset_daily_quests(Utc::now());
         assert!(!profile.is_quest_completed("quest_1"));
         assert!(profile.daily_quests.is_empty());
     }

--- a/src/gamification/quests.rs
+++ b/src/gamification/quests.rs
@@ -1,6 +1,6 @@
 //! Daily quest generation and tracking
 
-use chrono::{Datelike, Utc};
+use chrono::{Datelike, NaiveDate};
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
 use serde::{Deserialize, Serialize};
@@ -457,13 +457,14 @@ impl QuestGenerator {
     /// # Examples
     ///
     /// ```ignore
+    /// use chrono::Utc;
     /// use helix_trainer::gamification::{QuestGenerator, QuestTemplateRegistry, UserProfile};
     /// use helix_trainer::learning::PerformanceTracker;
     ///
     /// let profile = UserProfile::new(); // Level 1
     /// let tracker = PerformanceTracker::new();
     /// let registry = QuestTemplateRegistry::load_from_default_path("en")?;
-    /// let quests = QuestGenerator::generate_quests(&profile, &tracker, &registry);
+    /// let quests = QuestGenerator::generate_quests(&profile, &tracker, &registry, Utc::now().date_naive());
     ///
     /// assert_eq!(quests.len(), 3); // Beginners get 3 quests
     /// ```
@@ -471,15 +472,15 @@ impl QuestGenerator {
         profile: &UserProfile,
         tracker: &PerformanceTracker,
         registry: &QuestTemplateRegistry,
+        today: NaiveDate,
     ) -> Vec<Quest> {
-        let mut rng = Self::create_rng();
+        let mut rng = Self::create_rng(today);
         let distribution = QuestDistribution::for_level(profile.level);
         distribution.generate_quests(&mut rng, tracker, registry)
     }
 
-    fn create_rng() -> StdRng {
+    fn create_rng(today: NaiveDate) -> StdRng {
         // Seed with current date for consistency within a day
-        let today = Utc::now().date_naive();
         let seed = today.num_days_from_ce() as u64;
         StdRng::seed_from_u64(seed)
     }
@@ -709,20 +710,22 @@ mod tests {
         let tracker = PerformanceTracker::new();
         let registry = test_registry();
 
+        let today = chrono::Utc::now().date_naive();
+
         // Level 1 - should get 3 quests (2 easy + 1 medium)
         let mut profile = UserProfile::new();
         profile.level = 1;
-        let quests = QuestGenerator::generate_quests(&profile, &tracker, &registry);
+        let quests = QuestGenerator::generate_quests(&profile, &tracker, &registry, today);
         assert_eq!(quests.len(), 3);
 
         // Level 10 - should get 4 quests (1 easy + 2 medium + 1 hard)
         profile.level = 10;
-        let quests = QuestGenerator::generate_quests(&profile, &tracker, &registry);
+        let quests = QuestGenerator::generate_quests(&profile, &tracker, &registry, today);
         assert_eq!(quests.len(), 4);
 
         // Level 20 - should get 4 quests (1 medium + 2 hard + 1 exploration)
         profile.level = 20;
-        let quests = QuestGenerator::generate_quests(&profile, &tracker, &registry);
+        let quests = QuestGenerator::generate_quests(&profile, &tracker, &registry, today);
         assert_eq!(quests.len(), 4);
     }
 

--- a/src/gamification/streak.rs
+++ b/src/gamification/streak.rs
@@ -36,21 +36,21 @@ impl StreakManager {
     ///
     /// ```
     /// use helix_trainer::gamification::{StreakManager, UserProfile, StreakChange};
-    /// use chrono::{Utc, Duration};
+    /// use helix_trainer::time::{Clock, FakeClock};
     ///
-    /// let mut profile = UserProfile::new();
+    /// let clock = FakeClock::at("2026-01-15T12:00:00Z");
+    /// let mut profile = UserProfile::new_at(clock.now());
     /// profile.current_streak = 5;
-    ///
-    /// // Simulate next day activity
-    /// profile.last_activity = Utc::now() - Duration::days(1);
     /// profile.complete_quest("test_quest".to_string());
     ///
-    /// let change = StreakManager::update_streak(&mut profile);
+    /// // Simulate next day activity
+    /// clock.advance_days(1);
+    ///
+    /// let change = StreakManager::update_streak(&mut profile, clock.now());
     /// assert_eq!(change, StreakChange::Incremented { new_streak: 6 });
     /// assert_eq!(profile.current_streak, 6);
     /// ```
-    pub fn update_streak(profile: &mut UserProfile) -> StreakChange {
-        let now = Utc::now();
+    pub fn update_streak(profile: &mut UserProfile, now: DateTime<Utc>) -> StreakChange {
         let last_active = profile.last_activity;
 
         let days_since_active = Self::days_between(last_active, now);
@@ -154,61 +154,67 @@ impl StreakManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::time::{Clock, FakeClock};
     use chrono::Duration;
 
     #[test]
     fn test_streak_same_day_continues() {
-        let mut profile = UserProfile::new();
+        let clock = FakeClock::at("2026-01-15T12:00:00Z");
+        let mut profile = UserProfile::new_at(clock.now());
         profile.current_streak = 5;
 
-        let change = StreakManager::update_streak(&mut profile);
+        let change = StreakManager::update_streak(&mut profile, clock.now());
         assert_eq!(change, StreakChange::Continued);
         assert_eq!(profile.current_streak, 5);
     }
 
     #[test]
     fn test_streak_increments_next_day() {
-        let mut profile = UserProfile::new();
+        let clock = FakeClock::at("2026-01-15T12:00:00Z");
+        let mut profile = UserProfile::new_at(clock.now());
         profile.current_streak = 5;
-        profile.last_activity = Utc::now() - Duration::days(1);
         profile.complete_quest("test_quest".to_string());
+        clock.advance_days(1);
 
-        let change = StreakManager::update_streak(&mut profile);
+        let change = StreakManager::update_streak(&mut profile, clock.now());
         assert_eq!(change, StreakChange::Incremented { new_streak: 6 });
         assert_eq!(profile.current_streak, 6);
     }
 
     #[test]
     fn test_streak_doesnt_increment_without_quest() {
-        let mut profile = UserProfile::new();
+        let clock = FakeClock::at("2026-01-15T12:00:00Z");
+        let mut profile = UserProfile::new_at(clock.now());
         profile.current_streak = 5;
-        profile.last_activity = Utc::now() - Duration::days(1);
+        clock.advance_days(1);
         // No quest completed
 
-        let change = StreakManager::update_streak(&mut profile);
+        let change = StreakManager::update_streak(&mut profile, clock.now());
         assert_eq!(change, StreakChange::Continued);
         assert_eq!(profile.current_streak, 5);
     }
 
     #[test]
     fn test_streak_breaks_when_missed() {
-        let mut profile = UserProfile::new();
+        let clock = FakeClock::at("2026-01-15T12:00:00Z");
+        let mut profile = UserProfile::new_at(clock.now());
         profile.current_streak = 10;
-        profile.last_activity = Utc::now() - Duration::days(2);
+        clock.advance_days(2);
 
-        let change = StreakManager::update_streak(&mut profile);
+        let change = StreakManager::update_streak(&mut profile, clock.now());
         assert_eq!(change, StreakChange::Broken { was_streak: 10 });
         assert_eq!(profile.current_streak, 0);
     }
 
     #[test]
     fn test_streak_freeze_protects() {
-        let mut profile = UserProfile::new();
+        let clock = FakeClock::at("2026-01-15T12:00:00Z");
+        let mut profile = UserProfile::new_at(clock.now());
         profile.current_streak = 10;
         profile.streak_freeze_available = true;
-        profile.last_activity = Utc::now() - Duration::days(2);
+        clock.advance_days(2);
 
-        let change = StreakManager::update_streak(&mut profile);
+        let change = StreakManager::update_streak(&mut profile, clock.now());
         assert_eq!(change, StreakChange::Protected { used_freeze: true });
         assert_eq!(profile.current_streak, 10); // Streak preserved
         assert!(!profile.streak_freeze_available); // Freeze consumed
@@ -216,13 +222,14 @@ mod tests {
 
     #[test]
     fn test_longest_streak_updates() {
-        let mut profile = UserProfile::new();
+        let clock = FakeClock::at("2026-01-15T12:00:00Z");
+        let mut profile = UserProfile::new_at(clock.now());
         profile.current_streak = 5;
         profile.longest_streak = 5;
-        profile.last_activity = Utc::now() - Duration::days(1);
         profile.complete_quest("test".to_string());
+        clock.advance_days(1);
 
-        StreakManager::update_streak(&mut profile);
+        StreakManager::update_streak(&mut profile, clock.now());
         assert_eq!(profile.longest_streak, 6);
     }
 

--- a/src/learning/analytics.rs
+++ b/src/learning/analytics.rs
@@ -105,12 +105,12 @@ impl Analytics {
     pub fn get_progress_over_time(
         tracker: &PerformanceTracker,
         days: u32,
+        now: DateTime<Utc>,
     ) -> Vec<(DateTime<Utc>, f64)> {
         if days == 0 {
             return Vec::new();
         }
 
-        let now = Utc::now();
         let summary = Self::get_mastery_summary(tracker);
 
         // Simulate historical progress (linear growth for now)
@@ -302,7 +302,7 @@ mod tests {
     fn test_progress_over_time_zero_days() {
         let tracker = setup_tracker_with_varied_mastery();
 
-        let progress = Analytics::get_progress_over_time(&tracker, 0);
+        let progress = Analytics::get_progress_over_time(&tracker, 0, Utc::now());
         assert!(progress.is_empty());
     }
 
@@ -311,7 +311,7 @@ mod tests {
         let tracker = setup_tracker_with_varied_mastery();
 
         let days = 7;
-        let progress = Analytics::get_progress_over_time(&tracker, days);
+        let progress = Analytics::get_progress_over_time(&tracker, days, Utc::now());
 
         // Should have days+1 points (including day 0)
         assert_eq!(progress.len(), (days + 1) as usize);
@@ -331,7 +331,7 @@ mod tests {
     fn test_progress_over_time_growth() {
         let tracker = setup_tracker_with_varied_mastery();
 
-        let progress = Analytics::get_progress_over_time(&tracker, 5);
+        let progress = Analytics::get_progress_over_time(&tracker, 5, Utc::now());
 
         // First point should be 0 (simulated start)
         assert_eq!(progress[0].1, 0.0);

--- a/src/learning/performance.rs
+++ b/src/learning/performance.rs
@@ -2,9 +2,11 @@ use chrono::{DateTime, Utc};
 use fsrs::{FSRS, MemoryState};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use super::traits::ProgressionTier;
+use crate::time::{Clock, SystemClock};
 
 const DEFAULT_DIFFICULTY: f32 = 5.0; // Mixle difficulty (0-10 scale)
 const DEFAULT_DESIRED_RETENTION: f32 = 0.9; // 90% target retention
@@ -89,8 +91,7 @@ impl super::traits::ProgressionTier for MasteryLevel {
 }
 
 impl CommandPerformance {
-    pub fn new(command: String) -> Self {
-        let now = Utc::now();
+    pub fn new(command: String, now: DateTime<Utc>) -> Self {
         Self {
             command,
             stability: 0.0,
@@ -147,6 +148,7 @@ impl CommandPerformance {
         memory: MemoryState,
         interval: f32,
         rating_index: usize,
+        now: DateTime<Utc>,
     ) {
         // Determine new state based on rating and current state
         self.state = match (self.state, rating_index) {
@@ -178,7 +180,7 @@ impl CommandPerformance {
         self.stability = memory.stability;
         self.difficulty = memory.difficulty;
         self.scheduled_days = interval.round().max(1.0) as u32;
-        self.last_review = Utc::now();
+        self.last_review = now;
 
         // For first review (reps == 0), make command immediately due
         // This allows users to practice new commands right away
@@ -222,14 +224,28 @@ mod duration_serde {
 pub struct PerformanceTracker {
     stats: HashMap<String, CommandPerformance>,
     fsrs: FSRS, // FSRS scheduler instance
+    clock: Arc<dyn Clock>,
 }
 
 impl PerformanceTracker {
     pub fn new() -> Self {
+        Self::with_clock(Arc::new(SystemClock))
+    }
+
+    pub fn with_clock(clock: Arc<dyn Clock>) -> Self {
         Self {
             stats: HashMap::new(),
             fsrs: FSRS::new(&[]).unwrap(),
+            clock,
         }
+    }
+
+    /// Replace the clock this tracker reads time from.
+    ///
+    /// Used by [`crate::ui::state::ProgressState::with_clock`] to keep this tracker and its
+    /// sibling [`super::Scheduler`] reading from the same injected clock instance.
+    pub fn set_clock(&mut self, clock: Arc<dyn Clock>) {
+        self.clock = clock;
     }
 
     pub fn record_attempt(
@@ -239,11 +255,16 @@ impl PerformanceTracker {
         success: bool,
         optimal_time: Duration,
     ) {
+        // Single `now` read shared by CommandPerformance::new (first-attempt case),
+        // update_fsrs_state's elapsed-days calculation, and the persisted last_review
+        // timestamp — previously each read Utc::now() independently.
+        let now = self.clock.now();
+
         // Get or create performance entry
         let perf = self
             .stats
             .entry(command.to_string())
-            .or_insert_with(|| CommandPerformance::new(command.to_string()));
+            .or_insert_with(|| CommandPerformance::new(command.to_string(), now));
 
         // Update attempt counters
         perf.attempts += 1;
@@ -255,7 +276,7 @@ impl PerformanceTracker {
         perf.avg_time = perf.total_time / perf.attempts;
 
         // Update FSRS state
-        self.update_fsrs_state(command, duration, success, optimal_time);
+        self.update_fsrs_state(command, duration, success, optimal_time, now);
 
         // Update mastery level
         if let Some(perf) = self.stats.get_mut(command) {
@@ -285,11 +306,11 @@ impl PerformanceTracker {
     }
 
     /// Calculate elapsed days since last review
-    fn elapsed_days_since_review(perf: &CommandPerformance) -> u32 {
+    fn elapsed_days_since_review(perf: &CommandPerformance, now: DateTime<Utc>) -> u32 {
         if perf.reps == 0 {
             0
         } else {
-            (Utc::now() - perf.last_review).num_days().max(0) as u32
+            (now - perf.last_review).num_days().max(0) as u32
         }
     }
 
@@ -299,6 +320,7 @@ impl PerformanceTracker {
         duration: Duration,
         success: bool,
         optimal_time: Duration,
+        now: DateTime<Utc>,
     ) {
         let perf = self.stats.get(command).unwrap();
 
@@ -307,14 +329,14 @@ impl PerformanceTracker {
 
         // Get current memory state and elapsed time
         let memory_state = perf.memory_state();
-        let elapsed_days = Self::elapsed_days_since_review(perf);
+        let elapsed_days = Self::elapsed_days_since_review(perf, now);
 
         // Calculate next state from FSRS
         let next_state = self.calculate_next_fsrs_state(memory_state, elapsed_days, rating_index);
 
         // Update performance with new FSRS state
         let perf = self.stats.get_mut(command).unwrap();
-        perf.update_from_next_state(next_state.memory, next_state.interval, rating_index);
+        perf.update_from_next_state(next_state.memory, next_state.interval, rating_index, now);
 
         // Update retrievability (current recall probability)
         perf.retrievability = fsrs::current_retrievability(
@@ -347,9 +369,17 @@ impl PerformanceTracker {
     }
 
     pub fn from_stats(stats: HashMap<String, CommandPerformance>) -> Self {
+        Self::from_stats_with_clock(stats, Arc::new(SystemClock))
+    }
+
+    pub fn from_stats_with_clock(
+        stats: HashMap<String, CommandPerformance>,
+        clock: Arc<dyn Clock>,
+    ) -> Self {
         Self {
             stats,
             fsrs: FSRS::new(&[]).unwrap(),
+            clock,
         }
     }
 
@@ -418,7 +448,7 @@ mod tests {
 
     #[test]
     fn test_new_command_defaults() {
-        let perf = CommandPerformance::new("x".to_string());
+        let perf = CommandPerformance::new("x".to_string(), Utc::now());
         assert_eq!(perf.stability, 0.0);
         assert_eq!(perf.difficulty, DEFAULT_DIFFICULTY);
         assert_eq!(perf.reps, 0);
@@ -531,7 +561,7 @@ mod tests {
 
     #[test]
     fn test_memory_state_conversion() {
-        let mut perf = CommandPerformance::new("x".to_string());
+        let mut perf = CommandPerformance::new("x".to_string(), Utc::now());
         assert!(perf.memory_state().is_none());
 
         perf.stability = 5.0;
@@ -546,7 +576,7 @@ mod tests {
 
     #[test]
     fn test_mastery_level_progression() {
-        let mut perf = CommandPerformance::new("x".to_string());
+        let mut perf = CommandPerformance::new("x".to_string(), Utc::now());
         assert_eq!(perf.mastery_level, MasteryLevel::Beginner);
 
         // Simulate progression through states
@@ -592,6 +622,28 @@ mod tests {
         let weak = tracker.get_weak_commands();
         assert!(weak.contains(&"weak".to_string()));
         // "strong" might still be beginner mastery level initially, so don't assert it's not weak
+    }
+
+    #[test]
+    fn test_record_attempt_honors_injected_clock() {
+        use crate::time::FakeClock;
+
+        let clock = Arc::new(FakeClock::at("2026-01-15T12:00:00Z"));
+        let mut tracker = PerformanceTracker::with_clock(clock.clone());
+
+        tracker.record_attempt("x", Duration::from_secs(1), true, Duration::from_secs(1));
+        let first_last_review = tracker.get_performance("x").unwrap().last_review;
+        assert_eq!(first_last_review, clock.now());
+
+        clock.advance_days(3);
+        tracker.record_attempt("x", Duration::from_secs(1), true, Duration::from_secs(1));
+        let second_last_review = tracker.get_performance("x").unwrap().last_review;
+        assert_eq!(second_last_review, clock.now());
+        assert_eq!(
+            (second_last_review - first_last_review).num_days(),
+            3,
+            "elapsed_days_since_review must reflect the fake clock, not wall time"
+        );
     }
 
     #[test]

--- a/src/learning/scenario_history.rs
+++ b/src/learning/scenario_history.rs
@@ -137,14 +137,14 @@ impl ScenarioCompletion {
     /// # Examples
     ///
     /// ```
+    /// use chrono::Utc;
     /// use helix_trainer::learning::ScenarioCompletion;
     ///
-    /// let completion = ScenarioCompletion::new("delete_line_001".to_string(), 80, 40);
+    /// let completion = ScenarioCompletion::new("delete_line_001".to_string(), 80, 40, Utc::now());
     /// assert_eq!(completion.attempts, 1);
     /// assert_eq!(completion.best_score, 80);
     /// ```
-    pub fn new(scenario_id: String, score: u32, xp_earned: u64) -> Self {
-        let now = Utc::now();
+    pub fn new(scenario_id: String, score: u32, xp_earned: u64, now: DateTime<Utc>) -> Self {
         let mut completion = Self {
             scenario_id,
             attempts: 0,
@@ -159,7 +159,7 @@ impl ScenarioCompletion {
         };
 
         // Record the first attempt
-        completion.record_attempt(score, xp_earned);
+        completion.record_attempt(score, xp_earned, now);
         completion
     }
 
@@ -168,23 +168,24 @@ impl ScenarioCompletion {
     /// # Examples
     ///
     /// ```
+    /// use chrono::Utc;
     /// use helix_trainer::learning::ScenarioCompletion;
     ///
-    /// let mut completion = ScenarioCompletion::new("test".to_string(), 80, 40);
-    /// completion.record_attempt(100, 50);
+    /// let mut completion = ScenarioCompletion::new("test".to_string(), 80, 40, Utc::now());
+    /// completion.record_attempt(100, 50, Utc::now());
     /// assert_eq!(completion.attempts, 2);
     /// assert_eq!(completion.best_score, 100);
     /// ```
-    pub fn record_attempt(&mut self, score: u32, xp_earned: u64) {
+    pub fn record_attempt(&mut self, score: u32, xp_earned: u64, now: DateTime<Utc>) {
         // Prevent infinite recursion with depth protection
         if self.attempts >= MAX_REPEAT_DEPTH {
             return;
         }
 
-        let now = Utc::now();
-
-        // Reset daily counter if new day
-        self.check_and_reset_daily();
+        // Single `now` read shared with check_and_reset_daily (previously two independent
+        // Utc::now() calls, which could straddle a midnight boundary); this also fixes a
+        // latent race where the daily counter reset used a different instant than the attempt.
+        self.check_and_reset_daily(now);
 
         // Update counters using saturating arithmetic
         self.attempts = self.attempts.saturating_add(1);
@@ -205,9 +206,10 @@ impl ScenarioCompletion {
     /// # Examples
     ///
     /// ```
+    /// use chrono::Utc;
     /// use helix_trainer::learning::ScenarioCompletion;
     ///
-    /// let completion = ScenarioCompletion::new("test".to_string(), 50, 25);
+    /// let completion = ScenarioCompletion::new("test".to_string(), 50, 25, Utc::now());
     /// assert_eq!(completion.xp_multiplier(), 0.7); // Second attempt today (after construction)
     /// ```
     pub fn xp_multiplier(&self) -> f64 {
@@ -246,8 +248,8 @@ impl ScenarioCompletion {
     }
 
     /// Reset daily attempt counter if new day
-    fn check_and_reset_daily(&mut self) {
-        let today = Utc::now().date_naive();
+    fn check_and_reset_daily(&mut self, now: DateTime<Utc>) {
+        let today = now.date_naive();
         if today != self.last_attempt_date {
             self.attempts_today = 0;
             self.last_attempt_date = today;
@@ -290,13 +292,20 @@ impl ScenarioHistory {
     /// # Examples
     ///
     /// ```
+    /// use chrono::Utc;
     /// use helix_trainer::learning::ScenarioHistory;
     ///
     /// let mut history = ScenarioHistory::new();
-    /// let xp = history.record_completion("test", 100, 50);
+    /// let xp = history.record_completion("test", 100, 50, Utc::now());
     /// assert_eq!(xp, 50); // First attempt, full XP
     /// ```
-    pub fn record_completion(&mut self, scenario_id: &str, score: u32, base_xp: u64) -> u64 {
+    pub fn record_completion(
+        &mut self,
+        scenario_id: &str,
+        score: u32,
+        base_xp: u64,
+        now: DateTime<Utc>,
+    ) -> u64 {
         // Validate scenario ID format (defense in depth)
         if !is_valid_scenario_id(scenario_id) {
             return 0;
@@ -324,8 +333,10 @@ impl ScenarioHistory {
         // Record completion (creates new or updates existing)
         self.completions
             .entry(scenario_id.to_string())
-            .and_modify(|c| c.record_attempt(score, actual_xp))
-            .or_insert_with(|| ScenarioCompletion::new(scenario_id.to_string(), score, actual_xp));
+            .and_modify(|c| c.record_attempt(score, actual_xp, now))
+            .or_insert_with(|| {
+                ScenarioCompletion::new(scenario_id.to_string(), score, actual_xp, now)
+            });
 
         actual_xp
     }
@@ -335,11 +346,12 @@ impl ScenarioHistory {
     /// # Examples
     ///
     /// ```
+    /// use chrono::Utc;
     /// use helix_trainer::learning::ScenarioHistory;
     ///
     /// let mut history = ScenarioHistory::new();
-    /// history.record_completion("test1", 100, 50);
-    /// history.record_completion("test2", 80, 40);
+    /// history.record_completion("test1", 100, 50, Utc::now());
+    /// history.record_completion("test2", 80, 40, Utc::now());
     ///
     /// let stats = history.mastery_stats();
     /// assert_eq!(stats.learning, 2);
@@ -375,7 +387,7 @@ mod tests {
 
     #[test]
     fn test_new_completion_initializes_correctly() {
-        let completion = ScenarioCompletion::new("test_scenario".to_string(), 85, 42);
+        let completion = ScenarioCompletion::new("test_scenario".to_string(), 85, 42, Utc::now());
 
         assert_eq!(completion.scenario_id, "test_scenario");
         assert_eq!(completion.attempts, 1);
@@ -388,15 +400,15 @@ mod tests {
 
     #[test]
     fn test_mastery_progression_to_proficient() {
-        let mut completion = ScenarioCompletion::new("test".to_string(), 85, 40);
+        let mut completion = ScenarioCompletion::new("test".to_string(), 85, 40, Utc::now());
 
         // Need 3+ attempts AND 90+ score for proficient
         assert_eq!(completion.mastery_level, ScenarioMastery::Learning);
 
-        completion.record_attempt(92, 45);
+        completion.record_attempt(92, 45, Utc::now());
         assert_eq!(completion.mastery_level, ScenarioMastery::Learning); // Only 2 attempts
 
-        completion.record_attempt(95, 47);
+        completion.record_attempt(95, 47, Utc::now());
         assert_eq!(completion.mastery_level, ScenarioMastery::Proficient); // 3 attempts + 95 score
         assert_eq!(completion.attempts, 3);
         assert_eq!(completion.best_score, 95);
@@ -404,19 +416,19 @@ mod tests {
 
     #[test]
     fn test_mastery_progression_to_mastered() {
-        let mut completion = ScenarioCompletion::new("test".to_string(), 100, 50);
+        let mut completion = ScenarioCompletion::new("test".to_string(), 100, 50, Utc::now());
 
         assert_eq!(completion.perfect_count, 1);
         assert_eq!(completion.mastery_level, ScenarioMastery::Learning); // Need 2 perfect
 
-        completion.record_attempt(100, 50);
+        completion.record_attempt(100, 50, Utc::now());
         assert_eq!(completion.perfect_count, 2);
         assert_eq!(completion.mastery_level, ScenarioMastery::Mastered);
     }
 
     #[test]
     fn test_xp_multiplier_learning_phase() {
-        let completion = ScenarioCompletion::new("test".to_string(), 80, 40);
+        let completion = ScenarioCompletion::new("test".to_string(), 80, 40, Utc::now());
         // After new(), attempts_today = 1, so next call gets session penalty
         assert_eq!(completion.xp_multiplier(), 0.7); // Second attempt today (1.0 * 0.7)
     }
@@ -424,19 +436,19 @@ mod tests {
     #[test]
     fn test_xp_multiplier_session_penalty() {
         // Use scores < 90 to avoid triggering proficiency (needs 90+ AND 3+ attempts)
-        let mut completion = ScenarioCompletion::new("test".to_string(), 80, 40);
+        let mut completion = ScenarioCompletion::new("test".to_string(), 80, 40, Utc::now());
 
         // First attempt already recorded in new(), attempts_today = 1
         assert_eq!(completion.attempts_today, 1);
         assert_eq!(completion.mastery_level, ScenarioMastery::Learning);
         assert_eq!(completion.xp_multiplier(), 0.7); // Second today (1.0 * 0.7)
 
-        completion.record_attempt(85, 35);
+        completion.record_attempt(85, 35, Utc::now());
         assert_eq!(completion.attempts_today, 2);
         assert_eq!(completion.mastery_level, ScenarioMastery::Learning);
         assert_eq!(completion.xp_multiplier(), 0.7); // Third today (1.0 * 0.7)
 
-        completion.record_attempt(88, 30); // Keep < 90 to stay in learning
+        completion.record_attempt(88, 30, Utc::now()); // Keep < 90 to stay in learning
         assert_eq!(completion.attempts_today, 3);
         assert_eq!(completion.mastery_level, ScenarioMastery::Learning);
         assert_eq!(completion.xp_multiplier(), 0.3); // Fourth today (1.0 * 0.3)
@@ -444,8 +456,8 @@ mod tests {
 
     #[test]
     fn test_xp_multiplier_mastered() {
-        let mut completion = ScenarioCompletion::new("test".to_string(), 100, 50);
-        completion.record_attempt(100, 10); // Now mastered (2 perfect)
+        let mut completion = ScenarioCompletion::new("test".to_string(), 100, 50, Utc::now());
+        completion.record_attempt(100, 10, Utc::now()); // Now mastered (2 perfect)
 
         assert_eq!(completion.mastery_level, ScenarioMastery::Mastered);
         // attempts_today = 2, so session_mult = 0.7
@@ -459,7 +471,7 @@ mod tests {
     fn test_scenario_history_first_completion() {
         let mut history = ScenarioHistory::new();
 
-        let xp = history.record_completion("test", 100, 50);
+        let xp = history.record_completion("test", 100, 50, Utc::now());
         assert_eq!(xp, 50); // First attempt, full XP
 
         let completion = history.get("test").unwrap();
@@ -473,18 +485,18 @@ mod tests {
         let mut history = ScenarioHistory::new();
 
         // First attempt (creates new completion with attempts_today=1)
-        let xp1 = history.record_completion("test", 100, 50);
+        let xp1 = history.record_completion("test", 100, 50, Utc::now());
         assert_eq!(xp1, 50); // Full XP (first attempt gets 1.0 multiplier)
 
         // Second attempt (attempts_today=1 before call, session_mult=0.7, still learning)
-        let xp2 = history.record_completion("test", 100, 50);
+        let xp2 = history.record_completion("test", 100, 50, Utc::now());
         assert_eq!(xp2, 35); // 50 * 0.7 = 35 (session penalty)
 
         // Third attempt
         // After 2nd completion: perfect_count=2 (Mastered!), attempts_today=2
         // multiplier = mastery(0.2) * session(2->0.7) = 0.14
         // XP = 50 * 0.14 = 7.0 (rounded)
-        let xp3 = history.record_completion("test", 100, 50);
+        let xp3 = history.record_completion("test", 100, 50, Utc::now());
         assert_eq!(xp3, 7);
     }
 
@@ -493,15 +505,15 @@ mod tests {
         let mut history = ScenarioHistory::new();
 
         // Create scenarios at different mastery levels
-        history.record_completion("learning1", 80, 40);
-        history.record_completion("learning2", 50, 25);
+        history.record_completion("learning1", 80, 40, Utc::now());
+        history.record_completion("learning2", 50, 25, Utc::now());
 
-        history.record_completion("proficient", 90, 45);
-        history.record_completion("proficient", 92, 23); // 2nd attempt
-        history.record_completion("proficient", 95, 24); // 3rd attempt -> proficient
+        history.record_completion("proficient", 90, 45, Utc::now());
+        history.record_completion("proficient", 92, 23, Utc::now()); // 2nd attempt
+        history.record_completion("proficient", 95, 24, Utc::now()); // 3rd attempt -> proficient
 
-        history.record_completion("mastered", 100, 50);
-        history.record_completion("mastered", 100, 10); // 2nd perfect -> mastered
+        history.record_completion("mastered", 100, 50, Utc::now());
+        history.record_completion("mastered", 100, 10, Utc::now()); // 2nd perfect -> mastered
 
         let stats = history.mastery_stats();
         assert_eq!(stats.learning, 2);
@@ -511,33 +523,34 @@ mod tests {
 
     #[test]
     fn test_saturating_arithmetic_prevents_overflow() {
-        let mut completion = ScenarioCompletion::new("test".to_string(), 100, u64::MAX - 100);
+        let mut completion =
+            ScenarioCompletion::new("test".to_string(), 100, u64::MAX - 100, Utc::now());
 
         // Should not panic on overflow (note: new() already added some XP)
-        completion.record_attempt(80, 1000); // Use non-perfect to avoid mastery
+        completion.record_attempt(80, 1000, Utc::now()); // Use non-perfect to avoid mastery
         assert_eq!(completion.total_xp_earned, u64::MAX);
 
         // Test attempts saturation (but MAX_REPEAT_DEPTH = 100 prevents this)
         // Once attempts >= 100, record_attempt returns early
         completion.attempts = 50;
-        completion.record_attempt(80, 100);
+        completion.record_attempt(80, 100, Utc::now());
         assert_eq!(completion.attempts, 51); // Increments normally
 
         completion.attempts = MAX_REPEAT_DEPTH - 1;
-        completion.record_attempt(80, 100);
+        completion.record_attempt(80, 100, Utc::now());
         assert_eq!(completion.attempts, MAX_REPEAT_DEPTH); // Reaches limit
 
-        completion.record_attempt(80, 100);
+        completion.record_attempt(80, 100, Utc::now());
         assert_eq!(completion.attempts, MAX_REPEAT_DEPTH); // Blocked by MAX_REPEAT_DEPTH
     }
 
     #[test]
     fn test_max_repeat_depth_protection() {
-        let mut completion = ScenarioCompletion::new("test".to_string(), 100, 50);
+        let mut completion = ScenarioCompletion::new("test".to_string(), 100, 50, Utc::now());
         completion.attempts = MAX_REPEAT_DEPTH;
 
         // Should not increment beyond MAX_REPEAT_DEPTH
-        completion.record_attempt(100, 50);
+        completion.record_attempt(100, 50, Utc::now());
         assert_eq!(completion.attempts, MAX_REPEAT_DEPTH);
     }
 
@@ -558,28 +571,28 @@ mod tests {
 
     #[test]
     fn test_best_score_tracking() {
-        let mut completion = ScenarioCompletion::new("test".to_string(), 70, 35);
+        let mut completion = ScenarioCompletion::new("test".to_string(), 70, 35, Utc::now());
         assert_eq!(completion.best_score, 70);
 
-        completion.record_attempt(85, 42);
+        completion.record_attempt(85, 42, Utc::now());
         assert_eq!(completion.best_score, 85);
 
-        completion.record_attempt(80, 40); // Lower score
+        completion.record_attempt(80, 40, Utc::now()); // Lower score
         assert_eq!(completion.best_score, 85); // Should stay at max
     }
 
     #[test]
     fn test_perfect_count_tracking() {
-        let mut completion = ScenarioCompletion::new("test".to_string(), 95, 47);
+        let mut completion = ScenarioCompletion::new("test".to_string(), 95, 47, Utc::now());
         assert_eq!(completion.perfect_count, 0);
 
-        completion.record_attempt(100, 50);
+        completion.record_attempt(100, 50, Utc::now());
         assert_eq!(completion.perfect_count, 1);
 
-        completion.record_attempt(98, 49);
+        completion.record_attempt(98, 49, Utc::now());
         assert_eq!(completion.perfect_count, 1); // No change
 
-        completion.record_attempt(100, 10);
+        completion.record_attempt(100, 10, Utc::now());
         assert_eq!(completion.perfect_count, 2);
     }
 
@@ -604,18 +617,18 @@ mod tests {
 
         // Fill to just below limit
         for i in 0..MAX_SCENARIOS_TRACKED {
-            history.record_completion(&format!("scenario_{}", i), 100, 50);
+            history.record_completion(&format!("scenario_{}", i), 100, 50, Utc::now());
         }
 
         assert_eq!(history.completions.len(), MAX_SCENARIOS_TRACKED);
 
         // Try to add one more - should be rejected
-        let xp = history.record_completion("overflow_scenario", 100, 50);
+        let xp = history.record_completion("overflow_scenario", 100, 50, Utc::now());
         assert_eq!(xp, 0); // Returns 0 when at capacity
         assert_eq!(history.completions.len(), MAX_SCENARIOS_TRACKED); // No growth
 
         // Existing scenarios should still update
-        let xp2 = history.record_completion("scenario_0", 100, 50);
+        let xp2 = history.record_completion("scenario_0", 100, 50, Utc::now());
         assert!(xp2 > 0); // Still gets XP for existing scenario
     }
 
@@ -624,18 +637,50 @@ mod tests {
         let mut history = ScenarioHistory::new();
 
         // Valid IDs
-        assert!(history.record_completion("valid_scenario_001", 100, 50) > 0);
-        assert!(history.record_completion("test-scenario-2", 100, 50) > 0);
-        assert!(history.record_completion("a1b2c3", 100, 50) > 0);
+        assert!(history.record_completion("valid_scenario_001", 100, 50, Utc::now()) > 0);
+        assert!(history.record_completion("test-scenario-2", 100, 50, Utc::now()) > 0);
+        assert!(history.record_completion("a1b2c3", 100, 50, Utc::now()) > 0);
 
         // Invalid IDs - should be rejected
-        assert_eq!(history.record_completion("", 100, 50), 0); // Empty
-        assert_eq!(history.record_completion("../../../etc/passwd", 100, 50), 0); // Path traversal
-        assert_eq!(history.record_completion("drop table;", 100, 50), 0); // SQL injection attempt
-        assert_eq!(history.record_completion(&"x".repeat(101), 100, 50), 0); // Too long
+        assert_eq!(history.record_completion("", 100, 50, Utc::now()), 0); // Empty
+        assert_eq!(
+            history.record_completion("../../../etc/passwd", 100, 50, Utc::now()),
+            0
+        ); // Path traversal
+        assert_eq!(
+            history.record_completion("drop table;", 100, 50, Utc::now()),
+            0
+        ); // SQL injection attempt
+        assert_eq!(
+            history.record_completion(&"x".repeat(101), 100, 50, Utc::now()),
+            0
+        ); // Too long
 
         // Only valid IDs should be stored
         assert_eq!(history.completions.len(), 3);
+    }
+
+    #[test]
+    fn test_check_and_reset_daily_honors_injected_now() {
+        let day_one = DateTime::parse_from_rfc3339("2026-01-15T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let day_two = day_one + chrono::Duration::days(1);
+
+        let mut completion = ScenarioCompletion::new("test".to_string(), 80, 40, day_one);
+        assert_eq!(completion.attempts_today, 1);
+
+        completion.record_attempt(80, 40, day_one);
+        assert_eq!(
+            completion.attempts_today, 2,
+            "same day must accumulate, not reset"
+        );
+
+        completion.record_attempt(80, 40, day_two);
+        assert_eq!(
+            completion.attempts_today, 1,
+            "crossing the injected day boundary must reset the daily counter"
+        );
     }
 }
 

--- a/src/learning/scheduler.rs
+++ b/src/learning/scheduler.rs
@@ -1,6 +1,8 @@
 use super::performance::{CommandPerformance, PerformanceTracker};
+use crate::time::{Clock, SystemClock};
 use chrono::{DateTime, Utc};
 use std::collections::BinaryHeap;
+use std::sync::Arc;
 
 /// Review item with priority information
 #[derive(Debug, Clone)]
@@ -35,13 +37,31 @@ impl PartialOrd for ReviewItem {
 }
 
 /// Scheduler for spaced repetition reviews
-#[derive(Debug, Default)]
-pub struct Scheduler;
+pub struct Scheduler {
+    clock: Arc<dyn Clock>,
+}
+
+impl std::fmt::Debug for Scheduler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Scheduler").finish_non_exhaustive()
+    }
+}
+
+impl Default for Scheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl Scheduler {
-    /// Create a new scheduler
+    /// Create a new scheduler backed by the system clock
     pub fn new() -> Self {
-        Self
+        Self::with_clock(Arc::new(SystemClock))
+    }
+
+    /// Create a new scheduler backed by the given clock
+    pub fn with_clock(clock: Arc<dyn Clock>) -> Self {
+        Self { clock }
     }
 
     /// Record commands used in a completed scenario
@@ -123,7 +143,7 @@ impl Scheduler {
     /// # Arguments
     /// * `tracker` - Reference to performance tracker
     pub fn get_due_reviews(&self, tracker: &PerformanceTracker) -> Vec<String> {
-        let now = Utc::now();
+        let now = self.clock.now();
 
         tracker
             .all_commands()
@@ -148,7 +168,7 @@ impl Scheduler {
     /// * `tracker` - Reference to performance tracker
     /// * `limit` - Maximum number of items to return
     pub fn get_review_queue(&self, tracker: &PerformanceTracker, limit: usize) -> Vec<ReviewItem> {
-        let now = Utc::now();
+        let now = self.clock.now();
 
         // Build priority queue (BinaryHeap is max-heap by default)
         let heap: BinaryHeap<ReviewItem> = tracker
@@ -324,13 +344,13 @@ mod tests {
         let now = Utc::now();
 
         // Command 1: Very overdue, hard difficulty
-        let mut cmd1 = CommandPerformance::new("hard_overdue".to_string());
+        let mut cmd1 = CommandPerformance::new("hard_overdue".to_string(), now);
         cmd1.difficulty = 8.0;
         cmd1.scheduled_days = 10;
         cmd1.due = now - ChronoDuration::days(20); // 20 days overdue
 
         // Command 2: Slightly overdue, easy difficulty
-        let mut cmd2 = CommandPerformance::new("easy_overdue".to_string());
+        let mut cmd2 = CommandPerformance::new("easy_overdue".to_string(), now);
         cmd2.difficulty = 3.0;
         cmd2.scheduled_days = 10;
         cmd2.due = now - ChronoDuration::days(5); // 5 days overdue
@@ -458,7 +478,7 @@ mod tests {
     fn test_priority_zero_when_not_overdue() {
         let now = Utc::now();
 
-        let mut cmd = CommandPerformance::new("not_due".to_string());
+        let mut cmd = CommandPerformance::new("not_due".to_string(), now);
         cmd.difficulty = 8.0;
         cmd.scheduled_days = 10;
         cmd.due = now + ChronoDuration::days(5); // Future due date
@@ -467,6 +487,35 @@ mod tests {
 
         // Not overdue = zero priority
         assert_eq!(priority, 0.0);
+    }
+
+    #[test]
+    fn test_get_due_reviews_honors_injected_clock() {
+        use crate::time::FakeClock;
+
+        let clock = Arc::new(FakeClock::at("2030-01-01T00:00:00Z"));
+        let mut tracker = PerformanceTracker::with_clock(clock.clone());
+        tracker.record_attempt("x", Duration::from_secs(1), true, Duration::from_secs(1));
+        tracker.record_attempt("x", Duration::from_secs(1), true, Duration::from_secs(1));
+
+        let scheduled_days = tracker.get_performance("x").unwrap().scheduled_days;
+        assert!(
+            scheduled_days >= 1,
+            "second review should push the due date forward"
+        );
+
+        let scheduler = Scheduler::with_clock(clock.clone());
+        assert!(
+            scheduler.get_due_reviews(&tracker).is_empty(),
+            "not due yet relative to the fake clock"
+        );
+
+        clock.advance_days(scheduled_days as i64);
+        assert_eq!(
+            scheduler.get_due_reviews(&tracker),
+            vec!["x".to_string()],
+            "must become due once the injected clock advances, proving Scheduler doesn't read wall-clock time"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod learning;
 pub mod minigame;
 pub mod security;
 pub mod sound;
+pub mod time;
 pub mod ui;
 
 // Test utilities - only compiled in test builds

--- a/src/minigame/challenge.rs
+++ b/src/minigame/challenge.rs
@@ -5,6 +5,7 @@
 //! - Best score tracking (daily and all-time)
 //! - Deterministic scenario selection using seeded RNG
 
+use chrono::NaiveDate;
 use rand::SeedableRng;
 use rand::prelude::SliceRandom;
 use serde::{Deserialize, Serialize};
@@ -64,8 +65,8 @@ impl ChallengeProgress {
     }
 
     /// Check if player can attempt today's challenge
-    pub fn can_attempt(&self) -> bool {
-        let today = Self::today_string();
+    pub fn can_attempt(&self, today: NaiveDate) -> bool {
+        let today = Self::today_string(today);
 
         // Different day = reset attempts
         if self.last_challenge_date.as_deref() != Some(&today) {
@@ -76,8 +77,8 @@ impl ChallengeProgress {
     }
 
     /// Get remaining attempts for today
-    pub fn attempts_remaining(&self) -> u8 {
-        let today = Self::today_string();
+    pub fn attempts_remaining(&self, today: NaiveDate) -> u8 {
+        let today = Self::today_string(today);
 
         if self.last_challenge_date.as_deref() != Some(&today) {
             return CHALLENGE_MAX_ATTEMPTS;
@@ -87,8 +88,8 @@ impl ChallengeProgress {
     }
 
     /// Start a new attempt, resetting if new day
-    pub fn start_attempt(&mut self) {
-        let today = Self::today_string();
+    pub fn start_attempt(&mut self, today: NaiveDate) {
+        let today = Self::today_string(today);
 
         // Reset for new day
         if self.last_challenge_date.as_deref() != Some(&today) {
@@ -126,14 +127,14 @@ impl ChallengeProgress {
         }
     }
 
-    /// Get today's date string in YYYY-MM-DD format
-    fn today_string() -> String {
-        chrono::Utc::now().date_naive().to_string()
+    /// Get the given date as a YYYY-MM-DD string
+    fn today_string(today: NaiveDate) -> String {
+        today.to_string()
     }
 
-    /// Check if progress is for today
-    pub fn is_today(&self) -> bool {
-        self.last_challenge_date.as_deref() == Some(&Self::today_string())
+    /// Check if progress is for the given date
+    pub fn is_today(&self, today: NaiveDate) -> bool {
+        self.last_challenge_date.as_deref() == Some(&Self::today_string(today))
     }
 }
 
@@ -172,7 +173,7 @@ impl ChallengeProgress {
 /// use helix_trainer::minigame::{ChallengeConfig, select_challenge_scenarios};
 ///
 /// let scenarios = load_scenarios();
-/// let config = ChallengeConfig::for_today();
+/// let config = ChallengeConfig::for_date(chrono::Utc::now().date_naive());
 /// let selected = select_challenge_scenarios(&scenarios, &config);
 /// assert_eq!(selected.len(), 10);
 /// ```
@@ -226,35 +227,37 @@ mod tests {
 
     #[test]
     fn test_can_attempt_new_day() {
+        let today = NaiveDate::from_ymd_opt(2026, 1, 15).unwrap();
         let progress = ChallengeProgress::new();
-        assert!(progress.can_attempt());
-        assert_eq!(progress.attempts_remaining(), CHALLENGE_MAX_ATTEMPTS);
+        assert!(progress.can_attempt(today));
+        assert_eq!(progress.attempts_remaining(today), CHALLENGE_MAX_ATTEMPTS);
     }
 
     #[test]
     fn test_can_attempt_after_using_attempts() {
+        let today = NaiveDate::from_ymd_opt(2026, 1, 15).unwrap();
         let mut progress = ChallengeProgress::new();
-        let today = chrono::Utc::now().date_naive().to_string();
-        progress.last_challenge_date = Some(today);
+        progress.last_challenge_date = Some(today.to_string());
         progress.attempts_used_today = 2;
 
-        assert!(progress.can_attempt());
-        assert_eq!(progress.attempts_remaining(), 1);
+        assert!(progress.can_attempt(today));
+        assert_eq!(progress.attempts_remaining(today), 1);
 
         progress.attempts_used_today = 3;
-        assert!(!progress.can_attempt());
-        assert_eq!(progress.attempts_remaining(), 0);
+        assert!(!progress.can_attempt(today));
+        assert_eq!(progress.attempts_remaining(today), 0);
     }
 
     #[test]
     fn test_start_attempt_new_day() {
+        let today = NaiveDate::from_ymd_opt(2026, 1, 15).unwrap();
         let mut progress = ChallengeProgress::new();
         progress.last_challenge_date = Some("2020-01-01".to_string());
         progress.attempts_used_today = 3;
         progress.best_score_today = 5000;
         progress.best_scenarios_today = 8;
 
-        progress.start_attempt();
+        progress.start_attempt(today);
 
         // Should reset for new day
         assert_eq!(progress.attempts_used_today, 1);
@@ -265,24 +268,25 @@ mod tests {
 
     #[test]
     fn test_start_attempt_same_day() {
+        let today = NaiveDate::from_ymd_opt(2026, 1, 15).unwrap();
         let mut progress = ChallengeProgress::new();
-        let today = chrono::Utc::now().date_naive().to_string();
-        progress.last_challenge_date = Some(today.clone());
+        progress.last_challenge_date = Some(today.to_string());
         progress.attempts_used_today = 1;
         progress.best_score_today = 5000;
 
-        progress.start_attempt();
+        progress.start_attempt(today);
 
         // Should not reset, just increment
         assert_eq!(progress.attempts_used_today, 2);
         assert_eq!(progress.best_score_today, 5000);
-        assert_eq!(progress.last_challenge_date, Some(today));
+        assert_eq!(progress.last_challenge_date, Some(today.to_string()));
     }
 
     #[test]
     fn test_record_result_updates_daily_best() {
+        let today = NaiveDate::from_ymd_opt(2026, 1, 15).unwrap();
         let mut progress = ChallengeProgress::new();
-        progress.start_attempt();
+        progress.start_attempt(today);
 
         progress.record_result(1000, 5);
         assert_eq!(progress.best_score_today, 1000);
@@ -301,10 +305,11 @@ mod tests {
 
     #[test]
     fn test_record_result_updates_all_time_best() {
+        let today = NaiveDate::from_ymd_opt(2026, 1, 15).unwrap();
         let mut progress = ChallengeProgress::new();
         progress.all_time_best_score = 3000;
         progress.all_time_best_scenarios = 8;
-        progress.start_attempt();
+        progress.start_attempt(today);
 
         // Should not update (lower)
         progress.record_result(2000, 5);
@@ -319,8 +324,9 @@ mod tests {
 
     #[test]
     fn test_record_result_tracks_completions() {
+        let today = NaiveDate::from_ymd_opt(2026, 1, 15).unwrap();
         let mut progress = ChallengeProgress::new();
-        progress.start_attempt();
+        progress.start_attempt(today);
 
         // Incomplete challenge
         progress.record_result(1000, 9);
@@ -376,7 +382,8 @@ mod tests {
             .map(|i| create_test_scenario(&format!("scenario_{}", i)))
             .collect();
 
-        let config = ChallengeConfig::for_today();
+        let today = NaiveDate::from_ymd_opt(2026, 1, 15).unwrap();
+        let config = ChallengeConfig::for_date(today);
         let selected = select_challenge_scenarios(&scenarios, &config);
 
         // Should return all available scenarios
@@ -389,7 +396,8 @@ mod tests {
             .map(|i| create_test_scenario(&format!("scenario_{}", i)))
             .collect();
 
-        let config = ChallengeConfig::for_today();
+        let today = NaiveDate::from_ymd_opt(2026, 1, 15).unwrap();
+        let config = ChallengeConfig::for_date(today);
         let selected = select_challenge_scenarios(&scenarios, &config);
 
         // Should only return scenario_count scenarios
@@ -398,24 +406,26 @@ mod tests {
 
     #[test]
     fn test_challenge_max_attempts_enforced() {
+        let today = NaiveDate::from_ymd_opt(2026, 1, 15).unwrap();
         let mut progress = ChallengeProgress::new();
 
         // Use all attempts
         for _ in 0..CHALLENGE_MAX_ATTEMPTS {
-            assert!(progress.can_attempt());
-            progress.start_attempt();
+            assert!(progress.can_attempt(today));
+            progress.start_attempt(today);
         }
 
         // Should not be able to attempt anymore
-        assert!(!progress.can_attempt());
-        assert_eq!(progress.attempts_remaining(), 0);
+        assert!(!progress.can_attempt(today));
+        assert_eq!(progress.attempts_remaining(today), 0);
     }
 
     // CR-003: Test ChallengeProgress TOML serialization roundtrip
     #[test]
     fn test_challenge_progress_serialization_roundtrip() {
+        let today = NaiveDate::from_ymd_opt(2026, 1, 15).unwrap();
         let mut progress = ChallengeProgress::new();
-        progress.start_attempt();
+        progress.start_attempt(today);
         progress.record_result(5000, 8);
 
         let toml = toml::to_string(&progress).unwrap();
@@ -449,21 +459,23 @@ mod tests {
     // CR-008: Test is_today() method
     #[test]
     fn test_challenge_progress_is_today() {
+        let today = NaiveDate::from_ymd_opt(2026, 1, 15).unwrap();
         let mut progress = ChallengeProgress::new();
-        assert!(!progress.is_today()); // No date set yet
+        assert!(!progress.is_today(today)); // No date set yet
 
-        progress.start_attempt();
-        assert!(progress.is_today()); // Now has today's date
+        progress.start_attempt(today);
+        assert!(progress.is_today(today)); // Now has today's date
 
         progress.last_challenge_date = Some("2020-01-01".to_string());
-        assert!(!progress.is_today()); // Past date
+        assert!(!progress.is_today(today)); // Past date
     }
 
     // CR-018: Test empty scenario list
     #[test]
     fn test_select_challenge_scenarios_empty_input() {
         let scenarios: Vec<Scenario> = vec![];
-        let config = ChallengeConfig::for_today();
+        let today = NaiveDate::from_ymd_opt(2026, 1, 15).unwrap();
+        let config = ChallengeConfig::for_date(today);
         let selected = select_challenge_scenarios(&scenarios, &config);
         assert!(selected.is_empty());
     }

--- a/src/minigame/modes.rs
+++ b/src/minigame/modes.rs
@@ -226,12 +226,6 @@ pub struct ChallengeConfig {
 }
 
 impl ChallengeConfig {
-    /// Create a challenge config for today's date (UTC)
-    pub fn for_today() -> Self {
-        let today = chrono::Utc::now().date_naive();
-        Self::for_date(today)
-    }
-
     /// Create a challenge config for a specific date
     pub fn for_date(date: chrono::NaiveDate) -> Self {
         // Seed = days since Unix epoch, ensuring same seed for same date
@@ -252,15 +246,9 @@ impl ChallengeConfig {
         }
     }
 
-    /// Check if this challenge is for today
-    pub fn is_today(&self) -> bool {
-        self.date == chrono::Utc::now().date_naive()
-    }
-}
-
-impl Default for ChallengeConfig {
-    fn default() -> Self {
-        Self::for_today()
+    /// Check if this challenge is for the given date
+    pub fn is_today(&self, today: chrono::NaiveDate) -> bool {
+        self.date == today
     }
 }
 
@@ -290,7 +278,8 @@ mod tests {
 
     #[test]
     fn test_challenge_mode_config() {
-        let mode = MiniGameMode::Challenge(ChallengeConfig::for_today());
+        let mode =
+            MiniGameMode::Challenge(ChallengeConfig::for_date(chrono::Utc::now().date_naive()));
         assert!(mode.is_challenge());
         assert_eq!(mode.starting_lives(), 3);
         assert!(!mode.has_session_timer());
@@ -388,19 +377,21 @@ mod tests {
 
     #[test]
     fn test_challenge_is_today() {
-        let config = ChallengeConfig::for_today();
-        assert!(config.is_today());
+        let today = chrono::Utc::now().date_naive();
+        let config = ChallengeConfig::for_date(today);
+        assert!(config.is_today(today));
 
         let past = chrono::NaiveDate::from_ymd_opt(2020, 1, 1).unwrap();
         let past_config = ChallengeConfig::for_date(past);
-        assert!(!past_config.is_today());
+        assert!(!past_config.is_today(today));
     }
 
     #[test]
     fn test_mode_descriptions() {
         let arcade = MiniGameMode::Arcade(ArcadeConfig::default());
         let survival = MiniGameMode::Survival(SurvivalConfig::default());
-        let challenge = MiniGameMode::Challenge(ChallengeConfig::for_today());
+        let challenge =
+            MiniGameMode::Challenge(ChallengeConfig::for_date(chrono::Utc::now().date_naive()));
 
         assert!(!arcade.description().is_empty());
         assert!(!survival.description().is_empty());
@@ -446,7 +437,8 @@ mod tests {
     fn test_mode_name_values() {
         let arcade = MiniGameMode::Arcade(ArcadeConfig::default());
         let survival = MiniGameMode::Survival(SurvivalConfig::default());
-        let challenge = MiniGameMode::Challenge(ChallengeConfig::for_today());
+        let challenge =
+            MiniGameMode::Challenge(ChallengeConfig::for_date(chrono::Utc::now().date_naive()));
 
         assert_eq!(arcade.name(), "Arcade");
         assert_eq!(survival.name(), "Survival");
@@ -457,7 +449,8 @@ mod tests {
     fn test_mode_description_values() {
         let arcade = MiniGameMode::Arcade(ArcadeConfig::default());
         let survival = MiniGameMode::Survival(SurvivalConfig::default());
-        let challenge = MiniGameMode::Challenge(ChallengeConfig::for_today());
+        let challenge =
+            MiniGameMode::Challenge(ChallengeConfig::for_date(chrono::Utc::now().date_naive()));
 
         assert_eq!(
             arcade.description(),

--- a/src/minigame/session.rs
+++ b/src/minigame/session.rs
@@ -1329,7 +1329,8 @@ mod tests {
             create_test_scenario("s2", Difficulty::Beginner),
         ]);
 
-        let mode = MiniGameMode::Challenge(ChallengeConfig::for_today());
+        let mode =
+            MiniGameMode::Challenge(ChallengeConfig::for_date(chrono::Utc::now().date_naive()));
         let session = MiniGameSession::with_mode(scenarios, None, mode);
 
         assert_eq!(session.stats().lives(), 3);
@@ -1342,7 +1343,8 @@ mod tests {
             .map(|i| create_test_scenario(&format!("s{}", i), Difficulty::Beginner))
             .collect();
 
-        let mode = MiniGameMode::Challenge(ChallengeConfig::for_today());
+        let mode =
+            MiniGameMode::Challenge(ChallengeConfig::for_date(chrono::Utc::now().date_naive()));
         let session = MiniGameSession::with_mode(Arc::new(scenarios), None, mode);
 
         let progress = session.challenge_scenarios_completed();
@@ -1371,7 +1373,8 @@ mod tests {
     fn test_mode_has_session_timer() {
         let arcade = MiniGameMode::Arcade(ArcadeConfig::default());
         let survival = MiniGameMode::Survival(SurvivalConfig::default());
-        let challenge = MiniGameMode::Challenge(ChallengeConfig::for_today());
+        let challenge =
+            MiniGameMode::Challenge(ChallengeConfig::for_date(chrono::Utc::now().date_naive()));
 
         assert!(arcade.has_session_timer());
         assert!(!survival.has_session_timer());
@@ -1397,7 +1400,8 @@ mod tests {
             .map(|i| create_test_scenario(&format!("s{}", i), Difficulty::Beginner))
             .collect();
 
-        let mode = MiniGameMode::Challenge(ChallengeConfig::for_today());
+        let mode =
+            MiniGameMode::Challenge(ChallengeConfig::for_date(chrono::Utc::now().date_naive()));
         let mut session = MiniGameSession::with_mode(Arc::new(scenarios), None, mode);
 
         // Not game over initially

--- a/src/testing/app_state.rs
+++ b/src/testing/app_state.rs
@@ -5,7 +5,9 @@
 use crate::config::Scenario;
 use crate::gamification::{ProfileStorage, UserProfile};
 use crate::learning::PerformanceTracker;
-use crate::ui::state::AppState;
+use crate::time::Clock;
+use crate::ui::state::{AppState, ConfigState};
+use std::sync::Arc;
 
 /// Create a test AppState with no scenarios
 ///
@@ -30,6 +32,7 @@ pub struct TestAppStateBuilder {
     profile: Option<UserProfile>,
     storage: Option<ProfileStorage>,
     tracker: Option<PerformanceTracker>,
+    clock: Option<Arc<dyn Clock>>,
 }
 
 impl Default for TestAppStateBuilder {
@@ -46,6 +49,7 @@ impl TestAppStateBuilder {
             profile: None,
             storage: None,
             tracker: None,
+            clock: None,
         }
     }
 
@@ -79,12 +83,28 @@ impl TestAppStateBuilder {
         self
     }
 
+    /// Set a custom clock (e.g. [`crate::time::FakeClock`]) for deterministic time-based tests
+    pub fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = Some(clock);
+        self
+    }
+
     /// Build the AppState
     pub fn build(self) -> AppState {
         let profile = self.profile.unwrap_or_default();
         let storage = self.storage.unwrap_or_else(ProfileStorage::for_test);
         let tracker = self.tracker.unwrap_or_default();
-        AppState::new(self.scenarios, profile, storage, tracker)
+        match self.clock {
+            Some(clock) => AppState::with_clock(
+                self.scenarios,
+                profile,
+                storage,
+                tracker,
+                ConfigState::default(),
+                clock,
+            ),
+            None => AppState::new(self.scenarios, profile, storage, tracker),
+        }
     }
 }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,150 @@
+//! Clock abstraction for testable time-dependent logic.
+//!
+//! Production code obtains the current time through a [`Clock`] implementation instead of
+//! calling `Utc::now()` directly, so tests can inject [`FakeClock`] to control day-boundary
+//! and scheduling behavior deterministically.
+
+use chrono::{DateTime, Duration, NaiveDate, Utc};
+use std::sync::Mutex;
+
+/// Source of the current time for application logic.
+///
+/// Implementors must guarantee `now()` is safe to call from any thread, since long-lived
+/// holders of `Arc<dyn Clock>` are shared across tokio tasks. Callers may assume `today()`
+/// is consistent with `now()` (same instant, just truncated to a date).
+pub trait Clock: Send + Sync {
+    /// Returns the current UTC time.
+    fn now(&self) -> DateTime<Utc>;
+
+    /// Returns the current UTC date, derived from [`Clock::now`].
+    fn today(&self) -> NaiveDate {
+        self.now().date_naive()
+    }
+}
+
+/// [`Clock`] implementation backed by the system wall clock.
+///
+/// # Examples
+///
+/// ```
+/// use helix_trainer::time::{Clock, SystemClock};
+///
+/// let clock = SystemClock;
+/// let _now = clock.now();
+/// ```
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+}
+
+/// [`Clock`] implementation with a manually controlled time, for tests.
+///
+/// # Examples
+///
+/// ```
+/// use chrono::Duration;
+/// use helix_trainer::time::{Clock, FakeClock};
+///
+/// let clock = FakeClock::at("2026-01-15T12:00:00Z");
+/// let before = clock.now();
+/// clock.advance(Duration::days(1));
+/// assert!(clock.now() > before);
+/// ```
+#[derive(Debug)]
+pub struct FakeClock {
+    now: Mutex<DateTime<Utc>>,
+}
+
+impl FakeClock {
+    /// Creates a fake clock fixed at the given time.
+    pub fn new(now: DateTime<Utc>) -> Self {
+        Self {
+            now: Mutex::new(now),
+        }
+    }
+
+    /// Creates a fake clock fixed at the given RFC 3339 timestamp.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `rfc3339` is not a valid RFC 3339 timestamp. Intended for test ergonomics
+    /// where a malformed literal is a test bug, not a runtime condition to handle.
+    pub fn at(rfc3339: &str) -> Self {
+        let now = DateTime::parse_from_rfc3339(rfc3339)
+            .unwrap_or_else(|err| panic!("invalid RFC 3339 timestamp {rfc3339:?}: {err}"))
+            .with_timezone(&Utc);
+        Self::new(now)
+    }
+
+    /// Sets the clock to the given time.
+    pub fn set(&self, now: DateTime<Utc>) {
+        *self
+            .now
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = now;
+    }
+
+    /// Advances the clock by the given duration.
+    pub fn advance(&self, duration: Duration) {
+        let mut guard = self
+            .now
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *guard += duration;
+    }
+
+    /// Advances the clock by the given number of days.
+    pub fn advance_days(&self, days: i64) {
+        self.advance(Duration::days(days));
+    }
+}
+
+impl Clock for FakeClock {
+    fn now(&self) -> DateTime<Utc> {
+        *self
+            .now
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn system_clock_now_is_current() {
+        let clock = SystemClock;
+        let before = Utc::now();
+        let now = clock.now();
+        let after = Utc::now();
+        assert!(now >= before && now <= after);
+    }
+
+    #[test]
+    fn fake_clock_at_parses_rfc3339() {
+        let clock = FakeClock::at("2026-01-15T12:00:00Z");
+        assert_eq!(clock.today(), NaiveDate::from_ymd_opt(2026, 1, 15).unwrap());
+    }
+
+    #[test]
+    fn fake_clock_advance_days_moves_today() {
+        let clock = FakeClock::at("2026-01-15T12:00:00Z");
+        clock.advance_days(1);
+        assert_eq!(clock.today(), NaiveDate::from_ymd_opt(2026, 1, 16).unwrap());
+    }
+
+    #[test]
+    fn fake_clock_set_overrides_time() {
+        let clock = FakeClock::at("2026-01-15T12:00:00Z");
+        let new_time = DateTime::parse_from_rfc3339("2027-06-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        clock.set(new_time);
+        assert_eq!(clock.now(), new_time);
+    }
+}

--- a/src/ui/render/mode_selection.rs
+++ b/src/ui/render/mode_selection.rs
@@ -163,7 +163,11 @@ fn render_minigame_mode_submenu(
     let modes: [(MiniGameMode, &str); 3] = [
         (MiniGameMode::Arcade(ArcadeConfig::default()), "🎮"),
         (MiniGameMode::Survival(SurvivalConfig::default()), "💀"),
-        (MiniGameMode::Challenge(ChallengeConfig::for_today()), "📅"),
+        // Display-only placeholder icon; not tied to a live clock, so wall-clock is fine here.
+        (
+            MiniGameMode::Challenge(ChallengeConfig::for_date(chrono::Utc::now().date_naive())),
+            "📅",
+        ),
     ];
 
     for (idx, (mode, icon)) in modes.iter().enumerate() {

--- a/src/ui/render/review.rs
+++ b/src/ui/render/review.rs
@@ -112,7 +112,9 @@ fn render_command_info(frame: &mut Frame, area: Rect, state: &AppState, command:
     };
 
     let next_review = if let Some(p) = perf {
-        let now = chrono::Utc::now();
+        // `state: &AppState` is in scope here, so use the injected clock rather than
+        // the wall clock directly.
+        let now = state.progress.now();
         let days = (p.due - now).num_days();
         if days > 0 {
             format!("Next: in {} days", days)

--- a/src/ui/state/handlers/mode_selection.rs
+++ b/src/ui/state/handlers/mode_selection.rs
@@ -54,7 +54,7 @@ pub(in crate::ui::state) fn handle_mode_selection_select(
     // Check if mini-game mode selection is active
     if let Some(ref selection) = data.minigame_mode_selection {
         // Launch the selected mini-game mode
-        let mode = selection.selected_mode();
+        let mode = selection.selected_mode(ctx.progress.today());
         return handle_launch_minigame_mode(ctx, mode);
     }
 
@@ -433,8 +433,9 @@ mod tests {
         let (mut ui, mut game, mut progress, config) = create_test_context_with_scenarios();
         let mut ctx = HandlerContext::new(&mut ui, &mut game, &mut progress, &config);
 
-        let mode =
-            crate::minigame::MiniGameMode::Challenge(crate::minigame::ChallengeConfig::for_today());
+        let mode = crate::minigame::MiniGameMode::Challenge(
+            crate::minigame::ChallengeConfig::for_date(chrono::Utc::now().date_naive()),
+        );
         let outcome = handle_launch_minigame_mode(&mut ctx, mode).unwrap();
 
         assert!(outcome.is_transition());

--- a/src/ui/state/handlers/scenario.rs
+++ b/src/ui/state/handlers/scenario.rs
@@ -248,12 +248,14 @@ pub fn handle_complete_scenario(state: &mut AppState) -> Result<HandlerOutcome, 
     let is_first_today = ctx.progress.scenarios_completed_today == 0;
     let xp = ScenarioCompletionService::calculate_xp_components(&feedback, is_first_today);
 
+    let now = ctx.progress.now();
     let (actual_xp, mastery_level, mastery_multiplier, mastery_factor, repeat_penalty) =
         ScenarioCompletionService::record_and_scale_xp(
             &mut ctx.progress.profile,
             &scenario_id,
             feedback.score,
             xp.total_base_xp,
+            now,
         );
 
     // Store mastery info for results display

--- a/src/ui/state/mod.rs
+++ b/src/ui/state/mod.rs
@@ -23,7 +23,9 @@ use crate::gamification::{ProfileStorage, UserProfile};
 use crate::learning::PerformanceTracker;
 use crate::security::UserError;
 use crate::sound::SoundEffect;
+use crate::time::Clock;
 use std::fmt;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 // Message handlers in separate modules
@@ -389,11 +391,38 @@ impl AppState {
         performance_tracker: PerformanceTracker,
         config: ConfigState,
     ) -> Self {
+        Self::with_clock(
+            scenarios,
+            profile,
+            profile_storage,
+            performance_tracker,
+            config,
+            Arc::new(crate::time::SystemClock),
+        )
+    }
+
+    /// Create a new application state with custom configuration and an explicit clock
+    ///
+    /// Primarily useful for tests that need deterministic control over day-boundary
+    /// and scheduling behavior; see [`crate::time::FakeClock`].
+    pub fn with_clock(
+        scenarios: Vec<Scenario>,
+        profile: UserProfile,
+        profile_storage: ProfileStorage,
+        performance_tracker: PerformanceTracker,
+        config: ConfigState,
+        clock: Arc<dyn Clock>,
+    ) -> Self {
         Self {
             screen: TypedScreen::ModeSelection(ModeSelectionData::default()),
             ui: UIState::new(),
             game: GameState::new(scenarios),
-            progress: ProgressState::new(profile, performance_tracker, profile_storage),
+            progress: ProgressState::with_clock(
+                profile,
+                performance_tracker,
+                profile_storage,
+                clock,
+            ),
             config,
         }
     }

--- a/src/ui/state/screen.rs
+++ b/src/ui/state/screen.rs
@@ -416,13 +416,13 @@ impl MiniGameModeSelection {
     }
 
     /// Get the selected mode configuration
-    pub fn selected_mode(&self) -> crate::minigame::MiniGameMode {
+    pub fn selected_mode(&self, today: chrono::NaiveDate) -> crate::minigame::MiniGameMode {
         use crate::minigame::{ArcadeConfig, ChallengeConfig, MiniGameMode, SurvivalConfig};
 
         match self.selected_index {
             0 => MiniGameMode::Arcade(ArcadeConfig::default()),
             1 => MiniGameMode::Survival(SurvivalConfig::default()),
-            2 => MiniGameMode::Challenge(ChallengeConfig::for_today()),
+            2 => MiniGameMode::Challenge(ChallengeConfig::for_date(today)),
             _ => MiniGameMode::default(),
         }
     }
@@ -781,7 +781,7 @@ mod tests {
     fn test_selected_mode_invalid_index() {
         let mut selection = MiniGameModeSelection::new();
         selection.selected_index = 99;
-        let mode = selection.selected_mode();
+        let mode = selection.selected_mode(chrono::Utc::now().date_naive());
         // Should fall back to default Arcade mode
         assert!(mode.is_arcade());
     }
@@ -799,15 +799,16 @@ mod tests {
         assert!(!MiniGameModeSelection::mode_description(2).is_empty());
 
         // Test valid selected modes
+        let today = chrono::Utc::now().date_naive();
         let mut selection = MiniGameModeSelection::new();
         selection.selected_index = 0;
-        assert!(selection.selected_mode().is_arcade());
+        assert!(selection.selected_mode(today).is_arcade());
 
         selection.selected_index = 1;
-        assert!(selection.selected_mode().is_survival());
+        assert!(selection.selected_mode(today).is_survival());
 
         selection.selected_index = 2;
-        assert!(selection.selected_mode().is_challenge());
+        assert!(selection.selected_mode(today).is_challenge());
     }
 
     #[test]

--- a/src/ui/state/substates.rs
+++ b/src/ui/state/substates.rs
@@ -9,7 +9,9 @@ use crate::game::GameSession;
 use crate::gamification::{ProfileStorage, UserProfile};
 use crate::learning::{PerformanceTracker, ScenarioMastery, Scheduler};
 use crate::sound::SoundManager;
+use crate::time::Clock;
 use std::collections::HashSet;
+use std::sync::Arc;
 use std::time::Instant;
 
 use super::{QuestProgressChange, ReviewSessionState, XPBreakdown};
@@ -177,24 +179,53 @@ pub struct ProgressState {
 
     /// Sound manager for audio feedback
     pub sound_manager: SoundManager,
+
+    /// Source of the current time, injected for testability
+    ///
+    /// Private: construction is routed exclusively through [`ProgressState::new`] /
+    /// [`ProgressState::with_clock`] so that every clock-consuming field
+    /// (`performance_tracker`, `scheduler`) is guaranteed to share this same instance.
+    /// Reassigning the field directly after construction would not re-point those fields
+    /// and would silently reintroduce clock drift between them.
+    clock: Arc<dyn Clock>,
 }
 
 impl ProgressState {
-    /// Create new ProgressState
+    /// Create new ProgressState backed by the system clock
     pub fn new(
         profile: UserProfile,
         performance_tracker: PerformanceTracker,
         storage: ProfileStorage,
+    ) -> Self {
+        Self::with_clock(
+            profile,
+            performance_tracker,
+            storage,
+            Arc::new(crate::time::SystemClock),
+        )
+    }
+
+    /// Create new ProgressState with an explicit clock
+    ///
+    /// The clock is propagated to every clock-consuming field (`performance_tracker`,
+    /// `scheduler`) so they observe the same time, not just `self.clock`.
+    pub fn with_clock(
+        profile: UserProfile,
+        mut performance_tracker: PerformanceTracker,
+        storage: ProfileStorage,
+        clock: Arc<dyn Clock>,
     ) -> Self {
         // Initialize sound manager from profile config
         let mut sound_manager = SoundManager::new(profile.sound_config.clone());
         // Try to initialize audio (graceful failure)
         let _ = sound_manager.try_init();
 
+        performance_tracker.set_clock(clock.clone());
+
         Self {
             profile,
             performance_tracker,
-            scheduler: Scheduler::new(),
+            scheduler: Scheduler::with_clock(clock.clone()),
             storage,
             scenarios_completed_today: 0,
             commands_used_today: HashSet::new(),
@@ -202,7 +233,24 @@ impl ProgressState {
             session_start_time: Instant::now(),
             last_save_time: None,
             sound_manager,
+            clock,
         }
+    }
+
+    /// Get the current time from the injected clock
+    pub fn now(&self) -> chrono::DateTime<chrono::Utc> {
+        self.clock.now()
+    }
+
+    /// Get the current date from the injected clock
+    pub fn today(&self) -> chrono::NaiveDate {
+        self.clock.today()
+    }
+
+    /// Get a shared handle to the injected clock, e.g. to construct another clock-consuming
+    /// type (such as `PerformanceTracker::from_stats_with_clock`) that shares the same time.
+    pub fn clock(&self) -> Arc<dyn Clock> {
+        self.clock.clone()
     }
 
     /// Check if enough time has passed since last save
@@ -412,6 +460,47 @@ mod tests {
         assert!(progress.last_save_time.is_none());
         progress.mark_saved();
         assert!(progress.last_save_time.is_some());
+    }
+
+    /// Regression test: `ProgressState::with_clock` must propagate the injected clock to
+    /// every clock-consuming field, not just `self.clock`. Previously `performance_tracker`
+    /// kept whatever clock it was constructed with (typically `SystemClock`), so a command
+    /// recorded through it stamped `due`/`last_review` from the wall clock while
+    /// `scheduler.get_due_reviews` compared against the injected fake clock — due dates
+    /// would land far off from what the fake clock reported "now" as.
+    #[test]
+    fn test_with_clock_propagates_to_performance_tracker_and_scheduler() {
+        use crate::gamification::{ProfileStorage, UserProfile};
+        use crate::learning::PerformanceTracker;
+        use crate::time::{Clock, FakeClock};
+        use std::sync::Arc;
+
+        let clock = Arc::new(FakeClock::at("2026-01-15T12:00:00Z"));
+        let mut progress = ProgressState::with_clock(
+            UserProfile::new(),
+            PerformanceTracker::new(), // built with the default SystemClock
+            ProfileStorage::for_test(),
+            clock.clone(),
+        );
+
+        progress.performance_tracker.record_attempt(
+            "x",
+            std::time::Duration::from_secs(1),
+            true,
+            std::time::Duration::from_secs(1),
+        );
+
+        // If the tracker still used SystemClock, `last_review` would be wall-clock "now",
+        // not the fake clock's fixed instant.
+        let perf = progress.performance_tracker.get_performance("x").unwrap();
+        assert_eq!(perf.last_review, clock.now());
+
+        // The scheduler must observe the same fake "now" the tracker recorded against, so
+        // a command recorded at the fake clock's current time is immediately due.
+        let due = progress
+            .scheduler
+            .get_due_reviews(&progress.performance_tracker);
+        assert!(due.contains(&"x".to_string()));
     }
 
     #[test]

--- a/src/ui/state/tests/quest_tests.rs
+++ b/src/ui/state/tests/quest_tests.rs
@@ -393,8 +393,18 @@ fn test_quest_completion_populates_completed_quests_today() {
 /// `completed_quests_today` was populated by a live quest completion the day before.
 #[test]
 fn test_streak_increments_next_day_after_live_quest_completion() {
+    use crate::gamification::UserProfile;
+    use crate::testing::TestAppStateBuilder;
+    use crate::time::{Clock, FakeClock};
+    use std::sync::Arc;
+
     let scenario = create_test_scenario();
-    let mut state = create_test_app_state(vec![scenario]);
+    let clock = Arc::new(FakeClock::at("2026-01-15T12:00:00Z"));
+    let mut state = TestAppStateBuilder::new()
+        .scenario(scenario)
+        .profile(UserProfile::new_at(clock.now()))
+        .with_clock(clock.clone())
+        .build();
     state.progress.profile.current_streak = 3;
 
     {
@@ -422,11 +432,12 @@ fn test_streak_increments_next_day_after_live_quest_completion() {
     )
     .unwrap();
 
-    // Simulate that this activity happened yesterday, as `StreakManager` would see it
-    // at the start of the next session.
-    state.progress.profile.last_activity = chrono::Utc::now() - chrono::Duration::days(1);
+    // Advance the injected clock to the next day, as the next session's load would see it,
+    // instead of backdating `last_activity` directly.
+    clock.advance_days(1);
 
-    let change = StreakManager::update_streak(&mut state.progress.profile);
+    let now = state.progress.now();
+    let change = StreakManager::update_streak(&mut state.progress.profile, now);
 
     assert_eq!(
         change,

--- a/tests/gamification.rs
+++ b/tests/gamification.rs
@@ -19,7 +19,12 @@ fn test_complete_user_flow() {
     let registry = test_registry();
 
     // Day 1: Generate quests
-    let mut quests = QuestGenerator::generate_quests(&profile, &tracker, &registry);
+    let mut quests = QuestGenerator::generate_quests(
+        &profile,
+        &tracker,
+        &registry,
+        chrono::Utc::now().date_naive(),
+    );
     assert_eq!(quests.len(), 3); // Beginner gets 3 quests
 
     // Complete a command quest
@@ -35,7 +40,7 @@ fn test_complete_user_flow() {
     }
 
     // Update streak
-    let change = StreakManager::update_streak(&mut profile);
+    let change = StreakManager::update_streak(&mut profile, chrono::Utc::now());
     assert!(matches!(
         change,
         StreakChange::Continued | StreakChange::Incremented { .. }
@@ -78,17 +83,32 @@ fn test_quest_generation_adapts_to_level() {
     // Level 1: Easy quests
     let mut profile = UserProfile::new();
     profile.level = 1;
-    let quests = QuestGenerator::generate_quests(&profile, &tracker, &registry);
+    let quests = QuestGenerator::generate_quests(
+        &profile,
+        &tracker,
+        &registry,
+        chrono::Utc::now().date_naive(),
+    );
     assert_eq!(quests.len(), 3); // 2 easy + 1 medium
 
     // Level 10: Mixed difficulty
     profile.level = 10;
-    let quests = QuestGenerator::generate_quests(&profile, &tracker, &registry);
+    let quests = QuestGenerator::generate_quests(
+        &profile,
+        &tracker,
+        &registry,
+        chrono::Utc::now().date_naive(),
+    );
     assert_eq!(quests.len(), 4); // 1 easy + 2 medium + 1 hard
 
     // Level 20: Hard quests
     profile.level = 20;
-    let quests = QuestGenerator::generate_quests(&profile, &tracker, &registry);
+    let quests = QuestGenerator::generate_quests(
+        &profile,
+        &tracker,
+        &registry,
+        chrono::Utc::now().date_naive(),
+    );
     assert_eq!(quests.len(), 4); // 1 medium + 2 hard + 1 exploration
 }
 
@@ -116,8 +136,9 @@ fn test_quest_type_variations() {
     let registry = test_registry();
 
     // Generate multiple times and check variety
-    let quests1 = QuestGenerator::generate_quests(&profile, &tracker, &registry);
-    let quests2 = QuestGenerator::generate_quests(&profile, &tracker, &registry);
+    let today = chrono::Utc::now().date_naive();
+    let quests1 = QuestGenerator::generate_quests(&profile, &tracker, &registry, today);
+    let quests2 = QuestGenerator::generate_quests(&profile, &tracker, &registry, today);
 
     // Since they use the same date seed, they should be identical
     assert_eq!(quests1.len(), quests2.len());
@@ -156,14 +177,17 @@ fn test_achievement_progression() {
 
 #[test]
 fn test_streak_freeze_mechanics() {
-    let mut profile = UserProfile::new();
+    use helix_trainer::time::{Clock, FakeClock};
+
+    let clock = FakeClock::at("2026-01-15T12:00:00Z");
+    let mut profile = UserProfile::new_at(clock.now());
     profile.current_streak = 10;
     profile.streak_freeze_available = true;
 
     // Simulate missing a day
-    profile.last_activity = chrono::Utc::now() - chrono::Duration::days(2);
+    clock.advance_days(2);
 
-    let change = StreakManager::update_streak(&mut profile);
+    let change = StreakManager::update_streak(&mut profile, clock.now());
     assert_eq!(change, StreakChange::Protected { used_freeze: true });
     assert_eq!(profile.current_streak, 10); // Preserved
     assert!(!profile.streak_freeze_available); // Used up
@@ -264,7 +288,7 @@ fn test_daily_quest_reset() {
     assert_eq!(profile.completed_quests_today.len(), 2);
 
     // Reset daily quests
-    profile.reset_daily_quests();
+    profile.reset_daily_quests(chrono::Utc::now());
     assert_eq!(profile.completed_quests_today.len(), 0);
     assert_eq!(profile.daily_quests.len(), 0);
 }
@@ -413,21 +437,24 @@ fn test_freeze_eligibility() {
 
 #[test]
 fn test_longest_streak_tracking() {
-    let mut profile = UserProfile::new();
+    use helix_trainer::time::{Clock, FakeClock};
+
+    let clock = FakeClock::at("2026-01-15T12:00:00Z");
+    let mut profile = UserProfile::new_at(clock.now());
     profile.current_streak = 5;
     profile.longest_streak = 5;
 
     // Increment streak
-    profile.last_activity = chrono::Utc::now() - chrono::Duration::days(1);
     profile.complete_quest("test".to_string());
-    StreakManager::update_streak(&mut profile);
+    clock.advance_days(1);
+    StreakManager::update_streak(&mut profile, clock.now());
 
     assert_eq!(profile.current_streak, 6);
     assert_eq!(profile.longest_streak, 6);
 
     // Break streak
-    profile.last_activity = chrono::Utc::now() - chrono::Duration::days(2);
-    StreakManager::update_streak(&mut profile);
+    clock.advance_days(2);
+    StreakManager::update_streak(&mut profile, clock.now());
 
     assert_eq!(profile.current_streak, 0);
     assert_eq!(profile.longest_streak, 6); // Preserved

--- a/tests/spaced_repetition.rs
+++ b/tests/spaced_repetition.rs
@@ -112,7 +112,7 @@ fn test_complete_learning_workflow() {
     );
 
     // Check progress over time
-    let progress = Analytics::get_progress_over_time(&tracker, 7);
+    let progress = Analytics::get_progress_over_time(&tracker, 7, chrono::Utc::now());
     // Progress data should exist (even if placeholder for new tracker)
     assert!(progress.len() <= 8); // 0..=days = 8 entries for 7 days
 }
@@ -157,7 +157,7 @@ fn test_analytics_empty_tracker() {
     assert_eq!(mastery_summary.total_commands, 0);
     assert_eq!(mastery_summary.beginner, 0);
 
-    let progress = Analytics::get_progress_over_time(&tracker, 7);
+    let progress = Analytics::get_progress_over_time(&tracker, 7, chrono::Utc::now());
     // Returns placeholder data even for empty tracker (for UI consistency)
     assert!(progress.len() <= 8);
 


### PR DESCRIPTION
## Summary

- Add a `Clock` trait (`src/time.rs`) with `SystemClock` (production) and `FakeClock` (test) implementations, replacing direct `chrono::Utc::now()` calls in day-boundary and elapsed-time logic across `gamification/`, `learning/`, and `minigame/`.
- `PerformanceTracker`, `Scheduler`, and `ProgressState` hold an injected `clock: Arc<dyn Clock>` field (`with_clock()` constructor; `new()` defaults to `SystemClock`, so production behavior is unchanged).
- Serde-persisted value types (`StreakManager`, `UserProfile`, `Achievement`, `QuestGenerator`, `ScenarioCompletion`, `ScenarioHistory`, `Analytics`, `ChallengeProgress`, `ChallengeConfig`) take a mandatory trailing `now`/`today` parameter instead, since they can't hold a clock field.
- Two double-clock-read sites (`ScenarioCompletion::record_attempt` + `check_and_reset_daily`, `data_handling.rs`'s `ProfileReady` handler, `PerformanceTracker::record_attempt`) collapse to a single read per logical operation — a deliberate fix for a latent midnight-boundary race, called out explicitly rather than folded in silently.
- Existing tests that faked elapsed time by backdating stored fields are converted to use `FakeClock`.
- `Instant::now()` sites (arcade-mode elapsed-time measurement) are intentionally out of scope — `std::time::Instant` can't be constructed at an arbitrary value, so a matching monotonic-clock abstraction needs a different approach and is tracked as a follow-up.

## Breaking changes (pre-1.0.0, no deprecation shims per project convention)

Signatures of `StreakManager::update_streak`, `UserProfile::reset_daily_quests`, `Achievement::unlock`, `AchievementEngine::check_and_unlock`, `QuestGenerator::generate_quests`, `ScenarioCompletion::new`/`record_attempt`, `ScenarioHistory::record_completion`, `Analytics::get_progress_over_time`, `ChallengeProgress`'s day-boundary methods, and `ScenarioCompletionService::record_and_scale_xp` now take an explicit `now`/`today` parameter. `ChallengeConfig::for_today()` and `impl Default for ChallengeConfig` are removed in favor of the existing `for_date(today)` constructor. See `CHANGELOG.md` for the full list.

Fixes #269

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (1852/1852)
- [x] `cargo nextest run --workspace --all-features` (full surface incl. `tests/`)
- [x] `cargo test --doc` (incl. new `src/time.rs` doc-tests)
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] `cargo check --no-default-features`
- [x] New regression test `test_with_clock_propagates_to_performance_tracker_and_scheduler` proves the injected clock reaches both `PerformanceTracker` and `Scheduler`, not just one