### PR TITLE
fix(ui): clamp menu selection and fix scroll math for separator row

### DIFF
--- a/src/ui/render/menu.rs
+++ b/src/ui/render/menu.rs
@@ -9,7 +9,33 @@ use ratatui::{
 };
 use rust_i18n::t;
 
+/// Number of fixed, selectable menu entries after the scenario list: Review, Profile, Statistics, Quit.
+///
+/// Mirrors `handlers::menu::FIXED_MENU_ITEMS`. Duplicated here because `ui::render` and
+/// `ui::state::handlers` are separate module trees (handlers stays private to `ui::state`);
+/// keep the two literals in sync.
+const FIXED_MENU_ITEMS: usize = 4;
+
+/// Number of rendered rows appended after the scenario list: the `FIXED_MENU_ITEMS`
+/// selectable entries plus the non-selectable separator row `build_menu_items` inserts
+/// before them. Used for scroll-offset/scrollbar math, which operates on rendered rows —
+/// NOT for user-facing item counts (see `FIXED_MENU_ITEMS` for those).
+const RENDERED_FIXED_ROWS: usize = FIXED_MENU_ITEMS + 1;
+
+/// Converts a logical selection index into its rendered-row index.
+///
+/// `selected_item` is a scenario index (`0..scenario_count`) or one of the fixed entries
+/// (`scenario_count..scenario_count+FIXED_MENU_ITEMS`). `build_menu_items` inserts a
+/// separator row between the two groups, so any fixed-entry selection sits one row further
+/// down than its logical index suggests.
+fn selection_to_row(selected_item: usize, scenario_count: usize) -> usize {
+    selected_item + usize::from(selected_item >= scenario_count)
+}
+
 /// Calculate menu scroll offset to keep selected item visible
