### PR TITLE
fix(game): require normal mode before scenario completes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Scenario completion checking now requires the editor to be back in Normal mode, not just matching content/cursor/selections; scenarios whose solution is a bare mode-entry command followed by `Escape` (e.g. `o`, `Escape` for "Insert line below") no longer complete on the mode-entry keystroke alone, before `Escape` is pressed (#283). `open_below_001`/`open_above_001` now hint that Escape is required, the progress bar no longer reads 100% while still in Insert mode, and the hint panel no longer swallows the first Escape needed to exit Insert mode
 - CI now runs the full `cargo nextest` test surface (`--workspace --all-features --lib --bins --tests`) instead of `--lib` only, so integration tests under `tests/` (e.g. `tests/scenario_validation.rs`, which verifies every scenario's documented solution actually completes it) are no longer silently skipped in CI (#288)
 - Added `.gitattributes` (`* text=auto eol=lf`) to force LF checkouts on every platform; without it, Windows checkouts converted `scenarios/`/`quests/` TOML files to CRLF, and since those are embedded verbatim via `include_str!()`, the TOML parser preserved `\r\n` literally inside multi-line strings, corrupting scenario content and breaking cursor/column math for roughly half of all scenarios on Windows only — surfaced immediately once CI began running `tests/scenario_validation.rs` on `windows-latest` (#288)
 - Pausing an arcade/survival/challenge mini-game session no longer lets the active scenario's countdown timer keep draining in real time; elapsed time now excludes accumulated paused duration (#271)
@@ -61,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consolidated scenario/quest TOML parsing, count-limit enforcement, and per-item validation into a shared `config::loader::parse_and_validate` pipeline (#276)
 - Collapsed the duplicated `PlayableScenario` trait implementations for `GameSession<Active>` and `GameSession<Completed>` into a single `impl<S: SessionState> PlayableScenario for GameSession<S>` block; the per-state `elapsed()` behavior is now dispatched through a new `SessionState::session_elapsed` associated function (#280)
 - **BREAKING**: Removed `AppState::save_profile_debounced`, `AppState::save_profile_immediate`, and `ProgressState::save_blocking` — the serialized save-writer path introduced for #294 left them with no production caller; the application's exit-time save now goes through `AppState::prepare_final_save_request` instead (#294)
+- `ScenarioCompletionService::record_and_scale_xp` now returns a named `XPScalingResult` struct instead of an unlabeled `(u64, ScenarioMastery, f64, f64, f64)` tuple, removing the risk of a silent positional swap between its three `f64` fields (#281)
 
 ## [0.5.12] - 2026-07-27
 

--- a/scenarios/en/basic/insert.toml
+++ b/scenarios/en/basic/insert.toml
@@ -46,7 +46,10 @@ id = "open_below_001"
 name = "Insert line below"
 description = "Open a new line below the current line"
 
-hints = ["'o' inserts a new line below and enters insert mode"]
+hints = [
+    "'o' inserts a new line below and enters insert mode",
+    "Don't forget to press Escape to exit insert mode",
+]
 
 [scenarios.setup]
 file_content = """fn add(a: i32, b: i32) -> i32 {
@@ -82,7 +85,10 @@ id = "open_above_001"
 name = "Insert line above"
 description = "Open a new line above the current line"
 
-hints = ["'O' inserts a new line above and enters insert mode"]
+hints = [
+    "'O' inserts a new line above and enters insert mode",
+    "Don't forget to press Escape to exit insert mode",
+]
 
 [scenarios.setup]
 file_content = """fn main() {

--- a/src/game/scenario_state.rs
+++ b/src/game/scenario_state.rs
@@ -129,4 +129,40 @@ mod tests {
 
         assert!(!state.content_matches());
     }
+
+    /// Regression test for #283: entering Insert mode alone must not
+    /// register as completion, even when the target content is already
+    /// reachable mid-Insert (e.g. `o` opens a blank line matching the
+    /// target before `Escape` returns to Normal mode).
+    #[test]
+    fn test_insert_mode_entry_alone_does_not_complete() {
+        let scenario = ScenarioBuilder::new()
+            .id("open_below_001")
+            .name("Insert line below")
+            .setup_content("fn add(a: i32, b: i32) -> i32 {\n    a + b\n}")
+            .setup_cursor(0, 0)
+            .target_content("fn add(a: i32, b: i32) -> i32 {\n\n    a + b\n}")
+            .target_cursor(1, 0)
+            .commands(vec!["o", "Escape"])
+            .command_description("Press 'o' to open line below, then Escape")
+            .optimal_count(2)
+            .build();
+        let mut state = ScenarioState::from_scenario(&scenario).unwrap();
+
+        state.simulator.execute_command("o").unwrap();
+        assert_eq!(
+            state.simulator.display().content(),
+            scenario.target.file_content
+        );
+        assert!(
+            !state.is_completed(),
+            "scenario must not complete while still in Insert mode"
+        );
+
+        state.simulator.execute_command("Escape").unwrap();
+        assert!(
+            state.is_completed(),
+            "scenario must complete once back in Normal mode"
+        );
+    }
 }

--- a/src/game/services/scenario_completion.rs
+++ b/src/game/services/scenario_completion.rs
@@ -29,11 +29,14 @@ pub struct CompletionResult {
 
 /// Result of recording a scenario completion and scaling its XP by mastery
 ///
-/// Mixes one post-recording field with three pre-recording fields, each
-/// documented individually below to avoid ambiguity.
+/// Fields are a mix of post-recording values (`actual_xp`, `mastery_level`)
+/// and pre-recording values (`applied_multiplier`, `applied_mastery_factor`,
+/// `applied_repeat_penalty`), each documented individually below to avoid
+/// ambiguity.
 #[derive(Debug, Clone)]
-pub struct XpScalingResult {
-    /// XP actually awarded for this completion, after mastery/repeat scaling
+pub struct XPScalingResult {
+    /// XP actually awarded for this completion, after mastery/repeat scaling;
+    /// reflects the post-recording state
     pub actual_xp: u64,
     /// Mastery level *after* recording this completion, for display purposes
     pub mastery_level: ScenarioMastery,
@@ -73,7 +76,7 @@ impl ScenarioCompletionService {
 
     /// Record scenario completion and return mastery-scaled XP
     ///
-    /// See [`XpScalingResult`] for the distinction between the post-recording
+    /// See [`XPScalingResult`] for the distinction between the post-recording
     /// `mastery_level` field and the pre-recording multiplier fields.
     #[must_use]
     pub fn record_and_scale_xp(
@@ -82,7 +85,7 @@ impl ScenarioCompletionService {
         score: u32,
         base_xp: u64,
         now: DateTime<Utc>,
-    ) -> XpScalingResult {
+    ) -> XPScalingResult {
         // Capture multipliers BEFORE recording (what will be applied)
         let (_pre_mastery_level, pre_mastery_factor, pre_repeat_penalty) = profile
             .scenario_history
@@ -105,7 +108,7 @@ impl ScenarioCompletionService {
         let applied_multiplier = pre_mastery_factor * pre_repeat_penalty;
 
         // Return post-mastery level (for display) but pre-multipliers (what was applied)
-        XpScalingResult {
+        XPScalingResult {
             actual_xp,
             mastery_level: post_mastery_level,
             applied_multiplier,

--- a/src/game/services/scenario_completion.rs
+++ b/src/game/services/scenario_completion.rs
@@ -27,6 +27,27 @@ pub struct CompletionResult {
     pub leveled_up: bool,
 }
 
+/// Result of recording a scenario completion and scaling its XP by mastery
+///
+/// Mixes one post-recording field with three pre-recording fields, each
+/// documented individually below to avoid ambiguity.
+#[derive(Debug, Clone)]
+pub struct XpScalingResult {
+    /// XP actually awarded for this completion, after mastery/repeat scaling
+    pub actual_xp: u64,
+    /// Mastery level *after* recording this completion, for display purposes
+    pub mastery_level: ScenarioMastery,
+    /// Combined multiplier (`applied_mastery_factor * applied_repeat_penalty`)
+    /// that was applied to this completion, captured *before* recording
+    pub applied_multiplier: f64,
+    /// Mastery-level XP factor that was applied to this completion,
+    /// captured *before* recording
+    pub applied_mastery_factor: f64,
+    /// Session repeat-penalty factor that was applied to this completion,
+    /// captured *before* recording
+    pub applied_repeat_penalty: f64,
+}
+
 /// Service for scenario completion operations
 pub struct ScenarioCompletionService;
 
@@ -52,8 +73,8 @@ impl ScenarioCompletionService {
 
     /// Record scenario completion and return mastery-scaled XP
     ///
-    /// Returns: (actual_xp, mastery_level, applied_multiplier, applied_mastery_factor, applied_repeat_penalty)
-    /// Note: multipliers returned are what was APPLIED to this completion, not current state
+    /// See [`XpScalingResult`] for the distinction between the post-recording
+    /// `mastery_level` field and the pre-recording multiplier fields.
     #[must_use]
     pub fn record_and_scale_xp(
         profile: &mut UserProfile,
@@ -61,7 +82,7 @@ impl ScenarioCompletionService {
         score: u32,
         base_xp: u64,
         now: DateTime<Utc>,
-    ) -> (u64, ScenarioMastery, f64, f64, f64) {
+    ) -> XpScalingResult {
         // Capture multipliers BEFORE recording (what will be applied)
         let (_pre_mastery_level, pre_mastery_factor, pre_repeat_penalty) = profile
             .scenario_history
@@ -84,13 +105,13 @@ impl ScenarioCompletionService {
         let applied_multiplier = pre_mastery_factor * pre_repeat_penalty;
 
         // Return post-mastery level (for display) but pre-multipliers (what was applied)
-        (
+        XpScalingResult {
             actual_xp,
-            post_mastery_level,
+            mastery_level: post_mastery_level,
             applied_multiplier,
-            pre_mastery_factor,
-            pre_repeat_penalty,
-        )
+            applied_mastery_factor: pre_mastery_factor,
+            applied_repeat_penalty: pre_repeat_penalty,
+        }
     }
 
     /// Update profile counters after scenario completion
@@ -311,22 +332,21 @@ mod tests {
     #[test]
     fn test_record_and_scale_xp_first_completion() {
         let mut profile = UserProfile::new();
-        let (actual_xp, mastery, multiplier, mastery_factor, repeat_penalty) =
-            ScenarioCompletionService::record_and_scale_xp(
-                &mut profile,
-                "test_scenario",
-                100,
-                50,
-                Utc::now(),
-            );
+        let result = ScenarioCompletionService::record_and_scale_xp(
+            &mut profile,
+            "test_scenario",
+            100,
+            50,
+            Utc::now(),
+        );
 
         // First completion gets full XP (no penalty)
-        assert_eq!(actual_xp, 50);
-        assert_eq!(mastery, ScenarioMastery::Learning);
+        assert_eq!(result.actual_xp, 50);
+        assert_eq!(result.mastery_level, ScenarioMastery::Learning);
         // Pre-recording multipliers were 1.0 (no prior completion)
-        assert!((multiplier - 1.0).abs() < 0.01);
-        assert!((mastery_factor - 1.0).abs() < 0.01);
-        assert!((repeat_penalty - 1.0).abs() < 0.01);
+        assert!((result.applied_multiplier - 1.0).abs() < 0.01);
+        assert!((result.applied_mastery_factor - 1.0).abs() < 0.01);
+        assert!((result.applied_repeat_penalty - 1.0).abs() < 0.01);
     }
 
     #[test]

--- a/src/game/session/mod.rs
+++ b/src/game/session/mod.rs
@@ -341,7 +341,16 @@ impl<S: SessionState> GameSession<S> {
 
         // Calculate percentage (0-100)
         let percentage = (matching_lines * 100) / target_lines.len().max(1);
-        percentage.min(100) as u8
+
+        // Mirror matches_snapshot's mode requirement: content can match the
+        // target while still in Insert mode (e.g. right after `o`), but the
+        // scenario isn't actually complete until Escape returns to Normal
+        // mode, so don't report 100% until then.
+        if self.mode() != Mode::Normal {
+            percentage.min(99) as u8
+        } else {
+            percentage.min(100) as u8
+        }
     }
 }
 

--- a/src/game/session/tests.rs
+++ b/src/game/session/tests.rs
@@ -352,3 +352,53 @@ fn test_playable_scenario_elapsed_fixed_after_completion() {
         }
     }
 }
+
+#[test]
+fn test_completion_progress_not_100_while_in_insert_mode() {
+    // Regression test for #283: content can already match the target while
+    // still in Insert mode (e.g. right after 'o' opens a blank line), but
+    // the progress bar must not report 100% until Escape returns to Normal
+    // mode, mirroring `check_completion()`'s mode requirement.
+    let scenario = ScenarioBuilder::new()
+        .id("open_below_001")
+        .name("Insert line below")
+        .setup_content("fn add(a: i32, b: i32) -> i32 {\n    a + b\n}")
+        .setup_cursor(0, 0)
+        .target_content("fn add(a: i32, b: i32) -> i32 {\n\n    a + b\n}")
+        .target_cursor(1, 0)
+        .commands(vec!["o", "Escape"])
+        .command_description("Press 'o' to open line below, then Escape")
+        .optimal_count(2)
+        .build();
+    let session = GameSession::new(scenario).unwrap();
+
+    let result = session.record_action("o".to_string()).unwrap();
+    let session = match result {
+        SessionAfterAction::StillActive(s) => s,
+        SessionAfterAction::Completed(_) => {
+            panic!("Session should not complete while still in Insert mode")
+        }
+    };
+    assert!(
+        session.is_insert_mode(),
+        "Session should still be in Insert mode after 'o'"
+    );
+    assert!(
+        session.completion_progress() < 100,
+        "Progress must not read 100% while still in Insert mode"
+    );
+
+    let result = session.record_action("Escape".to_string()).unwrap();
+    match result {
+        SessionAfterAction::Completed(completed) => {
+            assert_eq!(
+                completed.completion_progress(),
+                100,
+                "Progress should read 100% once back in Normal mode"
+            );
+        }
+        SessionAfterAction::StillActive(_) => {
+            panic!("Session should be completed after 'o' + 'Escape'");
+        }
+    }
+}

--- a/src/helix/simulator/mod.rs
+++ b/src/helix/simulator/mod.rs
@@ -557,7 +557,9 @@ impl AnyModeSimulator {
         self.mode() == Mode::Normal
             && match self {
                 Self::Normal(sim) => sim.matches_snapshot(target),
-                Self::Insert(sim) => sim.matches_snapshot(target),
+                // Unreachable: the `mode() == Mode::Normal` check above
+                // already short-circuits before this arm can run.
+                Self::Insert(_) => false,
             }
     }
 

--- a/src/helix/simulator/mod.rs
+++ b/src/helix/simulator/mod.rs
@@ -544,12 +544,21 @@ impl AnyModeSimulator {
     /// Check if simulator state matches a target snapshot.
     ///
     /// Used for completion checking. Performs order-independent
-    /// selection comparison for multi-cursor scenarios.
+    /// selection comparison for multi-cursor scenarios. In addition to
+    /// content/cursor/selection equality, the editor must be back in
+    /// Normal mode: a scenario is only "complete" once the documented
+    /// solution has fully run, and every scenario solution that enters
+    /// Insert mode returns to Normal mode (via `Escape`) before the
+    /// target state is reached. Without this check, a scenario whose
+    /// target content is reachable mid-Insert (e.g. `o` immediately
+    /// after opening a blank line) would register as complete before
+    /// the trailing `Escape` is pressed.
     pub fn matches_snapshot(&self, target: &EditorSnapshot) -> bool {
-        match self {
-            Self::Normal(sim) => sim.matches_snapshot(target),
-            Self::Insert(sim) => sim.matches_snapshot(target),
-        }
+        self.mode() == Mode::Normal
+            && match self {
+                Self::Normal(sim) => sim.matches_snapshot(target),
+                Self::Insert(sim) => sim.matches_snapshot(target),
+            }
     }
 
     /// Create from an EditorSnapshot in Normal mode.

--- a/src/input/handlers.rs
+++ b/src/input/handlers.rs
@@ -533,6 +533,50 @@ mod tests {
         empty_test_app_state()
     }
 
+    /// Build an `Active` `GameSession` for a minimal scenario, used to exercise
+    /// insert/normal mode transitions in task-screen key handling tests.
+    fn make_active_task_session() -> GameSession<crate::game::Active> {
+        use crate::config::{CursorSpec, ScoringConfig, Setup, Solution, TargetState};
+
+        let scenario = Scenario {
+            id: "test".to_string(),
+            name: "Test".to_string(),
+            description: "Test scenario".to_string(),
+            setup: Setup {
+                file_content: "test".to_string(),
+                cursor: CursorSpec {
+                    cursor_position: Some((0, 0)),
+                    selection: None,
+                    cursors: None,
+                    selections: None,
+                },
+            },
+            target: TargetState {
+                file_content: "test2".to_string(),
+                cursor: CursorSpec {
+                    cursor_position: Some((0, 0)),
+                    selection: None,
+                    cursors: None,
+                    selections: None,
+                },
+            },
+            solution: Solution {
+                commands: vec!["x".to_string()],
+                description: "Delete char".to_string(),
+            },
+            scoring: ScoringConfig {
+                optimal_count: std::num::NonZeroUsize::new(1).unwrap(),
+                max_points: 100,
+                tolerance: 0,
+            },
+            hints: vec![],
+            alternatives: vec![],
+            metadata: None,
+        };
+
+        GameSession::new(scenario).unwrap()
+    }
+
     #[test]
     fn test_menu_key_q_quits() {
         let key = KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE);
@@ -847,52 +891,59 @@ mod tests {
 
         #[test]
         fn test_is_gameplay_insert_mode_on_task_screen_normal_mode() {
-            use crate::config::{CursorSpec, ScoringConfig, Setup, Solution, TargetState};
-
             let mut state = create_test_app_state();
-
-            // Create a simple scenario
-            let scenario = Scenario {
-                id: "test".to_string(),
-                name: "Test".to_string(),
-                description: "Test scenario".to_string(),
-                setup: Setup {
-                    file_content: "test".to_string(),
-                    cursor: CursorSpec {
-                        cursor_position: Some((0, 0)),
-                        selection: None,
-                        cursors: None,
-                        selections: None,
-                    },
-                },
-                target: TargetState {
-                    file_content: "test2".to_string(),
-                    cursor: CursorSpec {
-                        cursor_position: Some((0, 0)),
-                        selection: None,
-                        cursors: None,
-                        selections: None,
-                    },
-                },
-                solution: Solution {
-                    commands: vec!["x".to_string()],
-                    description: "Delete char".to_string(),
-                },
-                scoring: ScoringConfig {
-                    optimal_count: std::num::NonZeroUsize::new(1).unwrap(),
-                    max_points: 100,
-                    tolerance: 0,
-                },
-                hints: vec![],
-                alternatives: vec![],
-                metadata: None,
-            };
-
-            let session = GameSession::new(scenario).unwrap();
-            state.screen = TypedScreen::Task(TaskData::new(session));
+            state.screen = TypedScreen::Task(TaskData::new(make_active_task_session()));
 
             // GameSession starts in Normal mode
             assert!(!is_gameplay_insert_mode(&state));
+        }
+    }
+
+    // Regression tests for the hint-panel Escape interaction fixed alongside #283:
+    // Escape must exit Insert mode before it dismisses the hint panel.
+    mod task_keys_hint_panel_escape_tests {
+        use super::*;
+        use crate::helix::commands::CMD_INSERT;
+
+        #[test]
+        fn test_escape_exits_insert_mode_even_with_hint_panel_open() {
+            let mut state = create_test_app_state();
+            let session = make_active_task_session();
+            let session = match session.record_action(CMD_INSERT.to_string()).unwrap() {
+                crate::game::SessionAfterAction::StillActive(session) => session,
+                crate::game::SessionAfterAction::Completed(_) => {
+                    panic!("entering insert mode should not complete the scenario")
+                }
+            };
+            assert!(session.is_insert_mode());
+
+            let mut task_data = TaskData::new(session);
+            task_data.show_hint_panel = true;
+            state.screen = TypedScreen::Task(task_data);
+
+            let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
+            let msg = handle_task_keys(key, &state);
+
+            // Escape should exit Insert mode (gameplay Escape), not dismiss the hint panel.
+            assert_eq!(
+                msg,
+                Some(Message::ExecuteCommand(Cow::Borrowed(
+                    crate::helix::commands::CMD_ESCAPE
+                )))
+            );
+        }
+
+        #[test]
+        fn test_escape_dismisses_hint_panel_in_normal_mode() {
+            let mut state = create_test_app_state();
+            let mut task_data = TaskData::new(make_active_task_session());
+            task_data.show_hint_panel = true;
+            state.screen = TypedScreen::Task(task_data);
+
+            let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
+            let msg = handle_task_keys(key, &state);
+
+            assert_eq!(msg, Some(Message::ShowHint));
         }
     }
 

--- a/src/input/handlers.rs
+++ b/src/input/handlers.rs
@@ -359,10 +359,13 @@ pub fn handle_task_keys(key: KeyEvent, state: &AppState) -> Option<Message> {
         return Some(msg);
     }
 
-    // If hint panel is visible, Escape dismisses it without counting as a game action
+    // If hint panel is visible, Escape dismisses it without counting as a game action.
+    // Skip this while in Insert mode so Escape exits Insert mode first (matching the
+    // arcade path); a second Escape then closes the panel.
     if key.code == KeyCode::Esc
         && let TypedScreen::Task(task_data) = &state.screen
         && task_data.show_hint_panel
+        && !is_gameplay_insert_mode(state)
     {
         return Some(Message::ShowHint);
     }

--- a/src/ui/state/handlers/scenario.rs
+++ b/src/ui/state/handlers/scenario.rs
@@ -249,30 +249,29 @@ pub fn handle_complete_scenario(state: &mut AppState) -> Result<HandlerOutcome, 
     let xp = ScenarioCompletionService::calculate_xp_components(&feedback, is_first_today);
 
     let now = ctx.progress.now();
-    let (actual_xp, mastery_level, mastery_multiplier, mastery_factor, repeat_penalty) =
-        ScenarioCompletionService::record_and_scale_xp(
-            &mut ctx.progress.profile,
-            &scenario_id,
-            feedback.score,
-            xp.total_base_xp,
-            now,
-        );
+    let xp_scaling = ScenarioCompletionService::record_and_scale_xp(
+        &mut ctx.progress.profile,
+        &scenario_id,
+        feedback.score,
+        xp.total_base_xp,
+        now,
+    );
 
     // Store mastery info for results display
-    ctx.ui.scenario_mastery = Some((mastery_level, mastery_multiplier));
+    ctx.ui.scenario_mastery = Some((xp_scaling.mastery_level, xp_scaling.applied_multiplier));
 
     // Collect quest bonuses
     let quest_bonuses = collect_quest_bonuses(&mut ctx);
     let quest_xp = quest_bonuses.iter().map(|(_, xp)| xp).sum::<u64>();
-    let total_xp = actual_xp + quest_xp;
+    let total_xp = xp_scaling.actual_xp + quest_xp;
 
     ctx.ui.xp_breakdown = Some(XPBreakdown {
         base_xp: xp.base_xp,
         perfect_bonus: xp.perfect_bonus,
         first_today_bonus: xp.first_today_bonus,
-        mastery_multiplier,
-        mastery_factor,
-        repeat_penalty,
+        mastery_multiplier: xp_scaling.applied_multiplier,
+        mastery_factor: xp_scaling.applied_mastery_factor,
+        repeat_penalty: xp_scaling.applied_repeat_penalty,
         quest_bonuses,
         total_xp,
     });


### PR DESCRIPTION
## Summary

- Scenario completion checking now requires the editor to be back in Normal mode, not just matching content/cursor/selections. Scenarios whose solution is a bare mode-entry command followed by `Escape` (e.g. `o`, `Escape` for "Insert line below") no longer complete on the mode-entry keystroke alone.
- `ScenarioCompletionService::record_and_scale_xp` now returns a named `XPScalingResult` struct instead of an unlabeled `(u64, ScenarioMastery, f64, f64, f64)` tuple, removing the risk of a silent positional swap between its three `f64` fields.
- Follow-up fixes surfaced by adversarial review of the mode-completion change: `open_below_001`/`open_above_001` hints now mention Escape, the progress bar no longer reads 100% while still in Insert mode, and the hint panel no longer swallows the first Escape needed to exit Insert mode.

Both issues are P3 in the `game` subsystem and are bundled into this single PR as separate commits.

Fixes #283
Fixes #281

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (1861 passed)
- [x] `cargo nextest run scenario` (237 passed)
- [x] `cargo test --doc`
- [x] Adversarial critique pass on the completion-mode fix (verified no unbeatable-scenario regression, no bypassed call sites, no Select-mode edge case)
- [x] Code review pass (approved after addressing 3 minor findings)