### PR TITLE
spec(minigame): arcade game-mode variety decision record (NO-GO)

### DIFF
--- a/specs/arcade-game-mode-variety/BRD.md
+++ b/specs/arcade-game-mode-variety/BRD.md
@@ -1,0 +1,224 @@
+---
+aliases:
+  - Arcade Game Mode Variety BRD
+  - Issue 264 BRD
+tags:
+  - brd
+  - minigame
+  - decision-record
+  - status/rejected
+created: 2026-08-09
+project: "helix-trainer"
+status: rejected
+related:
+  - "[[README]]"
+  - "[[SRS]]"
+---
+
+# Arcade Game Mode Variety: Business Requirements Document
+
+> [!abstract]
+> Records the original business goal behind GitHub issue #264 and the
+> investigation finding that undermines it. This is a rejected-feature
+> record, not a build authorization — see [[README]] for the overall
+> decision.
+
+## Executive Summary
+
+Issue #264 proposed closing a perceived competitive-parity gap against
+[vim-be-good](https://github.com/ThePrimeagen/vim-be-good): helix-trainer's
+three minigame modes (`Arcade`, `Survival`, `Challenge`) all share one
+mechanic — complete a scenario under time/lives pressure — while vim-be-good
+ships mechanically distinct games (`relative`, `ci{`, `whackamole`, `snake`).
+The specific ask was a reflex/targeting-drill mechanic modeled on
+`whackamole`. Investigation found that targeting parity is **already met** by
+90 existing scenarios played through the current `Arcade` mode, and that a
+genuinely distinct mode would require real subsystem work not justified at
+current priority and evidence. The recommendation is NO-GO.
+
+## Problem Statement
+
+- **What problem existed (as originally framed)?** helix-trainer's arcade
+  offering was assessed as "one mechanic reskinned across pacing variants and
+  content categories" — no mechanic built around raw movement speed or
+  reflexive targeting, unlike vim-be-good's `whackamole`/`snake`.
+- **Who would experience this?** Learners who have exhausted the novelty of
+  the existing `Arcade`/`Survival`/`Challenge` modes and want a different kind
+  of engagement (per the original spec's US-001).
+- **What is the impact of not solving it (as originally claimed)?** Reduced
+  engagement variety; a competitive gap versus the one reference project
+  named in this project's `continuous-improvement` rules for game-mode
+  variety.
+
+> [!warning] Finding That Undermines the Premise
+> The premise "helix-trainer has no reflex/targeting mechanic" is **false**
+> as stated. See Finding 1 below. The premise survives only in a narrower,
+> continuity-focused form (Finding 2), which is not the form issue #264 was
+> filed under.
+
+## Finding 1 — Targeting Parity Already Shipped
+
+`EditorSnapshot::matches` (`src/helix/simulator/snapshot.rs:159-170`)
+short-circuits to content-equality + cursor-offset-equality whenever the
+target has at most one selection and no real (non-point) selection. That
+means: **any `Scenario` whose `target.file_content == setup.file_content`,
+differing only in cursor position, is mechanically a whack-a-mole round** —
+acquire a target on an unmodified buffer, nothing else.
+
+Measured against the shipped scenario library (134 total scenarios):
+
+| Category | Content-identical scenarios | Of which `optimal_count == 1` |
+|---|---|---|
+| `movement` | 61 | 42 |
+| `selection` | 25 | — |
+| `search` | 4 | — |
+| **Total** | **90** | **51** |
+
+Full `optimal_count` distribution among the 90: `{1: 51, 2: 17, 3: 20, 7: 2}`.
+Within the 61 `movement` rounds specifically: `{1: 42, 2: 14, 3: 3, 7: 2}` —
+19 of 61 need two or more commands.
+
+Concrete example: `find_char_001` in `scenarios/en/movement/find-till.toml`
+— cursor `[1,4]` → `[1,15]`, solution `["f="]`, `optimal_count = 1`. This is
+a single-motion target-acquisition round, played today in `Arcade` under a
+per-scenario timer, with lives and adaptive difficulty
+(`tests/scenario_validation.rs` verifies all shipped scenarios complete via
+their solution).
+
+These 90 (and especially the 51 single-command ones) are already-playable
+reflex/targeting rounds via the existing `Arcade` mode. Any new mode that
+merely generates similar targets with a shorter timer is **pacing**, not a
+new mechanic — and the original spec itself places pacing changes out of
+scope (draft spec, "Out of Scope": *"Changes to the existing
+`Arcade`/`Survival`/`Challenge` pacing variants... those remain as-is"*).
+
+## Finding 2 — The Real Differentiator Is Continuity, Not Targeting
+
+What actually makes `whackamole` (and `snake`) feel different from
+scenario-completion is **continuity, not targeting**: one persistent buffer,
+targets that respawn instantly, no per-round transition screen, and a single
+session clock — flow, rather than a series of discrete puzzles. A blind
+description test supports this: *"solve a series of short editing puzzles,
+each with its own timer"* vs. *"one buffer, targets keep appearing, hit as
+many as you can in 60 seconds without stopping"* — these are distinguishable.
+
+Delivering continuity requires subsystem work that does not exist in the
+codebase today (see [[plan#Cost Basis (Perishable)]] for the itemized,
+corrected cost). This is buildable in principle, but its cost is not the
+"~1 focused PR" that the first-pass evaluation assumed — see Finding 3.
+
+## Finding 3 — Priority and Evidence Basis
+
+Issue #264 was filed at **P3**, sourced from a single automated
+competitive-parity scan against **one** reference project
+(vim-be-good). There is no user-demand signal for this specific mechanic. By
+contrast, issue #198 (Helix command content-coverage gap) has stronger,
+independent evidence and remains unimplemented. This is the primary and
+durable basis for NO-GO — independent of the cost estimate for the
+continuous-play variant, which is a secondary and perishable data point (see
+[[plan#Cost Basis (Perishable)]]).
+
+## Target Users (As Originally Framed)
+
+### Primary Users
+Learners already using `Arcade`/`Survival`/`Challenge` who want a
+mechanically distinct engagement loop, not merely a harder/faster version of
+the same drill.
+
+### Secondary Users
+N/A — no admin or occasional-user distinction in this single-player TUI.
+
+### Stakeholders
+Project maintainers weighing engagement variety against implementation and
+maintenance cost, and against the competing, better-evidenced backlog item
+(#198).
+
+## Functional Requirements (As Originally Proposed)
+
+See [[SRS]] for the full FR-001..006 list with pass/fail status against the
+findings above. Summary: FR-001 (distinct core loop) and its associated
+success criterion SC-001 fail for the cheap version; FR-002/FR-003/FR-004
+remain hypothetically satisfiable only if the continuous version is ever
+built; FR-005/FR-006 are moot because nothing is being added.
+
+## Non-Functional Requirements (As Originally Proposed)
+
+See [[NFR]] for NFR-001..004 carried forward from the draft spec — all moot
+under NO-GO, annotated with what would apply if revisited.
+
+## Scope & Boundaries
+
+### In Scope (of this decision record)
+- Recording the business rationale for NO-GO
+- Recording the falsifiable kill-criterion as a documented, non-committed
+  option for a future revisit
+- Recording two independent spin-off bugs found during the investigation
+
+### Out of Scope
+
+> [!danger] Explicit Exclusions
+> - Building either the cheap (pacing) or continuous (subsystem) version of
+>   the reflex-drill mechanic now
+> - A `snake`-style movement game (excluded on principle in the original
+>   spec's investigation — it has no document, no target snapshot, no
+>   `Scenario`, and no `HelixSimulator` execution, so it conflicts with the
+>   spec's own FR-002 as originally proposed, not merely on scheduling)
+> - Filing GitHub issues for the spin-off bugs (recorded here for team-lead
+>   to file verbatim; not filed by this record)
+> - Content-coverage gaps tracked separately under issue #198
+
+## Constraints & Assumptions
+
+### Technical Constraints
+Any future revisit must route input through `HelixSimulator`/
+`AnyModeSimulator` (project-wide invariant; not a new constraint introduced
+here) and must not introduce a real-time per-frame game loop, since none
+exists today (`event_loop.rs` ticks are predicate-polling, not a session
+hook).
+
+### Business Constraints
+P3 priority; no allocated timeline or budget; competes for attention with
+issue #198, which has stronger evidence.
+
+### Assumptions
+
+> [!warning] Assumptions
+> - If a real user-demand signal for this mechanic appears, this NO-GO should
+>   be revisited (see [[plan#Revisit Triggers]])
+> - If the session-clock bug ([[appendix-spinoffs#Spin-off A]]) is fixed
+>   independently, the cost basis for the continuous version drops and should
+>   be re-evaluated on that basis alone
+
+## Success Criteria
+
+Not applicable — no feature is being built. See [[plan]] for the criteria
+that would apply to the kill-criterion experiment, if it is ever run.
+
+## Open Questions
+
+> [!question] Unresolved Items
+> - [ ] Should issue #264 be closed outright, or kept open and re-labeled to
+>       reflect this record (recommendation: close as researched-not-planned;
+>       team-lead decision)
+> - [ ] Should the two spin-off bugs be filed before or independently of
+>       closing #264 (recommendation: independently — they stand on their own
+>       merits per [[appendix-spinoffs]])
+
+## Glossary
+
+| Term | Definition |
+|------|-----------|
+| Content-identical scenario | A `Scenario` where `target.file_content == setup.file_content`; only cursor position differs |
+| `optimal_count` | Minimum number of commands (`NonZeroUsize`) required to complete a scenario, feeds `efficiency` scoring |
+| Cheap version | Reflex mode expressed as generated `Scenario` rounds reusing existing per-round machinery — pacing variant |
+| Continuous version | Reflex mode with a persistent buffer, instant target respawn, session clock — genuinely distinct mechanic |
+| Kill-criterion experiment | A throwaway, never-shipped local experiment designed to falsify (not validate) the "is this fun" hypothesis before any real build |
+
+## See Also
+
+- [[README]] — decision record index and traceability
+- [[SRS]] — functional requirements, marked pass/fail
+- [[NFR]] — non-functional requirements, moot under NO-GO
+- [[spec]] — decision-record version of the original feature spec
+- [[plan]] — kill-criterion experiment and revisit triggers
+- [[appendix-spinoffs]] — independently actionable bugs found during this investigation

--- a/specs/arcade-game-mode-variety/NFR.md
+++ b/specs/arcade-game-mode-variety/NFR.md
@@ -1,0 +1,119 @@
+---
+aliases:
+  - Arcade Game Mode Variety NFR
+  - Issue 264 NFR
+tags:
+  - nfr
+  - requirements/non-functional
+  - minigame
+  - decision-record
+  - status/rejected
+created: 2026-08-09
+project: "helix-trainer"
+status: rejected
+standard: "ISO/IEC 25010:2011"
+related:
+  - "[[BRD]]"
+  - "[[SRS]]"
+---
+
+# Arcade Game Mode Variety: Non-Functional Requirements Specification
+
+> [!abstract]
+> Carries forward NFR-001..004 from the draft spec. All are moot under the
+> NO-GO decision recorded in [[README]] — none were verified against a build,
+> because no build occurred. Retained here so a future revisit does not have
+> to re-derive them from scratch.
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+Records the quality-attribute requirements originally attached to the
+proposed reflex-drill mode, annotated with what is known about their
+achievability from static code inspection performed during the investigation
+— not from a live implementation.
+
+### 1.2 Scope
+
+Four NFRs were drafted originally; this document does not add new ones, since
+no feature exists to derive further quality requirements from. Sections of
+the ISO 25010 model not covered by the original draft (Reliability,
+Compatibility, Portability) are omitted as not applicable.
+
+> [!note] Not Applicable
+> Reliability, Compatibility, and Portability sections of the ISO 25010 model
+> are omitted. The draft spec did not raise requirements in these categories,
+> and no implementation exists to evaluate them against.
+
+### 1.3 Definitions
+
+| Term | Definition |
+|------|-----------|
+| Animation tick interval | The existing periodic tick used by `event_loop::run_async_event_loop` for UI animation and timeout polling |
+| `t!()` | `rust-i18n` macro used project-wide for translated strings |
+
+### 1.4 References
+
+- [[BRD]] — Business Requirements Document
+- [[SRS]] — Software Requirements Specification
+- ISO/IEC 25010:2011
+
+### 1.5 Priority and Trade-offs
+
+Not applicable — no feature was built, so no quality-attribute trade-offs
+were made in practice. The original draft did not specify a priority
+ordering among its four NFRs.
+
+## 2. Performance Efficiency
+
+### 2.1 Time Behaviour
+
+| ID | Requirement | Target | Status |
+|----|------------|--------|--------|
+| NFR-001 | A reflex-drill tick/render loop must not introduce perceptible input lag versus the existing animation tick interval | No perceptible lag vs. baseline | **Moot** — no tick/render loop was built. Would apply only to the continuous variant, which needs a genuine session-level tick path that does not exist today (see [[plan#Cost Basis (Perishable)]] item 1). |
+
+## 3. Usability
+
+### 3.1 Consistency (originally scoped under Usability)
+
+| ID | Requirement | Target | Status |
+|----|------------|--------|--------|
+| NFR-002 | Terminology, scoring vocabulary, and UI chrome for the new mode should match existing minigame screens | No divergent visual language | **Moot** — no UI was built. Prior analysis found the target-marker rendering path would need real new work (not reuse) to be consistent: `preview_positions` in `render_line_with_multi_cursor` (`src/ui/render/editor.rs:112-137`) is only consulted inside the per-char loop and lacks the end-of-line fallback that cursors get, so a target at EOL or on a blank line would render nothing without new code; separately, `render_editor_with_diff` colors a line green when it equals the target line, which is permanently true when `target.content == setup.content`, degenerating the progress affordance. |
+
+### 3.2 Internationalization
+
+| ID | Requirement | Details | Status |
+|----|------------|---------|--------|
+| NFR-004 | Any new user-facing strings must go through `rust-i18n`/`locales/`, not be hardcoded | All new strings translated | **Moot, and currently unachievable in the existing pattern if it were built as originally scoped.** `MiniGameMode::{name, description}` return hardcoded `&'static str`, duplicated index-wise in `MiniGameModeSelection::{mode_name, mode_description}` (`src/ui/state/screen.rs:435-464`); no `t!()` call exists anywhere in `src/ui/render/mode_selection.rs` or `src/ui/render/minigame.rs` today. A future revisit must either amend this requirement to "consistent with existing (currently non-i18n) mode strings", or explicitly scope a `&'static str` → `String`/`t!()` refactor as its own prerequisite work — it is not free reuse. |
+
+## 4. Maintainability
+
+### 4.1 Testability
+
+| ID | Requirement | Details | Status |
+|----|------------|---------|--------|
+| NFR-003 | Core targeting/timing logic for the new mode must be unit-testable without a real terminal, matching the existing `src/minigame/tests.rs` pattern | Deterministic, seed-reproducible tests | **Moot; the seam needed for this exists but is not wired end-to-end.** A generator taking `&mut R: RngExt` (the seam added in commit `8100ebc`) is necessary but not sufficient: `refill_queue` (`src/minigame/session.rs:940`) calls `rand::rng()` inline, so `MiniGameSession` would need a stored RNG or seed — a change to `with_mode`'s shape — before generated rounds could be made reproducible for tests. Only relevant if the continuous variant is ever built. |
+
+## 5. Verification Matrix
+
+| ID | Method | Environment | Status |
+|----|--------|-------------|--------|
+| NFR-001 | Manual perceived-lag check against baseline tick interval | Local | Not run — no build |
+| NFR-002 | Visual review against existing minigame screens | Local | Not run — no build |
+| NFR-003 | `cargo nextest run` with seeded RNG | CI | Not run — no build; seam exists but is not wired (see above) |
+| NFR-004 | `rust-i18n` lint / manual review of `locales/` | Local | Not run — no build; current pattern would fail this check even for existing modes' hardcoded strings, independent of this feature |
+
+## 6. Open Questions
+
+> [!question] Unresolved Quality Requirements
+> - [ ] If revisited, should NFR-004 be relaxed to match the existing
+>       non-i18n pattern of `MiniGameMode::name`/`description`, or should the
+>       i18n refactor of all three modes be taken as a prerequisite? This
+>       decision record does not resolve it — flagged for whoever revisits.
+
+## See Also
+
+- [[BRD]] — business requirements (source)
+- [[SRS]] — functional requirements
+- [[README]] — decision record index

--- a/specs/arcade-game-mode-variety/README.md
+++ b/specs/arcade-game-mode-variety/README.md
@@ -1,0 +1,112 @@
+---
+aliases:
+  - Arcade Game Mode Variety — Decision Record
+  - Issue 264 Decision Record
+tags:
+  - sdd
+  - decision-record
+  - minigame
+  - no-go
+created: 2026-08-09
+status: rejected
+related:
+  - "[[BRD]]"
+  - "[[SRS]]"
+  - "[[NFR]]"
+  - "[[spec]]"
+  - "[[plan]]"
+  - "[[tasks]]"
+  - "[[appendix-spinoffs]]"
+---
+
+# Decision Record: Arcade Game Mode Variety (GitHub Issue #264)
+
+> [!danger] Status: REJECTED (NO-GO)
+> This package does **not** describe an approved feature. It documents an
+> evaluation that concluded neither variant of the proposed feature should be
+> built now. Every section below is written in the past/evaluative tense —
+> "what was proposed", "what was found", "why it was rejected" — not as an
+> implementation plan.
+
+## What This Package Is
+
+A full BRD → SRS → NFR → spec → plan → tasks pipeline, run against issue #264
+("helix-trainer needs a reflex/targeting-drill arcade mechanic distinct from
+scenario-completion, inspired by vim-be-good's `whackamole`"), and adapted to
+record why the pipeline terminated in NO-GO rather than an approved build.
+
+## Headline Finding
+
+The premise of issue #264 does not hold as scoped. **90 of 134 shipped
+scenarios already have `target` content identical to `setup` content** (61 in
+the `movement` category, 51 with `optimal_count == 1`), and
+`tests/scenario_validation.rs` proves these complete via
+`EditorSnapshot::matches` (`src/helix/simulator/snapshot.rs:159-170`) content
++ cursor-offset comparison. These are, mechanically, whack-a-mole rounds —
+acquire a target on an unmodified buffer under time/lives pressure — and they
+already ship today, playable through the existing `Arcade` mode.
+
+A **cheap** version of the proposed feature (generated targets + a shorter
+timer, reusing the existing `Scenario`/`ActiveMiniScenario` machinery)
+therefore fails the spec's own distinctiveness bar (FR-001 / SC-001): its only
+delta from what already ships is pacing, which the original spec explicitly
+places out of scope.
+
+A **genuinely distinct** version exists in principle — the real differentiator
+is *continuity* (one persistent buffer, instant target respawn, no per-round
+transition screen, a real session clock), not targeting. But continuity
+requires real subsystem work that does not exist today: no session-level
+clock anywhere in `MiniGameSession`, the `Transition { success }` step would
+need removing for this mode, and a target generator/respawn path bypassing
+per-round `Scenario` re-instantiation.
+
+**Decision: NO-GO on building either version now.** The durable justification
+is P3 priority + single-reference-project evidence (vim-be-good only) + no
+user demand — see [[BRD#Problem Statement]] and [[plan#Decision Rationale]].
+The cost estimate for the continuous version is a secondary, perishable data
+point (see [[plan#Cost Basis (Perishable)]]) — it is explicitly not the
+load-bearing argument, because it will change if the independent session-clock
+bug ([[appendix-spinoffs#Spin-off A]]) is fixed on its own merits.
+
+## Traceability
+
+| BRD Finding | SRS Impact | NFR Status | Recommended Next Action |
+|---|---|---|---|
+| [[BRD#Finding 1 — Targeting Parity Already Shipped]]: 90/134 scenarios are already content-identical reflex rounds, proven by `tests/scenario_validation.rs` | [[SRS#FR-001]] and [[SRS#FR-002 (Success Criteria)|SC-001]] FAIL — distinctiveness bar not met by the cheap version | [[NFR#NFR-002 — Consistency]] moot (nothing ships) | None — do not build the cheap version. Close #264 as researched-not-planned. |
+| [[BRD#Finding 2 — The Real Differentiator Is Continuity, Not Targeting]]: a genuinely distinct mode exists in principle but requires a session clock, a state-machine change, and a respawn path | [[SRS#FR-002]], [[SRS#FR-003]], [[SRS#FR-004]] remain hypothetically satisfiable; [[SRS#FR-005]], [[SRS#FR-006]] moot (no variant added) | [[NFR#NFR-001 — Performance]], [[NFR#NFR-003 — Testability]] would apply if revisited; [[NFR#NFR-004 — i18n]] currently unachievable in the existing pattern (M3) | [[plan#Recommended Next Action — Kill-Criterion Experiment]] — a throwaway, uncommitted, falsifier-only local experiment, only if someone revisits this later |
+| [[BRD#Finding 3 — Priority and Evidence Basis]]: P3, single reference project, no user demand | N/A — this is the priority gate, independent of the above two | N/A | Do not promote #264 ahead of issue #198 (content coverage), which has stronger evidence |
+| Two independent spin-off bugs surfaced during investigation | N/A — out of scope for #264's requirements | N/A | File separately; see [[appendix-spinoffs]]. Not part of this decision, actionable regardless of it. |
+
+## Revisit Triggers
+
+Documented in [[plan#Revisit Triggers]]. In short: the session-clock bug
+([[appendix-spinoffs#Spin-off A]]) is fixed independently; a real user demand
+signal appears; a second reference project ships an equivalent mechanic.
+
+## Package Contents
+
+- [[BRD]] — business goal (competitive parity vs. vim-be-good) and the finding that undermines it
+- [[SRS]] — FR-001..006 as originally proposed, marked pass/fail against current-state evidence
+- [[NFR]] — NFR-001..004 carried forward from the draft spec, marked moot under NO-GO
+- [[spec]] — decision-record version of the original feature spec (what was evaluated, not what will be built)
+- [[plan]] — the kill-criterion experiment as the only recommended next action, plus revisit triggers
+- [[tasks]] — the experiment protocol broken into steps, explicitly not approved for execution
+- [[appendix-spinoffs]] — two independently actionable bugs found during the investigation, for team-lead to file verbatim
+
+## Investigation Chain
+
+This record synthesizes three rounds of design/critique, all under
+`.local/handoff/` in this worktree (gitignored, not part of this committed
+package):
+
+1. Architect's first plan (2026-08-09T16:44) — GO at P3, "no new subsystem" claim
+2. Critic's first critique (2026-08-09T16:57) — verdict: significant; 5 gaps, headlined by the targeting-parity finding
+3. Architect's revised plan (2026-08-09T17:00) — verdict flipped to NO-GO, all 5 gaps conceded
+4. Critic's second critique (2026-08-09T17:03) — verdict: minor; NO-GO endorsed with 4 corrections to the reasoning (not the conclusion)
+
+## See Also
+
+- Original draft spec (pre-critique, uncommitted): `.local/specs/002-arcade-game-mode-variety/spec.md` in the main checkout — superseded by [[spec]] in this package
+- GitHub issue #264
+- GitHub issue #198 — Helix command content-coverage gap (higher-evidence, separate concern)
+- [vim-be-good](https://github.com/ThePrimeagen/vim-be-good) — sole reference project cited for this gap

--- a/specs/arcade-game-mode-variety/SRS.md
+++ b/specs/arcade-game-mode-variety/SRS.md
@@ -1,0 +1,244 @@
+---
+aliases:
+  - Arcade Game Mode Variety SRS
+  - Issue 264 SRS
+tags:
+  - srs
+  - requirements/functional
+  - minigame
+  - decision-record
+  - status/rejected
+created: 2026-08-09
+project: "helix-trainer"
+status: rejected
+standard: "ISO/IEC/IEEE 29148:2018"
+related:
+  - "[[BRD]]"
+  - "[[NFR]]"
+---
+
+# Arcade Game Mode Variety: Software Requirements Specification
+
+> [!abstract]
+> Functional requirements as originally proposed for issue #264, each marked
+> against current-state evidence. Traceable to [[BRD]]. This document does
+> not authorize implementation — see [[README]] for the NO-GO decision.
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+Records the functional requirements originally drafted for a reflex/targeting
+minigame mode, and evaluates each against the codebase as it exists today, so
+a future reader can see exactly which requirements failed, which were never
+tested because the feature was rejected before build, and which remain
+hypothetically valid if this is ever revisited.
+
+### 1.2 Scope
+
+Covers the reflex-drill mechanic proposed in issue #264 only. Does not cover
+the existing `Arcade`/`Survival`/`Challenge` modes (unchanged) or content
+coverage (issue #198).
+
+### 1.3 Definitions, Acronyms, and Abbreviations
+
+| Term | Definition |
+|------|-----------|
+| `MiniGameMode` | Enum of minigame modes (`Arcade`, `Survival`, `Challenge`), `src/minigame/modes.rs` |
+| `MiniGameSession` | Typestate session state machine driving a minigame round, `src/minigame/session.rs` |
+| `ActiveMiniScenario` | Per-round active scenario state within a session |
+| `EditorSnapshot::matches` | Completion predicate comparing current editor state to a scenario's target, `src/helix/simulator/snapshot.rs:159` |
+| `DifficultyController` | Adaptive difficulty selection component, `src/minigame/difficulty.rs` |
+
+### 1.4 References
+
+- [[BRD]] — Business Requirements Document
+- [[NFR]] — Non-Functional Requirements Specification
+- `.local/specs/002-arcade-game-mode-variety/spec.md` (main checkout) — original draft spec this record supersedes
+
+### 1.5 Document Overview
+
+Section 2 gives overall context (unchanged system). Section 3 lists FR-001
+through FR-006 exactly as drafted, each with a verdict and evidence. Section
+4 is the verification matrix, marked "not run" throughout since no build
+occurred.
+
+## 2. Overall Description
+
+### 2.1 Product Perspective
+
+No system-context change: this record evaluates a proposed addition to
+`src/minigame/`, a subsystem of the single-binary helix-trainer TUI. No
+addition was made.
+
+### 2.2 Product Functions
+
+Not applicable — no new functional area was implemented.
+
+### 2.3 User Classes and Characteristics
+
+Unchanged from [[BRD#Target Users (As Originally Framed)]].
+
+### 2.4 Operating Environment
+
+Unchanged — TUI via ratatui/crossterm, tokio async runtime, as documented in
+the project's `CLAUDE.md`.
+
+### 2.5 Design and Implementation Constraints
+
+N/A — no implementation occurred.
+
+### 2.6 Assumptions and Dependencies
+
+See [[BRD#Assumptions]].
+
+## 3. Specific Requirements
+
+### 3.1 Functional Requirements — Original Text and Verdict
+
+> [!info] Traceability
+> Traces to the draft spec's Functional Requirements section (`.local/specs/002-arcade-game-mode-variety/spec.md:130-141`, main checkout).
+
+**FR-001** — WHEN the player selects the new reflex-drill mode THE SYSTEM
+SHALL present a core loop mechanically distinct from scenario-completion
+(e.g., acquire-and-act-on-a-target rather than transform-a-buffer-into-a-
+target-state).
+
+- *Priority*: should
+- *Verdict*: **FAILS** (for the cheap/generated-target variant)
+- *Evidence*: 90 of 134 shipped scenarios already have
+  `target.file_content == setup.file_content` (61 `movement`, 25 `selection`,
+  4 `search`); `EditorSnapshot::matches` (`src/helix/simulator/snapshot.rs:
+  159-170`) completes these on content + cursor-offset equality alone. A
+  generated-target reflex mode built on the same `Scenario` machinery differs
+  from these only by a shorter timer — pacing, which the draft spec's own
+  Out-of-Scope section excludes from counting as a distinct mechanic. See
+  [[BRD#Finding 1 — Targeting Parity Already Shipped]].
+- *If revisited*: only the continuous-play variant (persistent buffer,
+  instant respawn, session clock — [[BRD#Finding 2]]) could plausibly satisfy
+  this requirement; the cheap variant cannot regardless of implementation
+  quality.
+
+**FR-002** — WHEN the player executes an input during the reflex-drill mode
+THE SYSTEM SHALL route it through `HelixSimulator`/`AnyModeSimulator` command
+execution, never a bespoke coordinate-comparison shortcut.
+
+- *Priority*: must
+- *Verdict*: **hypothetically satisfiable, satisfied by construction** —
+  untested in production since nothing was built
+- *Evidence*: `ActiveMiniScenario::execute_single` (`src/minigame/session.rs:
+  220`) already routes every key through `AnyModeSimulator::execute_command`
+  for every existing mode; `src/input/handlers.rs:533,541` already emits
+  `Message::MiniGameCommand` for the arcade screen. Any mode expressed as a
+  `Scenario` (cheap variant) inherits this automatically. The continuous
+  variant would need to preserve this property explicitly when bypassing
+  per-round `Scenario` re-instantiation (see [[plan#Cost Basis (Perishable)]]
+  item 3/4).
+
+**FR-003** — WHEN a reflex-drill session ends THE SYSTEM SHALL report results
+through the existing scoring/gamification pipeline (XP, streaks,
+`MiniGameStats`-equivalent) used by `Arcade`/`Survival`/`Challenge`.
+
+- *Priority*: must
+- *Verdict*: **hypothetically satisfiable, satisfied by construction** —
+  untested in production
+- *Evidence*: `handle_minigame_game_over` (`src/ui/state/handlers/minigame.rs:
+  362-415`) is mode-agnostic; `ScoreCalculator::calculate`
+  (`src/minigame/scoring.rs:147`) takes only scalars. Both variants would
+  reuse this path without modification. Caution noted in
+  [[appendix-spinoffs]]-adjacent findings: this same reuse is what makes an
+  uncontrolled kill-criterion experiment dangerous to the real user profile
+  (see [[plan#Experiment Isolation Requirements]]) — `save_immediate()` is
+  called unconditionally on game over.
+
+**FR-004** — WHEN difficulty scaling applies to the reflex-drill mode THE
+SYSTEM SHALL reuse or extend `DifficultyController` rather than introducing
+an unrelated adaptive-difficulty mechanism.
+
+- *Priority*: should
+- *Verdict*: **hypothetically valid, moot under NO-GO**
+- *Evidence*: `DifficultyController::current_level()` /
+  `update_after_scenario(PerformancePoint)` could map level → target
+  distance, motion class, round time limit, the way
+  `SurvivalConfig::time_limit_for_level` already does. Generation would not
+  route through `next_scenario` (`src/minigame/difficulty.rs:402`), since
+  that selects from an existing `&[Scenario]` pool and generated rounds are
+  not in one. Only relevant if the continuous version is ever approved.
+
+**FR-005** — WHERE the reflex-drill mode is added THE SYSTEM SHALL expose it
+as a new `MiniGameMode` variant (or equivalent), consistent with how
+`Arcade`/`Survival`/`Challenge` are already modeled in
+`src/minigame/modes.rs`.
+
+- *Priority*: should
+- *Verdict*: **moot** — nothing is being added
+- *Evidence*: N/A. Prior analysis (superseded) concluded a single new variant
+  was preferable to a fourth top-level type, to avoid duplicating
+  `ActiveMiniScenario`, timers/pause, `MiniGameStats`, the countdown state
+  machine, render chrome, input routing, and the FSRS bridge. This reasoning
+  would still hold if revisited, but is not being acted on now.
+
+**FR-006** — WHEN the reflex-drill mode is unavailable or not yet built THE
+SYSTEM SHALL NOT regress or remove any existing `Arcade`/`Survival`/
+`Challenge` behavior.
+
+- *Priority*: must
+- *Verdict*: **trivially satisfied, moot** — no code changed, so no
+  regression is possible
+- *Evidence*: This decision record introduces zero source changes.
+
+### 3.2 Success Criteria (from the draft spec)
+
+| ID | Metric | Verdict |
+|----|--------|---------|
+| SC-001 | New mode is mechanically distinguishable from existing modes in a blind description test | **FAILS** for the cheap variant, same evidence as FR-001; unproven either way for the continuous variant since it was never built |
+| SC-002 | All new logic covered by unit tests, no regression in `cargo nextest run --workspace --all-features --lib --bins` | **Not applicable** — no new logic exists |
+| SC-003 | No increase in P0/P1 issues on existing modes after the change lands | **Not applicable** — nothing landed |
+
+### 3.3 Logical Data Requirements
+
+No new persistent entities were introduced. The draft spec's proposed data
+model (`Reflex-drill session state`: target location, acquisition deadline,
+hit/miss streak) was never implemented. Prior analysis noted, if ever
+revisited: `Scenario` (`src/config/scenarios.rs:93-114`) has no `Default`
+impl and requires `solution.commands` and `scoring.optimal_count:
+NonZeroUsize` to be synthesized by any generator — not cosmetic fields, since
+`optimal_count` feeds `efficiency` in both `ScoreCalculator::calculate` and
+`PerformancePoint` → `DifficultyController` (`src/minigame/session.rs:
+492-527`).
+
+## 4. Verification and Validation
+
+### 4.1 Verification Matrix
+
+| Requirement | Method | Criteria | Status |
+|------------|--------|----------|--------|
+| FR-001 | Blind description test | Distinguishable core loop | **FAILED — evaluated pre-build against existing content, not run as a live test** |
+| FR-002 | Code inspection | Routes through `AnyModeSimulator` | Not run — no build occurred |
+| FR-003 | Code inspection | Reuses existing scoring/gamification path | Not run — no build occurred |
+| FR-004 | Code inspection | Reuses `DifficultyController` | Not run — no build occurred |
+| FR-005 | Code review | New `MiniGameMode` variant, exhaustive matches | Not run — no build occurred |
+| FR-006 | Regression test suite | No P0/P1 regressions | Not applicable — no changes made |
+
+### 4.2 Acceptance Test Outline
+
+Not applicable. If the kill-criterion experiment in [[plan]] is ever run, its
+own acceptance criteria (a self-play fun/no-fun signal) apply instead — see
+[[plan#Kill-Criterion Experiment Protocol]].
+
+## 5. Appendices
+
+### 5.1 Traceability Matrix
+
+| BRD Requirement | SRS Requirement(s) | NFR Requirement(s) |
+|----------------|--------------------|--------------------|
+| [[BRD#Finding 1 — Targeting Parity Already Shipped]] | FR-001 (fails), SC-001 (fails) | NFR-002 (moot) |
+| [[BRD#Finding 2 — The Real Differentiator Is Continuity, Not Targeting]] | FR-002, FR-003, FR-004 (hypothetically valid) | NFR-001, NFR-003 (would apply if revisited) |
+| [[BRD#Finding 3 — Priority and Evidence Basis]] | FR-005, FR-006 (moot) | NFR-004 (currently unachievable in existing pattern) |
+
+## See Also
+
+- [[BRD]] — business requirements (source)
+- [[NFR]] — non-functional requirements
+- [[README]] — decision record index
+- [[plan]] — kill-criterion experiment and revisit triggers

--- a/specs/arcade-game-mode-variety/appendix-spinoffs.md
+++ b/specs/arcade-game-mode-variety/appendix-spinoffs.md
@@ -1,0 +1,159 @@
+---
+aliases:
+  - Arcade Game Mode Variety — Spin-off Findings
+  - Issue 264 Spin-off Bugs
+tags:
+  - sdd
+  - appendix
+  - minigame
+  - bug
+  - architecture
+created: 2026-08-09
+status: findings-only
+related:
+  - "[[README]]"
+  - "[[plan]]"
+---
+
+# Appendix: Spin-off Findings (Independent of the #264 Decision)
+
+> [!info] Purpose
+> These two bugs were discovered as a byproduct of investigating issue #264.
+> They are **not part of the NO-GO decision** recorded in [[README]] — they
+> are real, independently actionable defects in code that exists today,
+> regardless of what happens with #264. This appendix documents them
+> precisely enough for team-lead to file as GitHub issues verbatim. This
+> record does **not** file them.
+
+## Spin-off A — Arcade's Advertised Session Time Limit Is Not Implemented
+
+### Summary
+
+The UI promises `Arcade` mode is bounded by a 60-second session timer with 3
+lives. No such session-level timer exists in the code. `Arcade` actually runs
+until lives are exhausted, with no time bound at all.
+
+### Evidence
+
+- UI promise, rendered to the player in two places:
+  - `MiniGameMode::description()` → `"60 seconds, 3 lives, chase the high
+    score!"` (`src/minigame/modes.rs:67`, and the same literal again at
+    `:457`)
+  - `MiniGameModeSelection::mode_description(0)` → the identical string
+    (`src/ui/state/screen.rs:459`), rendered via `render_mode_option`'s
+    `description` parameter in `src/ui/render/mode_selection.rs`
+- The mechanism that should enforce this bound has zero non-test call sites:
+  - `MiniGameMode::has_session_timer()` (`src/minigame/modes.rs:43`)
+  - `MiniGameMode::session_duration()` (`src/minigame/modes.rs:48`) — both
+    are called only from unit tests in `src/minigame/session.rs:1370-1382`
+    and `src/minigame/modes.rs:264-372`, never from production code
+- `ArcadeConfig::session_duration` defaults to `Duration::from_secs(60)`
+  (`src/minigame/modes.rs:114`) — the value exists and is correct, it is
+  simply never read outside tests
+- The event loop's tick path only checks per-scenario timeout and
+  transition auto-advance — no session-level check exists:
+  ```
+  src/event_loop.rs:140-152
+  _ = tick_interval.tick() => {
+      if is_minigame_playing(state) && is_minigame_timed_out(state) {
+          ui::update(state, Message::MiniGameTimeout)?;
+      }
+      if should_minigame_advance(state) {
+          ui::update(state, Message::MiniGameNextScenario)?;
+      }
+      ...
+  }
+  ```
+- `MiniGameSession` (`src/minigame/session.rs:240-282`) has no session-level
+  clock field at all — `started_at` (`:50`) belongs to `ActiveMiniScenario`
+  (per-round), `transition_started_at` (`:266`) is for transitions only
+- No `MiniGameSessionTimeout`-equivalent message exists in the `Message` enum
+
+### Impact
+
+User-visible false promise: a player reading "60 seconds, 3 lives" and
+choosing `Arcade` for a short session will instead play until they lose all
+3 lives, which can take arbitrarily longer (or shorter) than 60 seconds.
+
+### Suggested Filing
+
+- **Title** (imperative, problem not fix): `Arcade mode has no session time limit despite advertised "60 seconds"`
+- **Labels**: `bug`, `minigame`, priority — recommend `P2` (matches this
+  project's P1/P2 tier definitions: "incorrect scoring... broken FSRS-
+  adjacent" for P1 vs. "suboptimal UX, minor display issue" for P2; this is a
+  UI-promise-vs-behavior mismatch rather than data loss or incorrect
+  scoring, so P2 fits — use judgment if a stronger read is warranted)
+- **Reproduction**: Start `Arcade` mode, note the "60 seconds, 3 lives"
+  description, play past the 60-second mark without losing 3 lives — the
+  session continues.
+- **Expected**: Session ends (or at minimum surfaces a warning) at 60
+  seconds, matching the advertised description.
+- **Actual**: Session runs indefinitely until 3 lives are lost, regardless of
+  elapsed time.
+
+## Spin-off B — Silent Non-Exhaustive `_ =>` Fallthroughs in Mode-Selection Code
+
+### Summary
+
+Multiple `match` expressions across the minigame mode-selection code use a
+wildcard `_ =>` arm instead of exhaustive matching. Adding a new
+`MiniGameMode` variant compiles cleanly without updating every site, and the
+unhandled index silently falls back to `Arcade`-equivalent behavior or an
+empty/placeholder string rather than failing to compile.
+
+### Evidence
+
+- `src/ui/state/screen.rs:435-464`, three functions on
+  `MiniGameModeSelection`, all keyed by `self.selected_index` /
+  `index: usize` (an integer, not the enum — inherently non-exhaustive by
+  construction):
+  - `selected_mode(&self, today) -> MiniGameMode` — `_ =>
+    MiniGameMode::default()` (silently resolves to `Arcade`)
+  - `mode_name(index: usize) -> &'static str` — `_ => "Unknown"`
+  - `mode_description(index: usize) -> &'static str` — `_ => ""`
+  - All three are gated by `Self::MODE_COUNT` (currently 3, at
+    `screen.rs:413` per the investigation) — bumping `MODE_COUNT` without
+    adding a matching arm to all three functions compiles cleanly and
+    silently mislabels or misbehaves at runtime.
+- `src/minigame/modes.rs`, same hazard class on the enum itself:
+  - `has_session_timer()` (`:43-45`) — uses `matches!(self,
+    Self::Arcade(_))`, silently `false` for any variant not explicitly
+    listed
+  - `is_arcade()` / `is_survival()` / `is_challenge()` (`:74-85`) — same
+    `matches!` pattern
+  - `session_duration()` (`:48-53`) — ends in `_ => None`
+
+### Impact
+
+None of these are compile-time enforced. A future contributor adding a
+fourth `MiniGameMode` variant (for this feature or any other) could pass
+every `cargo build`/`cargo clippy` check while `MiniGameModeSelection::
+selected_mode` silently launches `Arcade` under the new mode's menu label —
+a correctness bug that would only surface through manual play-testing, not
+through the type system that the rest of this project relies on
+(`#![forbid(unsafe_code)]`, typestate patterns elsewhere in `src/game/` and
+`src/minigame/session.rs`).
+
+### Suggested Filing
+
+- **Title**: `Non-exhaustive matches in minigame mode-selection code create silent-fallthrough hazard for new modes`
+- **Labels**: `architecture`, `minigame`, priority — recommend `P3` (cosmetic
+  today since only 3 modes exist and all are correctly indexed; the risk is
+  latent, triggered only by a future mode addition)
+- **Description**: List all eight call sites above (three in `screen.rs`,
+  five in `modes.rs`) in one issue — same fix (replace wildcard/`matches!`
+  patterns with exhaustive `match` over the enum, or restructure
+  `MiniGameModeSelection` to index by `MiniGameMode` variant rather than raw
+  `usize`) applies to all of them.
+- **Expected**: Adding a `MiniGameMode` variant without updating every
+  consuming `match` fails to compile.
+- **Actual**: Compiles cleanly; wrong mode is silently selected or labeled at
+  runtime.
+
+## See Also
+
+- [[README]] — decision record index (these findings are appended to, not
+  part of, the #264 NO-GO decision)
+- [[plan#Cost Basis (Perishable)]] — Spin-off A's fix directly reduces the
+  cost basis for a future #264 revisit, since fixing it independently is
+  what item 1 of the continuous-variant cost currently double-counts

--- a/specs/arcade-game-mode-variety/plan.md
+++ b/specs/arcade-game-mode-variety/plan.md
@@ -1,0 +1,173 @@
+---
+aliases:
+  - Arcade Game Mode Variety Plan
+  - Issue 264 — Recommended Next Action
+tags:
+  - sdd
+  - plan
+  - minigame
+  - decision-record
+  - status/rejected
+created: 2026-08-09
+status: rejected
+related:
+  - "[[spec]]"
+  - "[[BRD]]"
+  - "[[README]]"
+---
+
+# Technical Plan: Arcade Game Mode Variety — No Build Plan (NO-GO)
+
+> [!danger] References
+> **Spec**: [[spec]] — records the NO-GO decision
+> **This document does not describe an implementation plan.** Since the
+> feature was rejected, there is no architecture, data model, or rollout to
+> plan. This document instead records: (1) the corrected cost basis behind
+> the decision, (2) the one falsifiable experiment worth keeping as a
+> documented option, and (3) the conditions under which this decision should
+> be revisited.
+
+## 1. Decision Rationale
+
+The NO-GO decision rests on two independent legs, in priority order:
+
+1. **Primary, durable: P3 priority + single-reference-project evidence +
+   no user demand.** This is sufficient on its own regardless of cost. See
+   [[BRD#Finding 3 — Priority and Evidence Basis]].
+2. **Secondary, perishable: the continuous variant's cost is real
+   subsystem work, not the near-free "~1 focused PR" the first-pass
+   evaluation assumed.** See Cost Basis below.
+
+> [!warning] Do not treat the cost estimate as the reason
+> Reason 2 will change if the session-clock bug ([[appendix-spinoffs#Spin-off
+> A]]) is fixed independently — see Revisit Triggers below. If this record is
+> read after that bug is fixed and someone concludes "the cost dropped, so
+> build it," that is a misread: reason 1 alone was always sufficient, and
+> still is, unless the evidence and priority basis also change.
+
+## 2. Cost Basis (Perishable)
+
+The continuous (genuinely distinct) variant requires four items, as first
+identified:
+
+1. A session-level clock — does not exist anywhere in `MiniGameSession`
+   (verified: no field carries it; `started_at` at `session.rs:50` belongs to
+   `ActiveMiniScenario`, `transition_started_at` at `:266` is transition-only)
+2. Removal of the `Transition { success }` step from this mode's flow — a
+   state-machine change
+3. A target-respawn path inside a live buffer, bypassing per-round
+   `Scenario` re-instantiation
+4. Instant next-target generation
+
+### Two Corrections to This Cost Basis (from the second critique round)
+
+**Correction A — item 1 is double-counted against an independent bug.** The
+session-level clock is simultaneously booked as a cost of this feature *and*
+filed as an independent P2 bug ([[appendix-spinoffs#Spin-off A]]: the UI
+already promises "60 seconds" for `Arcade` and does not deliver it). It
+cannot be both. If that bug is fixed on its own merits — and it should be,
+since it is a user-visible false promise independent of #264 — the marginal
+cost of the continuous mode drops from four items to three, at zero
+attributable cost to #264.
+
+**Correction B — items 3 and 4 are one item, not two.** If item 3 (respawn
+without re-instantiating `ActiveMiniScenario`) is taken, the mode bypasses
+`Scenario` entirely for its live rounds. That means there is no
+`scoring.optimal_count` to synthesize and no `solution` to construct — so
+item 4 is not "build a `Scenario` generator" at all, it reduces to "pick a
+random reachable character offset != the current cursor" over a fixed
+buffer. FR-002 (route through the simulator) and FR-003 (reuse
+`ScoreCalculator`/`MiniGameStats`) both still hold under this simplified
+item.
+
+**Net corrected cost: ~2.5 items, not 4.** This does not flip the
+recommendation (see Section 1) — it corrects the record so a future reader
+is not anchored to an inflated number.
+
+## 3. Recommended Next Action — Kill-Criterion Experiment
+
+The only recommended next action, and only if someone chooses to revisit this
+decision, is a throwaway, falsifier-only local experiment — **not** a
+committed build step, and **not** approved for execution by this record
+alone (see [[tasks]] for why).
+
+### Kill-Criterion Experiment Protocol
+
+Run a `Reflex` *pacing* config (short timer, no new mechanic) over the
+existing shipped scenario pool, restricted to `category == movement` AND
+`optimal_count == 1` — **42 of the 61 `movement` scenarios**, not all 61.
+
+> [!warning] Scope restriction is load-bearing
+> A flat 2-3s limit across all 61 `movement` rounds would manufacture a false
+> negative: 19 of the 61 need ≥2 commands (`{1: 42, 2: 14, 3: 3, 7: 2}`
+> distribution), and the 2 rounds needing 7 commands are unwinnable in 2s
+> regardless of player skill. That would measure frustration at an
+> impossible timer, not fun-vs-not-fun for the true whack-a-mole analogue.
+> Restricting to `optimal_count == 1` isolates the actual hypothesis.
+
+Frame the result explicitly as a **falsifier, not a validator**: a negative
+signal from single-subject self-play ("this isn't fun") is trustworthy and
+sufficient to keep the NO-GO. A positive signal ("this is fun") is *not*
+sufficient on its own to flip the decision — see Revisit Triggers, which
+requires more than a fun self-play session.
+
+### Experiment Isolation Requirements
+
+`handle_minigame_game_over` (`src/ui/state/handlers/minigame.rs:362-415`)
+is mode-agnostic and unconditionally writes to the real user profile:
+`profile.add_xp(xp)`, `minigame_high_score`, `minigame_best_streak`,
+`minigame_games_played`, then calls `save_immediate()` →
+`~/.config/helix-trainer/profile.json`. **Disabling FSRS recording alone is
+not sufficient isolation** — `record_to_fsrs` has two call sites
+(`handlers/minigame.rs:157,370`), and suppressing both still leaves XP, high
+score, streak, and game count corrupted in the real profile.
+
+Required isolation, either of:
+- Point the experiment at an isolated `~/.config/helix-trainer/`-equivalent
+  config directory, or
+- Copy `profile.json` aside before the experiment and restore it after
+
+This is a hard requirement, not a suggestion — running the experiment
+without it corrupts the operator's real XP, high score, streak, game count,
+and FSRS review schedule.
+
+### What This Experiment Must Never Become
+
+- A shipped `MiniGameMode` variant, an enum change, a menu entry, or any
+  change to `MODE_COUNT`
+- A committed public API of any kind
+- Run against the real `~/.config/helix-trainer/` directory
+
+## 4. Revisit Triggers
+
+This decision should be actively revisited — not automatically reversed —
+under any of the following:
+
+| Trigger | What Changes |
+|---|---|
+| The session-clock bug ([[appendix-spinoffs#Spin-off A]]) is fixed independently | Cost basis drops from ~2.5 to ~1.5 items; re-run the priority/evidence check (Section 1, reason 1) fresh — it may still be NO-GO on evidence grounds alone |
+| A real user-demand signal appears (e.g., users request this specific mechanic, not just "more variety") | Reason 1 (no user demand) no longer holds; re-evaluate against the then-current cost basis |
+| A second reference project ships an equivalent reflex/targeting mechanic | Strengthens the evidence basis beyond "single reference project"; re-evaluate |
+| The kill-criterion experiment is run and yields a strong positive signal | Necessary but not sufficient alone — combine with at least one of the above before proposing a build |
+
+## 5. Constitution Compliance
+
+No project constitution exists yet for helix-trainer (`.local/specs/
+constitution.md` was not found). Compliance section omitted as not
+applicable.
+
+## 6. Risks and Mitigations
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|-------------|------------|
+| A future reader treats the corrected ~2.5-item cost as low enough to justify a build on cost alone | Feature gets built without addressing the real blocker (evidence/priority) | Medium | Section 1's explicit warning; Revisit Triggers require more than cost alone |
+| The kill-criterion experiment is run without isolation and corrupts a real user's profile | Data loss: XP, streak, high score, FSRS review schedule | Low (protocol documented) | Section 3's isolation requirement is marked hard, not optional |
+| Issue #264 is left open indefinitely without this record being linked | Future contributors re-investigate from scratch | Medium | [[BRD#Open Questions]] flags this for team-lead; recommend linking this record in the issue close/relabel |
+
+## See Also
+
+- [[spec]] — the rejected feature spec
+- [[BRD]] — business rationale
+- [[tasks]] — experiment protocol broken into steps (not approved for execution)
+- [[appendix-spinoffs]] — the independent bug this cost basis depends on
+- [[README]] — decision record index

--- a/specs/arcade-game-mode-variety/spec.md
+++ b/specs/arcade-game-mode-variety/spec.md
@@ -1,0 +1,242 @@
+---
+aliases:
+  - Arcade Game Mode Variety Spec
+  - Reflex Drill Minigame — Decision Record
+tags:
+  - sdd
+  - spec
+  - minigame
+  - decision-record
+  - status/rejected
+created: 2026-08-09
+status: rejected
+related:
+  - "[[BRD]]"
+  - "[[SRS]]"
+  - "[[NFR]]"
+  - "[[README]]"
+---
+
+# Feature: Arcade Game Mode Variety (Reflex/Speed-Drill Mechanic) — REJECTED
+
+> [!danger] Metadata
+> **Status**: rejected (NO-GO)
+> **Original author**: research finding (competitive parity scan vs. vim-be-good)
+> **Issue**: #264
+> **Priority**: P3
+> **Decision date**: 2026-08-09
+> **This is not an implementation spec.** It records what was evaluated and
+> why it was rejected. See [[README]] for the full decision record and
+> [[plan]] for the only recommended next action.
+
+## 1. What Was Proposed
+
+### Original Problem Statement
+
+`src/minigame/` offers three named modes — `Arcade`, `Survival`, `Challenge`
+(`src/minigame/modes.rs`, `MiniGameMode` enum) — that share one mechanic:
+complete a scenario from `scenarios/en/<category>/*.toml` under time/lives
+pressure, scored by `ScenarioScorer`/`ScoreCalculator`. They differ only in
+pacing (session timer, lives count, escalation curve), not in what the player
+does moment to moment.
+
+vim-be-good, the reference project named in this project's
+`continuous-improvement` rules for game-mode variety, ships mechanically
+distinct games: `relative` (relative-jump line deletion), `ci{` (text-object
+editing), `whackamole` (navigate to a moving/highlighted target as fast as
+possible — a pure reflex/speed drill, not scenario completion), and `snake`
+(a full arcade game played with `hjkl`).
+
+The original ask: decide whether helix-trainer should add at least one arcade
+mechanic that is *not* scenario-completion-under-pressure, inspired by
+`whackamole`.
+
+### Original Goal
+
+Decide whether to add a reflex/targeting drill mechanic and, if so, specify
+it in enough detail to hand off to `/sdd plan`.
+
+## 2. What Was Found
+
+### The Cheap Version Is Not Distinct
+
+`EditorSnapshot::matches` (`src/helix/simulator/snapshot.rs:159-170`)
+completes any scenario whose target has ≤1 selection and no real (non-point)
+selection via content equality + cursor-offset equality alone. A reflex-drill
+round is therefore already expressible as an ordinary `Scenario` whose
+`target.file_content == setup.file_content`. Measured against the shipped
+library: **90 of 134 scenarios already satisfy this** (61 `movement`, 25
+`selection`, 4 `search`; 51 with `optimal_count == 1`). These already run
+today through `Arcade`, under a timer, with lives and adaptive difficulty.
+
+A mode that generates similar targets procedurally and applies a shorter
+timer would differ from what already ships only in pacing — which the
+original spec's own Out-of-Scope section excludes as a distinct mechanic
+(*"Changes to the existing `Arcade`/`Survival`/`Challenge` pacing variants...
+those remain as-is"*). Full detail in [[BRD#Finding 1 — Targeting Parity
+Already Shipped]].
+
+### The Distinct Version Is Not Cheap
+
+The genuine differentiator — what makes `whackamole` feel different — is
+**continuity**: one persistent buffer, instant target respawn, no per-round
+transition screen, a real session clock. That requires:
+
+1. A session-level clock, which does not exist anywhere in `MiniGameSession`
+   (`started_at` at `session.rs:50` belongs to `ActiveMiniScenario`;
+   `transition_started_at` at `:266` is for transitions only)
+2. Removing the `Transition { success }` step from the mode's flow — a
+   state-machine change
+3. A target-respawn path inside a live buffer that bypasses
+   re-instantiating `ActiveMiniScenario` per round
+
+See [[plan#Cost Basis (Perishable)]] for the corrected, itemized cost — the
+first-pass evaluation initially assumed this was near-free and later
+conceded it is not.
+
+### Priority and Evidence
+
+This was raised at P3 from a single automated parity scan against one
+reference project, with no user-demand signal. Full detail in
+[[BRD#Finding 3 — Priority and Evidence Basis]].
+
+## 3. Decision
+
+> [!danger] NO-GO
+> Neither the cheap (pacing) nor the continuous (subsystem) version should be
+> built now. The cheap version fails the feature's own distinctiveness bar.
+> The continuous version is buildable but not justified at P3 with
+> single-source evidence and no user demand — see [[BRD#Finding 3]], which is
+> the load-bearing argument, not the cost estimate.
+
+Concretely: issue #264 should be closed as researched-not-planned, recording
+that the parity gap vs. `whackamole` is *continuity/flow*, not *targeting*,
+and that targeting parity is already met by 90 shipped scenarios. It should
+not be promoted ahead of issue #198 (content coverage), which has stronger
+evidence.
+
+## 4. User Stories (As Originally Proposed, Not Delivered)
+
+### US-001: Reflex-drill variety for engagement
+AS A learner who has been using the existing Arcade/Survival/Challenge modes
+I WANT an arcade option that tests raw cursor-movement speed and target
+acquisition rather than full scenario completion
+SO THAT I get a distinct kind of engagement and muscle-memory practice, not
+just a faster/harder version of the same drill
+
+**Status**: not satisfied by the cheap version (fails distinctiveness); would
+require the continuous version, which is NO-GO at current priority.
+
+### US-002: Real Helix motions, not simulated shortcuts
+AS A learner practicing under time pressure
+I WANT the reflex drill to respond to actual Helix keybindings executed
+through the real editor simulator
+SO THAT muscle memory built in the minigame transfers directly to real Helix
+usage
+
+**Status**: moot — would have been satisfied by construction had either
+variant been built (see [[SRS#FR-002]]), but nothing was built.
+
+### US-003: Fits the existing session/scoring architecture
+AS A maintainer
+I WANT any new arcade mechanic to plug into the existing `GameSession`/
+`MiniGameSession` typestate and gamification systems
+SO THAT XP, streaks, achievements, and FSRS-adjacent tracking keep working
+uniformly across all minigame modes
+
+**Status**: moot — see [[SRS#FR-003]].
+
+## 5. Functional Requirements
+
+See [[SRS]] for the full FR-001..006 list with individual pass/fail/moot
+verdicts and evidence.
+
+## 6. Non-Functional Requirements
+
+See [[NFR]] for NFR-001..004 carried forward from the draft spec, all moot
+under NO-GO.
+
+## 7. Data Model (Not Implemented)
+
+No persistent entities were added. See [[SRS#3.3 Logical Data Requirements]]
+for what a generator would have needed to synthesize, had this been built.
+
+## 8. Edge Cases Identified During Investigation (Not Implemented)
+
+These were identified as risks the design would have had to handle, had the
+continuous version been approved. Recorded for a future revisit, not as
+outstanding work:
+
+| Scenario | Risk Identified |
+|----------|-------------------|
+| A buffer-modifying command during a reflex round | Since target content == setup content, any edit makes `matches` permanently false; the round would silently burn to timeout instead of failing fast |
+| `profile.minigame_high_score` is a single scalar shared across modes | Reflex scores are on a different scale and would pollute it; a separate `reflex_high_score` field would be needed |
+| Target placed at the player's current cursor | The round would already be complete, but completion is only checked after a command executes — the generator must reject distance == 0 |
+| FSRS pollution | `record_to_fsrs` (`session.rs:825-856`) would write short-timer motion commands into `PerformanceTracker` at a different time scale than normal training, inflating stability and suppressing legitimate reviews — applies to both a real build and to the kill-criterion experiment in [[plan]] |
+
+## 9. Success Criteria
+
+See [[SRS#3.2 Success Criteria (from the draft spec)]] — SC-001 fails,
+SC-002/SC-003 are not applicable since nothing was built.
+
+## 10. Agent Boundaries (For Any Future Revisit)
+
+### Always (without asking), if ever revisited
+- Route all in-game input through `HelixSimulator`/`AnyModeSimulator`, never
+  simulate keypress effects with ad-hoc string/position math
+- Run the full check suite before any commit
+- Re-derive the cost basis in [[plan#Cost Basis (Perishable)]] against the
+  current state of the session-clock bug before committing to a scope
+
+### Ask First, if ever revisited
+- Adding any new dependency
+- Introducing a new top-level `GameMode`-like enum instead of a
+  `MiniGameMode` variant
+- Changing the `MiniGameSession` state machine's public API
+
+### Never
+- Build the cheap (generated-target, pacing-only) version — it fails the
+  feature's own distinctiveness bar regardless of implementation quality
+- Run the kill-criterion experiment ([[plan]]) against the user's real
+  config/profile directory
+- Treat this record as permission to implement — a revisit requires a fresh
+  decision, triggered per [[plan#Revisit Triggers]]
+
+## 11. Open Questions
+
+All five `[NEEDS CLARIFICATION]` items from the original draft spec were
+resolved during this investigation:
+
+- ~~Is a new reflex/targeting mechanic worth building, given P3 priority and
+  single-reference-project evidence?~~ **Resolved: no, not now — see
+  Decision above.**
+- ~~Should this be one `MiniGameMode` variant or a fourth top-level type?~~
+  **Resolved: one variant, if ever built — a fourth type would duplicate
+  `ActiveMiniScenario`, timers, `MiniGameStats`, countdown state, render
+  chrome, input routing, and the FSRS bridge for no benefit.**
+- ~~What counts as "fail" — lives, timer, or endless chase?~~ **Resolved:
+  per-round timeout costs a life, nothing else, unless a session clock is
+  built (which it isn't).**
+- ~~Does target highlighting need new rendering support?~~ **Resolved: yes,
+  more than initially assumed — see [[NFR#3.1 Consistency]].**
+- ~~Should a `snake`-style mode be a separate spec?~~ **Resolved: excluded on
+  principle, not scheduling — it has no document, no target snapshot, no
+  `Scenario`, and no `HelixSimulator` execution, conflicting with FR-002.**
+
+Remaining open question, not resolved by this record:
+
+- [NEEDS CLARIFICATION: should issue #264 be closed outright or re-labeled
+  and left open pointing at this record? Team-lead decision.]
+
+## 12. See Also
+
+- [[README]] — decision record index and full traceability
+- [[BRD]] — business rationale and findings
+- [[SRS]] — functional requirements with pass/fail verdicts
+- [[NFR]] — non-functional requirements, moot under NO-GO
+- [[plan]] — kill-criterion experiment and revisit triggers
+- [[tasks]] — experiment protocol steps (not approved for execution)
+- [[appendix-spinoffs]] — independently actionable bugs found during this investigation
+- Original draft spec (superseded by this record): `.local/specs/002-arcade-game-mode-variety/spec.md` in the main checkout
+- [vim-be-good](https://github.com/ThePrimeagen/vim-be-good) — sole reference project
+- GitHub issue #198 — Helix command content-coverage gap (higher-evidence, separate concern)

--- a/specs/arcade-game-mode-variety/tasks.md
+++ b/specs/arcade-game-mode-variety/tasks.md
@@ -1,0 +1,117 @@
+---
+aliases:
+  - Arcade Game Mode Variety Tasks
+  - Issue 264 — Experiment Protocol
+tags:
+  - sdd
+  - tasks
+  - minigame
+  - decision-record
+  - status/rejected
+created: 2026-08-09
+status: rejected
+related:
+  - "[[spec]]"
+  - "[[plan]]"
+---
+
+# Implementation Tasks: Arcade Game Mode Variety — None Approved
+
+> [!danger] References
+> **Spec**: [[spec]] — NO-GO
+> **Plan**: [[plan]]
+> **Total tasks**: 0 approved for execution; 1 optional experiment protocol
+> recorded below for whoever revisits this decision
+
+## Status
+
+No implementation tasks exist for this feature, because it was rejected
+before reaching a build phase — see [[spec#Decision]]. The only work item
+this record describes is the kill-criterion experiment from
+[[plan#Recommended Next Action — Kill-Criterion Experiment]], and it is
+**not approved for execution by this document**. It requires a separate,
+explicit go-ahead from whoever is revisiting the decision, because it writes
+to a local environment and must not touch the real user profile.
+
+> [!warning] This is a protocol, not a work order
+> The steps below describe *how* to run the experiment safely, if and when
+> someone decides to run it. Writing this protocol down is not the same as
+> authorizing the experiment. See [[plan#Revisit Triggers]] for when running
+> it would actually be warranted.
+
+---
+
+## Optional: T-EXP-001 — Kill-Criterion Self-Play Experiment
+
+**Context**: The only way to falsify (or fail to falsify) the "is fast
+cursor-acquisition fun" hypothesis underlying even the expensive continuous
+variant, without committing any code. See [[plan#Kill-Criterion Experiment
+Protocol]] for the full rationale.
+
+**Spec reference**: [[plan#Recommended Next Action — Kill-Criterion
+Experiment]], [[BRD#Finding 2 — The Real Differentiator Is Continuity, Not
+Targeting]]
+
+**Preconditions** (must all be true before starting):
+- [ ] An explicit decision to revisit #264 has been made by whoever owns that
+      call — this task is not self-authorizing
+- [ ] At least one [[plan#Revisit Triggers|revisit trigger]] has actually
+      fired — do not run this purely out of curiosity, since it still costs
+      setup time and carries the isolation risk below
+
+**Acceptance criteria**:
+- [ ] Runs as a local, uncommitted patch only — no new `MiniGameMode`
+      variant, no `MODE_COUNT` change, no menu entry, nothing staged for
+      commit
+- [ ] Scenario pool restricted to `category == movement` AND
+      `optimal_count == 1` (42 scenarios) — not the full 61 `movement`
+      scenarios (see [[plan#Kill-Criterion Experiment Protocol]] for why the
+      broader pool manufactures a false negative)
+- [ ] Timer set per the `optimal_count == 1` pool's actual solve time, not an
+      arbitrary flat value copied from a different pool
+- [ ] Config/profile isolation verified **before** the first session: either
+      a separate config directory is in use, or `profile.json` has been
+      copied aside — confirm the file the session will write to is not
+      `~/.config/helix-trainer/profile.json` unless it was explicitly backed
+      up first
+- [ ] Session results are read as a falsifier only: a "not fun" result is
+      recorded as sufficient to keep NO-GO; a "fun" result is recorded as
+      necessary-but-not-sufficient and must be paired with a fired revisit
+      trigger before being used to argue for a build
+- [ ] Real profile (`profile.json`, FSRS state, XP, streak, high score, game
+      count) verified unchanged after the experiment, or restored from
+      backup
+- [ ] Patch discarded (not committed, not left applied) after the session,
+      regardless of outcome
+
+**Dependencies**: none (this is the first and only task)
+
+**Files**: none committed — any local patch touches
+`src/minigame/modes.rs`/`session.rs` transiently only, per
+[[plan#What This Experiment Must Never Become]]
+
+**Complexity**: low (protocol), but isolation failure has real data-loss
+consequences — see [[plan#Risks and Mitigations]]
+
+---
+
+## Implementation Notes
+
+### Order of execution
+N/A — single optional task, gated on preconditions above.
+
+### Common patterns
+N/A — no code pattern is being established, since nothing ships.
+
+### Gotchas
+- Do not reuse the full 61-scenario `movement` pool for the timer test — see
+  the acceptance criteria above; this is the single most likely mistake if
+  this protocol is followed loosely.
+- Do not assume disabling FSRS recording alone is sufficient isolation — it
+  is not; see [[plan#Experiment Isolation Requirements]].
+
+## See Also
+
+- [[spec]] — the rejected feature spec
+- [[plan]] — cost basis, decision rationale, and revisit triggers
+- [[README]] — decision record index


### PR DESCRIPTION
## Summary

Runs the spec-driven pipeline (architect -> critic -> sdd -> reviewer, two rounds) against issue #264 and records the outcome: **NO-GO**.

- 90 of 134 shipped scenarios already have `target` content identical to `setup` content (61 in `movement`, 51 with `optimal_count == 1`), and these already complete as whack-a-mole-style reflex rounds via the existing `Arcade` mode (`tests/scenario_validation.rs` proves it through `EditorSnapshot::matches`).
- A cheap version of the proposed reflex-drill mechanic therefore fails the spec's own distinctiveness bar. A genuinely distinct version (continuous single-buffer play, live target respawn, a real session clock) is buildable but requires real subsystem work that doesn't exist today.
- Durable justification for NO-GO: P3 priority, single-reference-project (vim-be-good) evidence, no user demand — not the cost estimate, which is documented as secondary and perishable.
- Records a falsifiable kill-criterion experiment as an option for a future revisit, plus explicit revisit triggers.
- Appendix documents two independent bugs found during the investigation (Arcade's advertised 60s session limit isn't implemented; several non-exhaustive `_ =>` match arms in mode-selection code) — filed as separate issues, not part of this decision.

No `src/` changes — this PR adds only `specs/arcade-game-mode-variety/`.

## Test plan

- [x] Decision-record package reviewed and approved by `rust-code-reviewer` (two rounds, one nitpick fixed)
- [x] All file:line citations spot-checked against current code
- [x] YAML frontmatter validated
- N/A — no source code changed, no test suite impact