+///
+/// Both `selected` and `total_items` must be in the same coordinate space as the rendered
+/// row list (see `selection_to_row`) — this function has no way to detect a space mismatch.
 ///
 /// Returns (scroll_offset, visible_count) tuple
 fn calculate_menu_scroll(
@@ -253,7 +279,11 @@ pub(super) fn render_main_menu_background(frame: &mut Frame, state: &AppState) {
 
     // Calculate visible area height for menu (excluding borders)
     let menu_height = chunks[2].height.saturating_sub(2) as usize;
-    let total_items = state.game.scenario_collection.count() + 4; // +4 for Review, Profile, Statistics, Quit
+    let scenario_count = state.game.scenario_collection.count();
+    // display_total is the user-facing item count (title, instructions threshold);
+    // row_total is the rendered row count (includes the separator) for scroll/scrollbar math.
+    let display_total = scenario_count + FIXED_MENU_ITEMS;
+    let row_total = scenario_count + RENDERED_FIXED_ROWS;
 
     // Use default scroll offset (0) for background render - no selection
     let scroll_offset = 0;
@@ -269,18 +299,18 @@ pub(super) fn render_main_menu_background(frame: &mut Frame, state: &AppState) {
         .collect();
 
     // Add scroll indicator to title if list is scrollable
-    let menu_title = if total_items > menu_height {
+    let menu_title = if row_total > menu_height {
         let first_visible = scroll_offset + 1;
-        let last_visible = (scroll_offset + menu_height).min(total_items);
+        let last_visible = (scroll_offset + menu_height).min(display_total);
         t!(
             "menu.main_menu_with_scroll",
             first = first_visible,
             last = last_visible,
-            total = total_items
+            total = display_total
         )
         .to_string()
     } else {
-        t!("menu.main_menu_total", total = total_items).to_string()
+        t!("menu.main_menu_total", total = display_total).to_string()
     };
 
     let menu = List::new(visible_items)
@@ -292,12 +322,12 @@ pub(super) fn render_main_menu_background(frame: &mut Frame, state: &AppState) {
     render_quest_panel(frame, chunks[3], state);
 
     // Draw scrollbar if needed
-    if total_items > menu_height {
-        render_scrollbar(frame, chunks[2], scroll_offset, total_items, menu_height);
+    if row_total > menu_height {
+        render_scrollbar(frame, chunks[2], scroll_offset, row_total, menu_height);
     }
 
     // Instructions
-    let instructions = if total_items > 9 {
+    let instructions = if display_total > 9 {
         Paragraph::new(t!("menu.instructions_with_numbers").to_string())
     } else {
         Paragraph::new(t!("menu.instructions").to_string())
@@ -348,19 +378,31 @@ pub(super) fn render_main_menu(frame: &mut Frame, state: &mut AppState) {
 
     // Calculate visible area height for menu (excluding borders)
     let menu_height = chunks[2].height.saturating_sub(2) as usize;
-    let total_items = state.game.scenario_collection.count() + 4; // +4 for Review, Profile, Statistics, Quit
+    let scenario_count = state.game.scenario_collection.count();
+    // display_total is the user-facing item count (title, instructions threshold);
+    // row_total is the rendered row count (includes the separator) for scroll/scrollbar math.
+    let display_total = scenario_count + FIXED_MENU_ITEMS;
+    let row_total = scenario_count + RENDERED_FIXED_ROWS;
 
     // Get mutable access to menu_data for adjusting scroll
     let TypedScreen::Menu(menu_data) = &mut state.screen else {
         unreachable!("Already checked above")
     };
 
-    // Calculate scroll offset
+    // A filter change may have shrunk the scenario list since selected_item was last set
+    // (e.g. toggling a category filter while a later item was selected); clamp here, the
+    // single point every path that can select a menu item funnels through before display.
+    menu_data.selected_item = menu_data.selected_item.min(display_total.saturating_sub(1));
+
+    // Calculate scroll offset (in rendered-row space, matching row_total and the skip()
+    // below — build_menu_items' separator row shifts fixed entries one row past their
+    // logical index, see selection_to_row)
+    let selected_row = selection_to_row(menu_data.selected_item, scenario_count);
     let (scroll_offset, _) = calculate_menu_scroll(
-        menu_data.selected_item,
+        selected_row,
         menu_data.scroll_offset,
         menu_height,
-        total_items,
+        row_total,
     );
     menu_data.scroll_offset = scroll_offset;
 
@@ -378,18 +420,18 @@ pub(super) fn render_main_menu(frame: &mut Frame, state: &mut AppState) {
         .collect();
 
     // Add scroll indicator to title if list is scrollable
-    let menu_title = if total_items > menu_height {
+    let menu_title = if row_total > menu_height {
         let first_visible = scroll_offset + 1;
-        let last_visible = (scroll_offset + menu_height).min(total_items);
+        let last_visible = (scroll_offset + menu_height).min(display_total);
         t!(
             "menu.main_menu_with_scroll",
             first = first_visible,
             last = last_visible,
-            total = total_items
+            total = display_total
         )
         .to_string()
     } else {
-        t!("menu.main_menu_total", total = total_items).to_string()
+        t!("menu.main_menu_total", total = display_total).to_string()
     };
 
     let menu = List::new(visible_items)
@@ -401,12 +443,12 @@ pub(super) fn render_main_menu(frame: &mut Frame, state: &mut AppState) {
     render_quest_panel(frame, chunks[3], state);
 
     // Draw scrollbar if needed
-    if total_items > menu_height {
-        render_scrollbar(frame, chunks[2], scroll_offset, total_items, menu_height);
+    if row_total > menu_height {
+        render_scrollbar(frame, chunks[2], scroll_offset, row_total, menu_height);
     }
 
     // Instructions
-    let instructions = if total_items > 9 {
+    let instructions = if display_total > 9 {
         Paragraph::new(t!("menu.instructions_with_numbers").to_string())
     } else {
         Paragraph::new(t!("menu.instructions").to_string())
@@ -585,6 +627,121 @@ mod tests {
         fn test_calculate_menu_scroll_returns_visible_height() {
             let (_, visible) = calculate_menu_scroll(5, 0, 10, 20);
             assert_eq!(visible, 10);
+        }
+    }
+
+    // Regression tests for #311: Quit must be scrollable into view.
+    //
+    // `calculate_menu_scroll` operates purely on whatever index space it's given, so a test
+    // that only checks its output in isolation (as `calculate_menu_scroll_tests` above does)
+    // cannot catch a caller passing it the wrong space. These tests instead combine
+    // `selection_to_row` with `calculate_menu_scroll` exactly as `render_main_menu` does, and
+    // assert on the property that actually matters: the selected item's *rendered row* must
+    // fall inside the visible window after scrolling. A caller that skips `selection_to_row`
+    // (passing the logical `scenario_count + FIXED_MENU_ITEMS - 1` index straight through, as
+    // the original code and the first, inert `RENDERED_FIXED_ROWS`-only fix both did) computes
+    // an offset that is exactly one row short of this for every case below.
+    mod quit_reachability_tests {
+        use super::*;
+
+        fn assert_quit_row_visible(scenario_count: usize, visible_height: usize) {
+            let quit_selected_item = scenario_count + FIXED_MENU_ITEMS - 1;
+            let row_total = scenario_count + RENDERED_FIXED_ROWS;
+
+            // Ground truth, independent of `selection_to_row` (the function under test):
+            // `build_menu_items` always lays out scenario rows, then 1 separator row, then
+            // the 4 fixed entries, so Quit's physical row is always `row_total - 1`. Deriving
+            // this from `selection_to_row` instead would make the assertion vacuous against a
+            // broken (e.g. identity) `selection_to_row`, since `calculate_menu_scroll` always
+            // makes whatever row it's given visible.
+            let true_quit_row = row_total - 1;
+
+            let scroll_input_row = selection_to_row(quit_selected_item, scenario_count);
+            let (offset, _) = calculate_menu_scroll(scroll_input_row, 0, visible_height, row_total);
+
+            assert!(
+                offset <= true_quit_row && true_quit_row < offset + visible_height,
+                "Quit's true rendered row {true_quit_row} not inside visible window \
+                 [{offset}, {}) for scenario_count={scenario_count}, visible_height={visible_height} \
+                 (selection_to_row produced {scroll_input_row})",
+                offset + visible_height
+            );
+        }
+
+        #[test]
+        fn test_quit_reachable_critic_counterexample_10_5() {
+            assert_quit_row_visible(10, 5);
+        }
+
+        #[test]
+        fn test_quit_reachable_critic_counterexample_20_10() {
+            assert_quit_row_visible(20, 10);
+        }
+
+        #[test]
+        fn test_quit_reachable_critic_counterexample_50_12() {
+            assert_quit_row_visible(50, 12);
+        }
+
+        #[test]
+        fn test_quit_reachable_large_scenario_count() {
+            assert_quit_row_visible(200, 20);
+        }
+
+        #[test]
+        fn test_quit_reachable_visible_height_of_one() {
+            // Degenerate but valid: a single visible row must still be able to show Quit.
+            assert_quit_row_visible(10, 1);
+        }
+    }
+
+    // Regression test for #311: end-to-end through the real update()/render_main_menu()
+    // pipeline, not just the scroll-math helpers directly.
+    mod quit_reachable_end_to_end {
+        use super::*;
+        use crate::testing::{ScenarioBuilder, test_app_state_with_scenarios};
+        use crate::ui::state::{MenuData, Message, TypedScreen, update};
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        #[test]
+        fn test_quit_visible_after_scrolling_down_through_long_menu() {
+            let scenarios: Vec<_> = (0..30)
+                .map(|i| {
+                    ScenarioBuilder::new()
+                        .id(format!("scenario_{i}"))
+                        .setup_content("line 1\n")
+                        .target_content("line 2\n")
+                        .optimal_count(1)
+                        .build()
+                })
+                .collect();
+            let scenario_count = scenarios.len();
+            let mut state = test_app_state_with_scenarios(scenarios);
+            state.screen = TypedScreen::Menu(MenuData::default());
+
+            let backend = TestBackend::new(80, 24);
+            let mut terminal = Terminal::new(backend).unwrap();
+
+            let mut last_text = String::new();
+            for _ in 0..(scenario_count + FIXED_MENU_ITEMS) {
+                update(&mut state, Message::MenuDown).unwrap();
+                terminal.draw(|f| render_main_menu(f, &mut state)).unwrap();
+                let buffer = terminal.backend().buffer().clone();
+                last_text = buffer.content.iter().map(|c| c.symbol()).collect();
+            }
+
+            let TypedScreen::Menu(menu_data) = &state.screen else {
+                panic!("expected TypedScreen::Menu");
+            };
+            assert_eq!(
+                menu_data.selected_item,
+                scenario_count + FIXED_MENU_ITEMS - 1
+            );
+            assert!(
+                last_text.contains("Quit"),
+                "Quit not visible after scrolling to the end of a {scenario_count}-scenario menu: {last_text}"
+            );
         }
     }
 }

--- a/src/ui/state/handlers/category_filters.rs
+++ b/src/ui/state/handlers/category_filters.rs
@@ -491,6 +491,59 @@ mod tests {
         assert!(filter.categories.is_none());
     }
 
+    /// Regression test for #312/S1: `handle_category_filter_toggle` runs while
+    /// `state.screen == CategoryFilters`, not `Menu`, so it has no way to touch
+    /// `MenuData::selected_item` itself even though it can shrink the filtered list. The
+    /// render-time clamp in `render_main_menu` is defensive coverage for a `selected_item`
+    /// left stale by a toggle like this one — today `handle_back_to_menu` always resets
+    /// `MenuData` to default when leaving `CategoryFilters`, so this path doesn't currently
+    /// produce a stale index in production, but the same clamp also guards the
+    /// `ui.last_menu_selected` restore paths in `src/ui/state/handlers/scenario.rs`.
+    #[test]
+    fn test_category_filter_toggle_live_path_leaves_stale_selection_for_render_to_clamp() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let mut state = create_test_state_with_categories(); // 3 scenarios, one per category
+        state.screen = TypedScreen::Menu(MenuData {
+            selected_item: 6, // last valid index: 3 scenarios + 4 fixed entries - 1
+            ..MenuData::default()
+        });
+
+        let data = CategoryFiltersData {
+            selected_index: 0,
+            return_to: ReturnDestination::Menu,
+        };
+        let mut ctx = HandlerContext::new(
+            &mut state.ui,
+            &mut state.game,
+            &mut state.progress,
+            &state.config,
+        );
+        // The real production handler behind the live CategoryFilterToggle message.
+        handle_category_filter_toggle(&data, &mut ctx).unwrap();
+
+        let filtered_count = state.game.scenario_collection.count();
+        assert_eq!(
+            filtered_count, 1,
+            "toggling one of three single-scenario categories should shrink to 1"
+        );
+
+        // state.screen is still Menu with the stale selected_item=6 here — nothing about
+        // handle_category_filter_toggle touches it. Rendering the Menu screen is the only
+        // remaining point that can catch it.
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| crate::ui::render::render(f, &mut state))
+            .unwrap();
+
+        let TypedScreen::Menu(menu_data) = &state.screen else {
+            panic!("expected TypedScreen::Menu");
+        };
+        assert_eq!(menu_data.selected_item, 4); // filtered_count(1) + FIXED_MENU_ITEMS(4) - 1
+    }
+
     #[test]
     fn test_category_filter_toggle_out_of_bounds() {
         let mut state = create_test_state_with_categories();

--- a/src/ui/state/handlers/menu.rs
+++ b/src/ui/state/handlers/menu.rs
@@ -11,9 +11,14 @@ use crate::ui::state::{AppState, HandlerContext, HandlerOutcome, MenuData};
 /// Number of fixed menu entries appended after the scenario list: Review, Profile, Statistics, Quit.
 const FIXED_MENU_ITEMS: usize = 4;
 
+/// Total number of menu items for a given filtered scenario count: scenarios plus the fixed trailing entries.
+pub(crate) fn total_menu_items_for_count(scenario_count: usize) -> usize {
+    scenario_count + FIXED_MENU_ITEMS
+}
+
 /// Total number of menu items: filtered scenarios plus the fixed trailing entries.
 fn total_menu_items(ctx: &HandlerContext<'_>) -> usize {
-    ctx.game.scenario_collection.count() + FIXED_MENU_ITEMS
+    total_menu_items_for_count(ctx.game.scenario_collection.count())
 }
 
 /// Handle MenuUp message

--- a/src/ui/state/mod.rs
+++ b/src/ui/state/mod.rs
@@ -544,6 +544,24 @@ fn apply_outcome(state: &mut AppState, outcome: HandlerOutcome) {
     }
 }
 
+/// Clamps `MenuData::selected_item` after a filter change may have shrunk the
+/// filtered scenario list.
+///
+/// `ToggleCategoryFilter`/`ToggleDifficultyFilter`/`ToggleCompletedFilter` are dispatched
+/// screen-agnostically via `HandlerContext`, which structurally excludes `state.screen`, so
+/// the filter handlers themselves cannot perform this clamp. This is a no-op unless the menu
+/// screen is currently active. `ui::render::menu::render_main_menu` performs an equivalent
+/// clamp on every render as a backstop for paths (e.g. the `CategoryFilterToggle` filter
+/// popup) that mutate the filter while `MenuData` isn't the active screen.
+fn clamp_menu_selection_to_filtered_count(state: &mut AppState) {
+    if let TypedScreen::Menu(ref mut menu_data) = state.screen {
+        let max_index =
+            handlers::menu::total_menu_items_for_count(state.game.scenario_collection.count())
+                .saturating_sub(1);
+        menu_data.selected_item = menu_data.selected_item.min(max_index);
+    }
+}
+
 /// Pure update function for state transitions
 ///
 /// This function is the heart of the Elm Architecture pattern.
@@ -944,6 +962,7 @@ pub fn update(state: &mut AppState, msg: Message) -> Result<(), UserError> {
             );
             let outcome = handlers::handle_toggle_category_filter(&mut ctx, category)?;
             apply_outcome(state, outcome);
+            clamp_menu_selection_to_filtered_count(state);
             Ok(())
         }
         Message::ToggleDifficultyFilter(difficulty) => {
@@ -955,6 +974,7 @@ pub fn update(state: &mut AppState, msg: Message) -> Result<(), UserError> {
             );
             let outcome = handlers::handle_toggle_difficulty_filter(&mut ctx, difficulty)?;
             apply_outcome(state, outcome);
+            clamp_menu_selection_to_filtered_count(state);
             Ok(())
         }
         Message::ToggleCompletedFilter => {
@@ -966,6 +986,7 @@ pub fn update(state: &mut AppState, msg: Message) -> Result<(), UserError> {
             );
             let outcome = handlers::handle_toggle_completed_filter(&mut ctx)?;
             apply_outcome(state, outcome);
+            clamp_menu_selection_to_filtered_count(state);
             Ok(())
         }
         Message::ResetFilters => {

--- a/src/ui/state/tests/filter_tests.rs
+++ b/src/ui/state/tests/filter_tests.rs
@@ -3,7 +3,7 @@
 use super::common::{create_test_app_state, create_test_scenario};
 use crate::config::{CompletionFilter, Difficulty, ScenarioCategory, SortMode};
 use crate::testing::ScenarioBuilder;
-use crate::ui::state::{Message, update};
+use crate::ui::state::{Message, TypedScreen, update};
 
 /// Create scenarios with different categories and difficulties
 fn create_diverse_scenarios() -> Vec<crate::config::Scenario> {
@@ -282,4 +282,125 @@ fn test_filter_with_empty_result() {
 
     // Selection+Beginner doesn't exist, should show 0
     assert_eq!(state.game.scenario_collection.count(), 0);
+}
+
+// ==================== Regression tests for #312 ====================
+// Filter toggles that shrink the filtered scenario list must clamp
+// MenuData::selected_item back into bounds, or the menu can end up
+// pointing at an index past the end of the (now shorter) item list.
+
+fn selected_menu_item(state: &crate::ui::state::AppState) -> usize {
+    match &state.screen {
+        TypedScreen::Menu(menu_data) => menu_data.selected_item,
+        other => panic!("expected TypedScreen::Menu, got {other:?}"),
+    }
+}
+
+fn set_selected_menu_item(state: &mut crate::ui::state::AppState, index: usize) {
+    match &mut state.screen {
+        TypedScreen::Menu(menu_data) => menu_data.selected_item = index,
+        other => panic!("expected TypedScreen::Menu, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_toggle_category_filter_clamps_selection_when_list_shrinks() {
+    let scenarios = create_diverse_scenarios();
+    let mut state = create_test_app_state(scenarios);
+    update(&mut state, Message::SelectTrainingMode).unwrap();
+
+    // 4 scenarios + 4 fixed entries = 8 items, last valid index is 7 (Quit)
+    set_selected_menu_item(&mut state, 7);
+
+    // Movement filter shrinks the list to 2 scenarios: 2 + 4 = 6 items, last index 5
+    update(
+        &mut state,
+        Message::ToggleCategoryFilter(ScenarioCategory::Movement),
+    )
+    .unwrap();
+
+    assert_eq!(state.game.scenario_collection.count(), 2);
+    assert_eq!(selected_menu_item(&state), 5);
+}
+
+#[test]
+fn test_toggle_difficulty_filter_clamps_selection_when_list_shrinks() {
+    let scenarios = create_diverse_scenarios();
+    let mut state = create_test_app_state(scenarios);
+    update(&mut state, Message::SelectTrainingMode).unwrap();
+
+    set_selected_menu_item(&mut state, 7);
+
+    // Beginner filter shrinks the list to 2 scenarios (both movement_*): last index 5
+    update(
+        &mut state,
+        Message::ToggleDifficultyFilter(Difficulty::Beginner),
+    )
+    .unwrap();
+
+    assert_eq!(state.game.scenario_collection.count(), 2);
+    assert_eq!(selected_menu_item(&state), 5);
+}
+
+#[test]
+fn test_toggle_completed_filter_clamps_selection_to_fixed_entries_when_list_becomes_empty() {
+    let scenario = create_test_scenario();
+    let mut state = create_test_app_state(vec![scenario]);
+    update(&mut state, Message::SelectTrainingMode).unwrap();
+
+    // 1 scenario + 4 fixed entries = 5 items, last valid index is 4 (Quit)
+    set_selected_menu_item(&mut state, 4);
+
+    // "Completed only" filter hides the one (uncompleted) scenario entirely
+    update(&mut state, Message::ToggleCompletedFilter).unwrap();
+
+    assert_eq!(state.game.scenario_collection.count(), 0);
+    // The 4 fixed entries remain selectable even with an empty scenario list
+    assert_eq!(selected_menu_item(&state), 3);
+}
+
+#[test]
+fn test_toggle_category_filter_clamps_selection_across_sequential_toggles_to_empty() {
+    let scenarios = create_diverse_scenarios();
+    let mut state = create_test_app_state(scenarios);
+    update(&mut state, Message::SelectTrainingMode).unwrap();
+
+    set_selected_menu_item(&mut state, 7);
+
+    // Selection category alone leaves 1 scenario: 1 + 4 = 5 items, last index 4
+    update(
+        &mut state,
+        Message::ToggleCategoryFilter(ScenarioCategory::Selection),
+    )
+    .unwrap();
+    assert_eq!(state.game.scenario_collection.count(), 1);
+    assert_eq!(selected_menu_item(&state), 4);
+
+    // Combined with Beginner, Selection+Beginner has no matches: 0 + 4 = 4 items, last index 3
+    update(
+        &mut state,
+        Message::ToggleDifficultyFilter(Difficulty::Beginner),
+    )
+    .unwrap();
+    assert_eq!(state.game.scenario_collection.count(), 0);
+    assert_eq!(selected_menu_item(&state), 3);
+}
+
+#[test]
+fn test_toggle_filter_does_not_change_selection_when_already_in_bounds() {
+    let scenarios = create_diverse_scenarios();
+    let mut state = create_test_app_state(scenarios);
+    update(&mut state, Message::SelectTrainingMode).unwrap();
+
+    // Selection stays at 0, well within bounds of the shrunk list too
+    set_selected_menu_item(&mut state, 0);
+
+    update(
+        &mut state,
+        Message::ToggleCategoryFilter(ScenarioCategory::Movement),
+    )
+    .unwrap();
+
+    assert_eq!(state.game.scenario_collection.count(), 2);
+    assert_eq!(selected_menu_item(&state), 0);
 }


### PR DESCRIPTION
## Summary

- Filter toggles (category/difficulty/completed) could leave `MenuData::selected_item` past the end of the newly-shrunk filtered list. A render-time clamp now covers every path that can leave a stale index (including `ui.last_menu_selected` restore paths), complementing the existing dispatcher-level clamp.
- `total_items` passed into the menu scroll math undercounted the separator row between the scenario list and the fixed entries (Review/Profile/Statistics/Quit), so `max_offset` was one row short and Quit could never be scrolled into view on long lists. Selection indices are now converted to rendered-row space (`selection_to_row`) before computing scroll offsets, and the user-facing item count (title/instructions) is kept separate from the row-space count used for scroll math.

Both fixes went through two rounds of adversarial critique during development; the first-round fixes were found to be inert/insufficiently wired and were reworked before landing here.

Fixes #312
Fixes #311

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (1911/1911 passed)
- [x] 7 new regression tests added: 5 parametrized Quit-reachability cases (including small-N and h=1 edge cases), 1 end-to-end scroll-to-Quit render test, 1 live-path filter-toggle clamp test — each verified to fail against the pre-fix code