### PR TITLE
feat(helix-core): add named registers and command-line goto mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New `src/time.rs` module: `Clock` trait abstraction over the current time, with a `SystemClock` production implementation and a `FakeClock` for deterministic tests (#269)
 - A persistent, scrollable Achievements screen (`p`/`s`/`a` cycles between Profile, Statistics, and Achievements from the mode selection, menu, profile, statistics, and paused-arcade screens) listing every achievement with its unlocked/locked status, so players can review the full roster outside the transient unlock toast (#292)
+- Named registers: `"<reg><op>` (e.g. `"ay`, `"ap`) scopes `y`/`p`/`P`/`R` to a named register instead of the default one, via a new `RegisterFile` on the simulator; unnamed `y`/`p`/`P`/`R` are unchanged and remain equivalent to `""y`/`""p`/`""P`/`""R` (#282)
+- Command-line mode: `:` opens a command-line prompt; only `:goto N` (alias `:g N`) is implemented, transcribed from real Helix `:goto` semantics (1-based line number, clamped to the last real line, `:goto 0` is a silent no-op, cursor moves to line start) — no other typed command (`:w`, `:sort`, `:clear-register`, shell commands, etc.) is implemented, since the trainer has no file/buffer/LSP/shell concepts to back them (#282)
+- New scenarios: one named-register scenario (`scenarios/en/registers/named-registers.toml`) and one `:goto` scenario (`scenarios/en/movement/command-line-goto.toml`); new `ScenarioCategory::Registers`
+- `helix::commands::normalize_command_id` canonicalizes register ops and command-line invocations (`"ay` -> `"y`, `:g 3` -> `:goto`) to a stable FSRS/quest card id, applied at all three places a raw command string is recorded for learning/quest tracking
 
 ### Changed
 
@@ -36,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Arcade mode's Esc key now cancels a pending prefix state (count, `g`/`m`/`z`, register selection, command-line buffer) instead of always pausing the game — **behavior change**: previously the first Esc while e.g. a count prefix was building would pause the mini-game; it now cancels the prefix on the first Esc and pauses on the second. Without this fix the new command-line buffer was an unrecoverable trap in arcade mode, draining the scenario timer until Enter or a lucky escape (#282)
+- Arcade mode's input state (pending count/prefix/register/command-line buffer) is now reset when advancing to the next scenario, instead of potentially leaking into the next scenario's fresh input (#282)
+- An unmapped Alt- or Ctrl-modified key reaching the fallback key-to-command path is now dropped instead of being silently serialized as the bare character — previously an unmapped Alt-x reached the input state machine as plain `x`, executing whatever `x` resolves to instead of being ignored (#282)
+- `parse_key_code`'s single-key check now counts chars instead of bytes, so a non-ASCII character (or a macOS Option-composed character not otherwise mapped) is correctly rejected instead of silently falling through to a literal space (#282)
 - Arcade mode now fires the `LevelUp` notification for level-ups driven by quest XP, scenario-completion XP, and end-of-game XP, matching the training-mode path; previously all three `add_xp` calls in the arcade handlers discarded their `leveled_up` result (#309)
 - Breaking a daily streak (a missed day with no freeze available) now surfaces a `StreakBroken` notification instead of only being logged, mirroring the existing `StreakFreezeGranted`/`StreakFreezeUsed` notifications (#310)
 - Returning to the menu from the arcade game-over screen no longer re-runs game-over XP/stat/FSRS bookkeeping a second time; `handle_minigame_back_to_menu` now only invokes `handle_minigame_game_over` when the session hasn't already reached the `GameOver` state (#317)

--- a/docs/HELIX_KEYBINDINGS.md
+++ b/docs/HELIX_KEYBINDINGS.md
@@ -516,6 +516,15 @@ Access command mode with <kbd>:</kbd> in normal mode. Common commands:
 | `:rsort` | | Sort selections in reverse |
 | `:run-shell-command` | `:sh` | Run shell command and show output |
 
+**Implemented in the trainer:** only `:goto`/`:g` (line clamping, trailing-blank-line
+rule, `:goto 0` as a silent no-op, cursor moves to line start). Every other
+command above is a reference for real Helix behavior; typing it in the
+trainer's command line raises an "unknown command" error rather than running
+it — the trainer has no file, buffer, LSP, shell, or theme concepts to back
+them, and none are planned. `:clear-register` and `:sort` were considered and
+explicitly deferred (not shippable as a verifiable lesson with the current
+scenario completion model — see the register/command-mode design notes).
+
 ---
 
 ## Implementation Checklist
@@ -570,7 +579,7 @@ Track which commands have been implemented in the simulator:
 | ✅ | <kbd>y</kbd> | Yank (copy) selection |
 | ✅ | <kbd>p</kbd> | Paste after selection |
 | ✅ | <kbd>P</kbd> | Paste before selection |
-| ❌ | <kbd>"</kbd> + reg | Select register for yank/paste |
+| ✅ | <kbd>"</kbd> + reg | Select register for yank/paste (scoped to y/p/P/R; see Command Mode Commands) |
 | ✅ | <kbd>></kbd> | Indent selection |
 | ✅ | <kbd><</kbd> | Unindent selection |
 | ❌ | <kbd>=</kbd> | Format selection (LSP) |
@@ -656,6 +665,13 @@ Track which commands have been implemented in the simulator:
 | ✅ | <kbd>ma</kbd> + object | Select around text object |
 | ✅ | <kbd>mi</kbd> + object | Select inside text object |
 
+### Command Mode
+
+| Status | Keys | Description |
+|:------:|------|-------------|
+| ✅ | <kbd>:</kbd>goto N, <kbd>:</kbd>g N | Go to line N (1-based, clamped, cursor to line start) |
+| ❌ | everything else in the Command Mode Commands table above | No file/buffer/LSP/shell/theme concepts in the trainer |
+
 ---
 
 ## Implementation Summary
@@ -679,6 +695,8 @@ Track which commands have been implemented in the simulator:
 | **Indentation** | 2 | <kbd>></kbd> <kbd><</kbd> |
 | **Line ops** | 3 | <kbd>J</kbd> <kbd>Alt+J</kbd> <kbd>Ctrl+c</kbd> |
 | **Clipboard** | 3 | <kbd>y</kbd> <kbd>p</kbd> <kbd>P</kbd> |
+| **Registers** | 1 | <kbd>"</kbd> + reg (scopes y/p/P/R to a named register) |
+| **Command Mode** | 1 | <kbd>:goto</kbd> / <kbd>:g</kbd> |
 | **Repeat** | 2 | <kbd>.</kbd> <kbd>Alt+.</kbd> |
 
 ### Training Scenarios Coverage
@@ -694,7 +712,7 @@ Track which commands have been implemented in the simulator:
 
 - Tree-sitter selections (<kbd>Alt+o</kbd>, <kbd>Alt+i</kbd>, etc.)
 - LSP integration commands
-- Macros and registers (<kbd>Q</kbd>, <kbd>q</kbd>, <kbd>"</kbd>)
+- Macros (<kbd>Q</kbd>, <kbd>q</kbd>) — named registers (<kbd>"</kbd>) are implemented, scoped to y/p/P/R
 - Window mode (<kbd>Ctrl+w</kbd>)
 - Space mode (<kbd>Space</kbd>)
 - Jumplist (<kbd>Ctrl+i</kbd>, <kbd>Ctrl+o</kbd>)

--- a/docs/SCENARIOS_AND_QUESTS.md
+++ b/docs/SCENARIOS_AND_QUESTS.md
@@ -102,7 +102,7 @@ description = "Use 'l' five times (less efficient)"
 
 ```toml
 [scenarios.metadata]
-category = "movement"              # movement, editing, clipboard, search, selection, textobjects, advanced
+category = "movement"              # movement, editing, clipboard, search, selection, textobjects, advanced, registers
 difficulty = "beginner"            # beginner, intermediate, advanced
 tags = ["word", "motion"]          # Flexible filtering tags
 commands_taught = ["w"]            # Commands this scenario teaches

--- a/scenarios/en/movement/command-line-goto.toml
+++ b/scenarios/en/movement/command-line-goto.toml
@@ -1,0 +1,45 @@
+# Command-line Goto
+# Scenarios for the ':' command-line mode's ':goto'/':g' command
+
+[[scenarios]]
+id = "command_line_goto_001"
+name = "Go to line with :goto"
+description = "Use the ':' command line and ':goto N' to jump to a specific line number"
+
+hints = [
+    "':' opens the command line",
+    "'goto N' (or its alias 'g N') moves the cursor to the start of line N",
+    "Press Enter to run the command",
+]
+
+[scenarios.setup]
+file_content = """line one
+line two
+line three
+line four
+"""
+cursor_position = [0, 0]
+
+[scenarios.target]
+file_content = """line one
+line two
+line three
+line four
+"""
+cursor_position = [2, 0]
+
+[scenarios.solution]
+commands = [":goto 3"]
+description = "Type ':goto 3' and press Enter to jump to line 3"
+
+[scenarios.scoring]
+optimal_count = 1
+max_points = 100
+tolerance = 0
+
+[scenarios.metadata]
+category = "movement"
+difficulty = "intermediate"
+tags = ["goto", "command-line", "navigation"]
+commands_taught = [":goto"]
+estimated_time_seconds = 15

--- a/scenarios/en/registers/named-registers.toml
+++ b/scenarios/en/registers/named-registers.toml
@@ -1,0 +1,45 @@
+# Named Registers
+# Scenarios covering register-scoped yank/paste ("<reg><op>)
+
+[[scenarios]]
+id = "named_register_yank_paste_001"
+name = "Yank into a named register"
+description = "Yank a line into register 'a', overwrite the default register, then paste from 'a' to prove it survived independently"
+
+hints = [
+    "'\"a' selects register 'a' for the next yank or paste",
+    "'\"ay' yanks the current selection into register 'a' instead of the default register",
+    "Register 'a' is untouched by a later plain 'y', which only overwrites the default register",
+    "'\"aP' pastes register 'a's content before the cursor",
+]
+
+[scenarios.setup]
+file_content = """alpha
+beta
+gamma
+"""
+cursor_position = [0, 0]
+
+[scenarios.target]
+file_content = """alpha
+beta
+alpha
+gamma
+"""
+cursor_position = [2, 5]
+
+[scenarios.solution]
+commands = ["x", '"ay', "j", "x", "y", "j", '"aP']
+description = "Select and yank 'alpha' into register a, select and yank 'beta' into the default register, then paste register a's content before 'gamma'"
+
+[scenarios.scoring]
+optimal_count = 7
+max_points = 100
+tolerance = 0
+
+[scenarios.metadata]
+category = "registers"
+difficulty = "intermediate"
+tags = ["yank", "paste", "register"]
+commands_taught = ['"y', '"P']
+estimated_time_seconds = 30

--- a/src/config/scenarios.rs
+++ b/src/config/scenarios.rs
@@ -64,6 +64,7 @@ pub enum ScenarioCategory {
     Selection,
     TextObjects,
     Advanced,
+    Registers,
     Multi, // Multiple categories
     Other,
 }

--- a/src/config/scenarios/embedded.rs
+++ b/src/config/scenarios/embedded.rs
@@ -35,6 +35,8 @@ const EDITING_SURROUND: &str = include_str!("../../../scenarios/en/editing/surro
 
 const MOVEMENT_BASIC: &str = include_str!("../../../scenarios/en/movement/basic-movement.toml");
 const MOVEMENT_COMBINED: &str = include_str!("../../../scenarios/en/movement/combined.toml");
+const MOVEMENT_COMMAND_LINE_GOTO: &str =
+    include_str!("../../../scenarios/en/movement/command-line-goto.toml");
 const MOVEMENT_DOCUMENT: &str = include_str!("../../../scenarios/en/movement/document.toml");
 const MOVEMENT_FIND_TILL: &str = include_str!("../../../scenarios/en/movement/find-till.toml");
 const MOVEMENT_GOTO_COMMANDS: &str =
@@ -48,6 +50,12 @@ const MOVEMENT_PARAGRAPH: &str = include_str!("../../../scenarios/en/movement/pa
 const MOVEMENT_PRECISION: &str = include_str!("../../../scenarios/en/movement/precision.toml");
 const MOVEMENT_WORD_BASICS: &str = include_str!("../../../scenarios/en/movement/word-basics.toml");
 const MOVEMENT_WORD: &str = include_str!("../../../scenarios/en/movement/word.toml");
+
+// ============================================================================
+// Register scenarios
+// ============================================================================
+
+const REGISTERS_NAMED: &str = include_str!("../../../scenarios/en/registers/named-registers.toml");
 
 // ============================================================================
 // Repeat scenarios
@@ -95,6 +103,7 @@ const EN_SCENARIOS: &[&str] = &[
     // Movement
     MOVEMENT_BASIC,
     MOVEMENT_COMBINED,
+    MOVEMENT_COMMAND_LINE_GOTO,
     MOVEMENT_DOCUMENT,
     MOVEMENT_FIND_TILL,
     MOVEMENT_GOTO_COMMANDS,
@@ -105,6 +114,8 @@ const EN_SCENARIOS: &[&str] = &[
     MOVEMENT_PRECISION,
     MOVEMENT_WORD_BASICS,
     MOVEMENT_WORD,
+    // Registers
+    REGISTERS_NAMED,
     // Repeat
     REPEAT_BASIC,
     // Search
@@ -158,7 +169,7 @@ mod tests {
     #[test]
     fn test_get_embedded_scenarios_en() {
         let scenarios = get_embedded_scenarios("en");
-        assert_eq!(scenarios.len(), 27, "Expected 27 scenario files");
+        assert_eq!(scenarios.len(), 29, "Expected 29 scenario files");
     }
 
     #[test]

--- a/src/game/services/scenario_completion.rs
+++ b/src/game/services/scenario_completion.rs
@@ -150,12 +150,18 @@ impl ScenarioCompletionService {
     }
 
     /// Extract command strings from feedback
+    ///
+    /// Normalizes register ops (`"ay` -> `"y`) and command-line invocations
+    /// (`:g 3` -> `:goto`) so FSRS mints one learning card per skill rather
+    /// than one per register letter or argument value.
     #[must_use]
     pub fn extract_commands(feedback: &Feedback) -> Vec<String> {
         feedback
             .user_actions
             .iter()
-            .map(|action| action.command.clone())
+            .map(|action| {
+                crate::helix::commands::normalize_command_id(&action.command).into_owned()
+            })
             .collect()
     }
 }

--- a/src/helix/commands.rs
+++ b/src/helix/commands.rs
@@ -84,6 +84,12 @@ pub const CMD_FLIP_SELECTIONS: &str = "Alt-;";
 pub const CMD_MATCH_MODE: &str = "m";
 pub const CMD_MATCH_BRACKETS: &str = "mm";
 
+// Named register selection (prefix for register-scoped yank/paste: "<reg><op>)
+pub const CMD_SELECT_REGISTER: &str = "\"";
+
+// Command-line mode (prefix for `:`-typed commands, e.g. ":goto 3")
+pub const CMD_COMMAND_LINE: &str = ":";
+
 // Match mode surround commands (ms{char}, mr{from}{to}, md{char})
 pub const CMD_SURROUND_ADD_PREFIX: &str = "ms";
 pub const CMD_SURROUND_REPLACE_PREFIX: &str = "mr";
@@ -140,3 +146,96 @@ pub const CMD_VIEW_BOTTOM: &str = "zb";
 pub const CMD_VIEW_CENTER_HORIZONTAL: &str = "zm";
 pub const CMD_SCROLL_DOWN: &str = "zj";
 pub const CMD_SCROLL_UP: &str = "zk";
+
+/// Canonicalize a raw executed command string to a stable FSRS/quest card id.
+///
+/// Two families of commands otherwise mint a separate learning card per
+/// operand, which fragments spaced-repetition data for what is really one
+/// skill:
+///
+/// - Register-scoped clipboard ops (`"ay`, `"by`, ...) collapse to `"y`
+///   (the register letter is not the thing being taught).
+/// - Command-line invocations (`:goto 3`, `:g 7`, ...) collapse to their
+///   canonical name (`:goto`), folding aliases (`:g` -> `:goto`) so both
+///   spellings share one card.
+///
+/// Every other command string is returned unchanged.
+///
+/// # Examples
+///
+/// ```
+/// use helix_trainer::helix::commands::normalize_command_id;
+///
+/// assert_eq!(normalize_command_id("\"ay"), "\"y");
+/// assert_eq!(normalize_command_id(":goto 3"), ":goto");
+/// assert_eq!(normalize_command_id(":g 3"), ":goto");
+/// assert_eq!(normalize_command_id("h"), "h");
+/// ```
+pub fn normalize_command_id(cmd: &str) -> std::borrow::Cow<'_, str> {
+    use std::borrow::Cow;
+
+    if cmd.starts_with(CMD_SELECT_REGISTER) {
+        // Destructure via `chars()`, not `len() == 3` (bytes) + `.nth(2)`:
+        // a multi-byte register char would make `len()` 3 for only 2 chars,
+        // and `.nth(2).expect(...)` would then panic on `None`. This form
+        // only matches when there are exactly 3 chars total.
+        let mut chars = cmd.chars();
+        chars.next(); // the leading '"', already confirmed by starts_with
+        if let (Some(_register), Some(op), None) = (chars.next(), chars.next(), chars.next()) {
+            return Cow::Owned(format!("{CMD_SELECT_REGISTER}{op}"));
+        }
+    }
+
+    if let Some(body) = cmd.strip_prefix(CMD_COMMAND_LINE) {
+        let name = body.split_whitespace().next().unwrap_or("");
+        let canonical = match name {
+            "g" => "goto",
+            other => other,
+        };
+        return Cow::Owned(format!("{CMD_COMMAND_LINE}{canonical}"));
+    }
+
+    Cow::Borrowed(cmd)
+}
+
+#[cfg(test)]
+mod normalize_command_id_tests {
+    use super::*;
+
+    #[test]
+    fn register_op_normalizes_to_bare_op() {
+        assert_eq!(normalize_command_id("\"ay"), "\"y");
+        assert_eq!(normalize_command_id("\"bp"), "\"p");
+    }
+
+    #[test]
+    fn command_line_normalizes_to_canonical_name() {
+        assert_eq!(normalize_command_id(":goto 3"), ":goto");
+        assert_eq!(normalize_command_id(":g 3"), ":goto");
+        assert_eq!(normalize_command_id(":g"), ":goto");
+    }
+
+    /// Regression test: a multi-byte register char used to panic via
+    /// `len() == 3` (bytes) succeeding while `.nth(2)` (chars) returned
+    /// `None`.
+    #[test]
+    fn malformed_register_strings_do_not_panic() {
+        assert_eq!(normalize_command_id("\"é"), "\"é"); // 2 chars, 3 bytes - no op char
+        assert_eq!(normalize_command_id("\""), "\"");
+        assert_eq!(normalize_command_id("\"aay"), "\"aay");
+    }
+
+    #[test]
+    fn register_op_with_non_ascii_register_still_normalizes() {
+        // 3 chars (quote + register + op), 4 bytes - well-formed despite
+        // the multi-byte register char.
+        assert_eq!(normalize_command_id("\"éy"), "\"y");
+    }
+
+    #[test]
+    fn unrelated_commands_are_unchanged() {
+        assert_eq!(normalize_command_id("h"), "h");
+        assert_eq!(normalize_command_id("gg"), "gg");
+        assert_eq!(normalize_command_id("ms("), "ms(");
+    }
+}

--- a/src/helix/registry/keytrie.rs
+++ b/src/helix/registry/keytrie.rs
@@ -166,6 +166,33 @@ impl KeyTrie {
         let len = buffer.len();
         let first_char = buffer.chars().next().unwrap();
 
+        // Named register prefix ("<reg><op>): "<reg> is always partial,
+        // waiting for the operator character. No allow-list on the register
+        // char itself, same as the 'r' replace-char prefix - but the
+        // operator IS allow-listed to y/p/P/R, matching `RegisterOpPending`
+        // (`src/input/typestate/handlers/register.rs`), which cancels on
+        // any other key. Uses `chars().count()`, not the byte-based `len`
+        // above: a multi-byte register char (e.g. `"é`) would otherwise make
+        // `len() == 3` true for only 2 actual chars (missing the operator).
+        if first_char == '"' {
+            let char_count = buffer.chars().count();
+            if char_count <= 2 {
+                return KeyMatch::Partial;
+            }
+            if char_count == 3 {
+                let op = buffer
+                    .chars()
+                    .nth(2)
+                    .expect("char_count == 3 checked above");
+                return if matches!(op, 'y' | 'p' | 'P' | 'R') {
+                    KeyMatch::Complete(buffer.to_string())
+                } else {
+                    KeyMatch::Invalid
+                };
+            }
+            return KeyMatch::Invalid;
+        }
+
         // Check for multi-key command
         if len == 2 {
             // Multi-key goto commands
@@ -485,5 +512,49 @@ mod tests {
         // 4-char sequences that don't start with 'mr' are invalid
         assert_eq!(trie.resolve("miwa"), KeyMatch::Invalid);
         assert_eq!(trie.resolve("mawx"), KeyMatch::Invalid);
+    }
+
+    // Named register prefix tests
+
+    #[test]
+    fn test_register_prefix_partial() {
+        let trie = KeyTrie::new();
+        assert_eq!(trie.resolve("\""), KeyMatch::Partial);
+        assert_eq!(trie.resolve("\"a"), KeyMatch::Partial);
+    }
+
+    #[test]
+    fn test_register_op_complete_for_scoped_ops() {
+        let trie = KeyTrie::new();
+        assert_eq!(trie.resolve("\"ay"), KeyMatch::Complete("\"ay".to_string()));
+        assert_eq!(trie.resolve("\"ap"), KeyMatch::Complete("\"ap".to_string()));
+        assert_eq!(trie.resolve("\"aP"), KeyMatch::Complete("\"aP".to_string()));
+        assert_eq!(trie.resolve("\"aR"), KeyMatch::Complete("\"aR".to_string()));
+    }
+
+    /// Regression test: the KeyTrie must reject register ops outside y/p/P/R,
+    /// matching `RegisterOpPending`'s cancel behavior, instead of reporting
+    /// `Complete` for an operator the real UI would never execute.
+    #[test]
+    fn test_register_op_invalid_for_out_of_scope_operator() {
+        let trie = KeyTrie::new();
+        assert_eq!(trie.resolve("\"ad"), KeyMatch::Invalid);
+        assert_eq!(trie.resolve("\"ax"), KeyMatch::Invalid);
+    }
+
+    /// Regression test: byte length must not be confused with char count for
+    /// a multi-byte register char (`"é` is 1 char, 2 bytes -> 3 bytes total,
+    /// but only 2 chars, so it must still be `Partial`, not `Complete`).
+    #[test]
+    fn test_register_prefix_multibyte_register_char_is_partial() {
+        let trie = KeyTrie::new();
+        assert_eq!(trie.resolve("\"é"), KeyMatch::Partial);
+        assert_eq!(trie.resolve("\"éy"), KeyMatch::Complete("\"éy".to_string()));
+    }
+
+    #[test]
+    fn test_register_op_invalid_too_long() {
+        let trie = KeyTrie::new();
+        assert_eq!(trie.resolve("\"aay"), KeyMatch::Invalid);
     }
 }

--- a/src/helix/simulator/command_line.rs
+++ b/src/helix/simulator/command_line.rs
@@ -1,0 +1,205 @@
+//! Parsing and execution of `:`-prefixed command-line invocations
+//!
+//! Only real, existing Helix typable commands are implemented here — see
+//! [`CommandLine::parse`] for the exact set. This is intentionally narrow:
+//! the trainer must never teach a command Helix does not have.
+
+use crate::helix::simulator::{EditorMode, HelixSimulator};
+use crate::security::UserError;
+use helix_core::Selection;
+
+/// A parsed `:` command-line invocation, ready to execute.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandLine {
+    /// `:goto N` / `:g N` — move the cursor to the start of line `N` (1-based).
+    Goto(usize),
+}
+
+impl CommandLine {
+    /// Parse a `:`-prefixed command-line string (the leading colon included).
+    ///
+    /// Supports exactly `:goto N` and its alias `:g N`. Any other command
+    /// name, wrong argument count, or non-numeric argument is a
+    /// [`UserError::CommandFailed`] with a sanitized, bounded message.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use helix_trainer::helix::simulator::command_line::CommandLine;
+    ///
+    /// assert_eq!(CommandLine::parse(":goto 3").unwrap(), CommandLine::Goto(3));
+    /// assert_eq!(CommandLine::parse(":g 3").unwrap(), CommandLine::Goto(3));
+    /// assert!(CommandLine::parse(":nope").is_err());
+    /// ```
+    pub fn parse(input: &str) -> Result<Self, UserError> {
+        let body = input.strip_prefix(':').ok_or_else(|| {
+            UserError::command_failed(format!("not a command: '{}'", bound(input)))
+        })?;
+
+        let mut parts = body.split_whitespace();
+        let name = parts
+            .next()
+            .ok_or_else(|| UserError::command_failed("empty command"))?;
+
+        match name {
+            "goto" | "g" => {
+                let arg = parts.next().ok_or_else(|| {
+                    UserError::command_failed(format!(":{} requires one argument", bound(name)))
+                })?;
+                if parts.next().is_some() {
+                    return Err(UserError::command_failed(format!(
+                        ":{} takes exactly one argument",
+                        bound(name)
+                    )));
+                }
+                let n: usize = arg.parse().map_err(|_| {
+                    UserError::command_failed(format!(
+                        ":{} {}: not a number",
+                        bound(name),
+                        bound(arg)
+                    ))
+                })?;
+                Ok(Self::Goto(n))
+            }
+            other => Err(UserError::command_failed(format!(
+                "unknown command ':{}'",
+                bound(other)
+            ))),
+        }
+    }
+
+    /// Execute this command against the simulator.
+    pub fn execute<M: EditorMode>(&self, sim: &mut HelixSimulator<M>) -> Result<(), UserError> {
+        match self {
+            Self::Goto(n) => execute_goto(sim, *n),
+        }
+    }
+}
+
+/// `:goto N`, transcribed from helix-term 25.07.1's `goto_line` implementation:
+/// `N` is 1-based, clamped to the document's last real line (excluding a
+/// trailing empty line produced by a final newline), and moves the cursor to
+/// line *start* (not first non-blank). `:goto 0` is a silent no-op, matching
+/// Helix wrapping the argument in `NonZeroUsize::new`.
+fn execute_goto<M: EditorMode>(sim: &mut HelixSimulator<M>, n: usize) -> Result<(), UserError> {
+    if n == 0 {
+        return Ok(());
+    }
+
+    let len_lines = sim.doc.len_lines();
+    let last_line_is_empty = len_lines > 0 && sim.doc.line(len_lines - 1).len_chars() == 0;
+    let max_line = if last_line_is_empty {
+        len_lines.saturating_sub(2)
+    } else {
+        len_lines.saturating_sub(1)
+    };
+
+    let line_idx = (n - 1).min(max_line);
+    let pos = sim.doc.line_to_char(line_idx);
+    sim.selection = Selection::point(pos);
+    Ok(())
+}
+
+/// Bound and sanitize text before embedding it in a user-facing error.
+///
+/// `UserError::CommandFailed`'s `Display` impl echoes `context` verbatim, so
+/// anything derived from raw command-line input must be scrubbed here first.
+/// Stricter than `sanitize_terminal_output` (which additionally allows
+/// `\n`/`\t`): this text is embedded in a single-line error message, where a
+/// literal newline or tab has no legitimate use.
+fn bound(s: &str) -> String {
+    s.chars()
+        .filter(|c| c.is_ascii_graphic() || *c == ' ')
+        .take(64)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::helix::simulator::NormalMode;
+
+    #[test]
+    fn parses_goto_and_alias() {
+        assert_eq!(CommandLine::parse(":goto 3").unwrap(), CommandLine::Goto(3));
+        assert_eq!(CommandLine::parse(":g 3").unwrap(), CommandLine::Goto(3));
+    }
+
+    #[test]
+    fn rejects_missing_colon() {
+        assert!(CommandLine::parse("goto 3").is_err());
+    }
+
+    #[test]
+    fn rejects_wrong_arity() {
+        assert!(CommandLine::parse(":goto").is_err());
+        assert!(CommandLine::parse(":goto 1 2").is_err());
+    }
+
+    #[test]
+    fn rejects_non_numeric_argument() {
+        assert!(CommandLine::parse(":goto abc").is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_command() {
+        assert!(CommandLine::parse(":nope").is_err());
+        assert!(CommandLine::parse(":sort").is_err());
+        assert!(CommandLine::parse(":clear-register a").is_err());
+    }
+
+    #[test]
+    fn goto_moves_cursor_to_line_start() {
+        let mut sim: HelixSimulator<NormalMode> =
+            HelixSimulator::new("aaa\nbbb\nccc\n".to_string());
+        CommandLine::Goto(2).execute(&mut sim).unwrap();
+        assert_eq!(sim.selection.primary().head, 4); // start of "bbb"
+    }
+
+    #[test]
+    fn goto_zero_is_silent_noop() {
+        let mut sim: HelixSimulator<NormalMode> =
+            HelixSimulator::new("aaa\nbbb\nccc\n".to_string());
+        sim.selection = Selection::point(5);
+        CommandLine::Goto(0).execute(&mut sim).unwrap();
+        assert_eq!(sim.selection.primary().head, 5); // unchanged
+    }
+
+    #[test]
+    fn goto_clamps_past_end_ignoring_trailing_blank_line() {
+        // Trailing newline produces an empty final line; max real line is "ccc".
+        let mut sim: HelixSimulator<NormalMode> =
+            HelixSimulator::new("aaa\nbbb\nccc\n".to_string());
+        CommandLine::Goto(100).execute(&mut sim).unwrap();
+        assert_eq!(sim.selection.primary().head, 8); // start of "ccc"
+    }
+
+    #[test]
+    fn goto_clamps_past_end_without_trailing_newline() {
+        let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("aaa\nbbb\nccc".to_string());
+        CommandLine::Goto(100).execute(&mut sim).unwrap();
+        assert_eq!(sim.selection.primary().head, 8); // start of "ccc"
+    }
+
+    #[test]
+    fn error_message_bounds_and_sanitizes_echoed_input() {
+        let long_garbage = "x".repeat(500);
+        let err = CommandLine::parse(&format!(":{long_garbage}")).unwrap_err();
+        let message = err.to_string();
+        assert!(message.len() < 200, "message should be bounded: {message}");
+    }
+
+    #[test]
+    fn error_message_strips_newlines_and_tabs() {
+        // Defense in depth: unreachable from the UI today (the input filter
+        // is ascii_graphic+space), but the echoed text must never carry a
+        // raw newline/tab/CR into a single-line error message. The
+        // "not a command" path is the one place the full raw input (not
+        // already whitespace-split) reaches `bound()`.
+        let err = CommandLine::parse("no-colon\nwith\ttabs\rhere").unwrap_err();
+        let message = err.to_string();
+        assert!(!message.contains('\n'));
+        assert!(!message.contains('\t'));
+        assert!(!message.contains('\r'));
+    }
+}

--- a/src/helix/simulator/commands/clipboard.rs
+++ b/src/helix/simulator/commands/clipboard.rs
@@ -4,13 +4,24 @@ use crate::helix::simulator::{EditorMode, HelixSimulator};
 use crate::security::UserError;
 use helix_core::{Selection, Transaction};
 
-/// Yank (copy) the primary selection to clipboard
+/// Yank (copy) the primary selection to the unnamed register
 ///
 /// Copies the full `anchor..head` range of the primary selection, normalized
 /// regardless of selection direction. A point selection (`anchor == head`),
 /// as used for a plain cursor with no active selection, falls back to
 /// yanking the single character under the cursor.
 pub fn yank<M: EditorMode>(sim: &mut HelixSimulator<M>) -> Result<(), UserError> {
+    yank_to_register(sim, None)
+}
+
+/// Yank (copy) the primary selection to a named register
+///
+/// `register: None` addresses the unnamed register, matching Helix where
+/// `""y` and `y` behave identically. See [`yank`] for the selection rules.
+pub fn yank_to_register<M: EditorMode>(
+    sim: &mut HelixSimulator<M>,
+    register: Option<char>,
+) -> Result<(), UserError> {
     let range = sim.selection.primary();
 
     if range.anchor == range.head {
@@ -18,20 +29,31 @@ pub fn yank<M: EditorMode>(sim: &mut HelixSimulator<M>) -> Result<(), UserError>
         if head >= sim.doc.len_chars() {
             return Ok(());
         }
-        sim.clipboard = Some(sim.doc.char(head).to_string());
+        let text = sim.doc.char(head).to_string();
+        sim.registers.set(register, text);
     } else {
         let text = range.fragment(sim.doc.slice(..)).into_owned();
-        sim.clipboard = Some(text);
+        sim.registers.set(register, text);
     }
 
     Ok(())
 }
 
-/// Paste clipboard content after cursor
+/// Paste the unnamed register's content after cursor
 ///
 /// In Helix, cursor stays on the last pasted character
 pub fn paste_after<M: EditorMode>(sim: &mut HelixSimulator<M>) -> Result<(), UserError> {
-    if let Some(text) = &sim.clipboard {
+    paste_after_from_register(sim, None)
+}
+
+/// Paste a named register's content after cursor
+///
+/// `register: None` addresses the unnamed register. See [`paste_after`].
+pub fn paste_after_from_register<M: EditorMode>(
+    sim: &mut HelixSimulator<M>,
+    register: Option<char>,
+) -> Result<(), UserError> {
+    if let Some(text) = sim.registers.get(register) {
         let range = sim.selection.primary();
         // A point selection (plain cursor) sits ON its char, so "after" is
         // one past it. A range selection's `to()` is already one past its
@@ -45,7 +67,7 @@ pub fn paste_after<M: EditorMode>(sim: &mut HelixSimulator<M>) -> Result<(), Use
 
         let transaction = Transaction::change(
             &sim.doc,
-            [(insert_pos, insert_pos, Some(text.as_str().into()))].into_iter(),
+            [(insert_pos, insert_pos, Some(text.into()))].into_iter(),
         );
 
         sim.apply_transaction(transaction);
@@ -57,11 +79,21 @@ pub fn paste_after<M: EditorMode>(sim: &mut HelixSimulator<M>) -> Result<(), Use
     Ok(())
 }
 
-/// Paste clipboard content before cursor
+/// Paste the unnamed register's content before cursor
 ///
 /// In Helix, cursor stays on the last pasted character
 pub fn paste_before<M: EditorMode>(sim: &mut HelixSimulator<M>) -> Result<(), UserError> {
-    if let Some(text) = &sim.clipboard {
+    paste_before_from_register(sim, None)
+}
+
+/// Paste a named register's content before cursor
+///
+/// `register: None` addresses the unnamed register. See [`paste_before`].
+pub fn paste_before_from_register<M: EditorMode>(
+    sim: &mut HelixSimulator<M>,
+    register: Option<char>,
+) -> Result<(), UserError> {
+    if let Some(text) = sim.registers.get(register) {
         // Insert before the start of the selection (or at the cursor for a
         // point selection, where `from()` equals `head`).
         let insert_pos = sim.selection.primary().from();
@@ -69,7 +101,7 @@ pub fn paste_before<M: EditorMode>(sim: &mut HelixSimulator<M>) -> Result<(), Us
 
         let transaction = Transaction::change(
             &sim.doc,
-            [(insert_pos, insert_pos, Some(text.as_str().into()))].into_iter(),
+            [(insert_pos, insert_pos, Some(text.into()))].into_iter(),
         );
 
         sim.apply_transaction(transaction);

--- a/src/helix/simulator/commands/editing.rs
+++ b/src/helix/simulator/commands/editing.rs
@@ -218,9 +218,19 @@ pub fn switch_to_uppercase<M: EditorMode>(sim: &mut HelixSimulator<M>) -> Result
     Ok(())
 }
 
-/// Replace selection with yanked text (Helix 'R' command)
+/// Replace selection with the unnamed register's content (Helix 'R' command)
 pub fn replace_with_yanked<M: EditorMode>(sim: &mut HelixSimulator<M>) -> Result<(), UserError> {
-    let Some(yanked) = &sim.clipboard else {
+    replace_with_yanked_from_register(sim, None)
+}
+
+/// Replace selection with a named register's content (Helix 'R' command)
+///
+/// `register: None` addresses the unnamed register. See [`replace_with_yanked`].
+pub fn replace_with_yanked_from_register<M: EditorMode>(
+    sim: &mut HelixSimulator<M>,
+    register: Option<char>,
+) -> Result<(), UserError> {
+    let Some(yanked) = sim.registers.get(register) else {
         return Ok(()); // Nothing yanked
     };
 
@@ -228,11 +238,10 @@ pub fn replace_with_yanked<M: EditorMode>(sim: &mut HelixSimulator<M>) -> Result
         return Ok(()); // Nothing to paste
     }
 
-    let yanked = yanked.clone();
     let transaction = Transaction::change_by_selection(&sim.doc, &sim.selection, |range| {
         let start = range.from();
         let end = range.to();
-        (start, end, Some(yanked.clone().into()))
+        (start, end, Some(yanked.into()))
     });
 
     sim.apply_transaction(transaction);
@@ -592,7 +601,7 @@ mod tests {
     #[test]
     fn test_replace_with_yanked() {
         let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("hello world".to_string());
-        sim.clipboard = Some("REPLACED".to_string());
+        sim.registers.set(None, "REPLACED".to_string());
         sim.selection = Selection::single(0, 5);
 
         replace_with_yanked(&mut sim).unwrap();
@@ -603,7 +612,6 @@ mod tests {
     #[test]
     fn test_replace_with_yanked_no_clipboard() {
         let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("hello world".to_string());
-        sim.clipboard = None;
         sim.selection = Selection::single(0, 5);
 
         replace_with_yanked(&mut sim).unwrap();

--- a/src/helix/simulator/commands/mod.rs
+++ b/src/helix/simulator/commands/mod.rs
@@ -270,6 +270,32 @@ pub(super) fn execute_normal_mode_command_internal(
         return Ok(());
     }
 
+    if cmd.starts_with(CMD_SELECT_REGISTER) {
+        // Destructure via `chars()` rather than `len() == 3` + `.nth(k).unwrap()`:
+        // `len()` counts bytes, so a multi-byte register char (e.g. `"é`,
+        // 1 char but 2 bytes) would make `len() == 3` true for only 2 chars,
+        // and `.nth(2)` would then panic on `None`. This form only matches
+        // when there are exactly 3 chars total (quote + register + op).
+        let mut chars = cmd.chars();
+        chars.next(); // the leading '"', already confirmed by starts_with
+        if let (Some(register), Some(op), None) = (chars.next(), chars.next(), chars.next()) {
+            return match op {
+                'y' => clipboard::yank_to_register(sim, Some(register)),
+                'p' => clipboard::paste_after_from_register(sim, Some(register)),
+                'P' => clipboard::paste_before_from_register(sim, Some(register)),
+                'R' => editing::replace_with_yanked_from_register(sim, Some(register)),
+                _ => Err(UserError::command_failed(format!(
+                    "unknown register operation '{}'",
+                    op
+                ))),
+            };
+        }
+    }
+
+    if cmd.starts_with(CMD_COMMAND_LINE) {
+        return crate::helix::simulator::command_line::CommandLine::parse(cmd)?.execute(sim);
+    }
+
     if cmd == CMD_ESCAPE {
         return Ok(());
     }
@@ -348,6 +374,21 @@ pub(super) fn execute_command_any_mode(
             } else {
                 (result, AnyModeSimulator::Normal(normal_sim))
             }
+        }
+        AnyModeSimulator::Insert(insert_sim)
+            if cmd.len() > 1 && cmd.starts_with(CMD_COMMAND_LINE) =>
+        {
+            // Command-line strings are assembled by `CommandLinePending` in
+            // Normal mode only; guarded here too so an *assembled* `:`-prefixed
+            // string (e.g. ":goto 3") can never be inserted as literal text.
+            // `cmd.len() > 1` matters: insert mode delivers every typed
+            // character as its own one-char command, so without this a
+            // literal ':' keystroke (len 1) would hit this arm and be
+            // rejected instead of inserted.
+            let result = Err(UserError::command_failed(
+                "command-line is not available in insert mode",
+            ));
+            (result, AnyModeSimulator::Insert(insert_sim))
         }
         AnyModeSimulator::Insert(mut insert_sim) => {
             let exiting = cmd == CMD_ESCAPE;
@@ -515,6 +556,20 @@ mod tests {
             assert!(events.is_empty());
         }
 
+        /// Named regression test for S3/Q2: register ops and command-line
+        /// invocations are deliberately not `.`-repeatable. `cmd_to_key_events`
+        /// has no dedicated arm for either shape, so both fall through to the
+        /// generic "unmatched, len != 1" branch and produce no key events -
+        /// `record_command_if_needed_normal` then skips recording entirely
+        /// (an empty `key_events` slice is never recorded), so `.` after
+        /// `"ay` or `:goto 3` is a no-op, matching Helix (`.` repeats changes,
+        /// not yanks or navigation).
+        #[test]
+        fn test_cmd_to_key_events_register_op_and_command_line_are_not_repeatable() {
+            assert!(cmd_to_key_events("\"ay").is_empty());
+            assert!(cmd_to_key_events(":goto 3").is_empty());
+        }
+
         #[test]
         fn test_cmd_to_key_events_all_modifiers_none() {
             let events = cmd_to_key_events("a");
@@ -583,6 +638,90 @@ mod tests {
             assert_eq!(events[0].code, KeyCode::Char('m'));
             assert_eq!(events[1].code, KeyCode::Char('i'));
             assert_eq!(events[2].code, KeyCode::Char('p'));
+        }
+    }
+
+    // Register and command-line dispatch regression tests
+    mod register_and_command_line_dispatch_tests {
+        use super::*;
+        use crate::helix::simulator::{AnyModeSimulator, HelixSimulator, NormalMode};
+
+        #[test]
+        fn insert_mode_literal_colon_is_inserted_not_rejected() {
+            // Regression: the insert-mode ':' guard must only reject an
+            // *assembled* command-line string (len > 1), not a single typed
+            // ':' character, which insert mode delivers as its own one-char
+            // command.
+            let mut sim = AnyModeSimulator::Insert(
+                HelixSimulator::<NormalMode>::new(String::new()).enter_insert_mode(),
+            );
+            sim.execute_command(":").unwrap();
+            assert_eq!(sim.to_editor_state().unwrap().content(), ":");
+        }
+
+        #[test]
+        fn insert_mode_assembled_command_line_is_rejected() {
+            let mut sim = AnyModeSimulator::Insert(
+                HelixSimulator::<NormalMode>::new(String::new()).enter_insert_mode(),
+            );
+            assert!(sim.execute_command(":goto 3").is_err());
+        }
+
+        /// Named-register round-trip for `P` (paste before), not just `y`/`p`.
+        #[test]
+        fn register_paste_before_with_explicit_named_register() {
+            let mut sim: HelixSimulator<NormalMode> =
+                HelixSimulator::new("hello world".to_string());
+            sim.selection = helix_core::Selection::single(0, 5); // "hello"
+
+            execute_normal_mode_command_internal(&mut sim, "\"ay").unwrap(); // register a = "hello"
+
+            sim.selection = helix_core::Selection::point(6); // on 'w' in "world"
+            execute_normal_mode_command_internal(&mut sim, "\"aP").unwrap();
+
+            assert_eq!(sim.doc.to_string(), "hello helloworld");
+        }
+
+        /// Named-register round-trip for `R` (replace selection with
+        /// register content), not just `y`/`p`.
+        #[test]
+        fn register_replace_with_explicit_named_register() {
+            let mut sim: HelixSimulator<NormalMode> =
+                HelixSimulator::new("hello world".to_string());
+            sim.selection = helix_core::Selection::single(0, 5); // "hello"
+            execute_normal_mode_command_internal(&mut sim, "\"ay").unwrap(); // register a = "hello"
+
+            sim.selection = helix_core::Selection::single(6, 11); // "world"
+            execute_normal_mode_command_internal(&mut sim, "\"aR").unwrap();
+
+            assert_eq!(sim.doc.to_string(), "hello hello");
+        }
+
+        #[test]
+        fn register_dispatch_handles_non_ascii_register_without_panicking() {
+            // Regression: byte-length gating on a char index used to panic
+            // for a multi-byte register char (e.g. "é" is 1 char, 2 bytes).
+            // A well-formed 3-char command (quote + register + op) with a
+            // non-ASCII register succeeds like any other register letter.
+            let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("hello".to_string());
+            assert!(execute_normal_mode_command_internal(&mut sim, "\"éy").is_ok());
+
+            // An unsupported op with the same non-ASCII register is a clean
+            // error, not a panic.
+            let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("hello".to_string());
+            assert!(execute_normal_mode_command_internal(&mut sim, "\"éz").is_err());
+        }
+
+        #[test]
+        fn register_dispatch_does_not_panic_on_malformed_length() {
+            let mut sim: HelixSimulator<NormalMode> = HelixSimulator::new("hello".to_string());
+            // Too short: just the prefix, no register/op.
+            assert!(execute_normal_mode_command_internal(&mut sim, "\"").is_err());
+            // Too short: prefix + register, missing op - also a multi-byte
+            // register char (2 chars, 3 bytes), the original panic trigger.
+            assert!(execute_normal_mode_command_internal(&mut sim, "\"é").is_err());
+            // Too long: register + op + trailing char.
+            assert!(execute_normal_mode_command_internal(&mut sim, "\"aay").is_err());
         }
     }
 }

--- a/src/helix/simulator/mod.rs
+++ b/src/helix/simulator/mod.rs
@@ -9,10 +9,12 @@
 //! The simulator uses the typestate pattern to enforce mode-specific operations
 //! at compile time. See the `mode` module for details.
 
+pub mod command_line;
 pub mod commands;
 pub mod find_state;
 mod insert_mode;
 mod mode;
+pub mod register_file;
 pub mod search_state;
 pub mod snapshot;
 mod undo;
@@ -32,7 +34,9 @@ use std::marker::PhantomData;
 pub use mode::{EditorMode, InsertMode, NormalMode};
 
 // Re-export state types
+pub use command_line::CommandLine;
 pub use find_state::{FindDirection, FindState, FindType};
+pub use register_file::RegisterFile;
 pub use search_state::{SearchDirection, SearchState};
 pub use snapshot::{EditorDisplay, EditorSnapshot, SelectionBounds, SerializableRange};
 pub use view_state::ViewState;
@@ -85,8 +89,11 @@ pub struct HelixSimulator<M: EditorMode = NormalMode> {
     /// applied, matching standard editor undo/redo semantics.
     pub(super) redo_stack: Vec<Rope>,
 
-    /// Clipboard for yank and paste operations
-    pub(super) clipboard: Option<String>,
+    /// Named registers for yank, paste, and replace operations
+    ///
+    /// Plain `y`/`p`/`P`/`R` (with no `"<reg>` prefix) read and write the
+    /// unnamed register; see [`RegisterFile`].
+    pub(super) registers: RegisterFile,
 
     /// Repeat buffer for recording and replaying actions
     pub(super) repeat_buffer: RepeatBuffer,
@@ -270,7 +277,7 @@ impl HelixSimulator<NormalMode> {
             selection: Selection::point(0),
             history: Vec::new(),
             redo_stack: Vec::new(),
-            clipboard: None,
+            registers: RegisterFile::new(),
             repeat_buffer: RepeatBuffer::new(),
             is_repeating: false,
             repeat_depth: 0,
@@ -312,7 +319,7 @@ impl HelixSimulator<NormalMode> {
             selection,
             history: Vec::new(),
             redo_stack: Vec::new(),
-            clipboard: None,
+            registers: RegisterFile::new(),
             repeat_buffer: RepeatBuffer::new(),
             is_repeating: false,
             repeat_depth: 0,
@@ -381,7 +388,7 @@ impl HelixSimulator<NormalMode> {
             selection,
             history: Vec::new(),
             redo_stack: Vec::new(),
-            clipboard: None,
+            registers: RegisterFile::new(),
             repeat_buffer: RepeatBuffer::new(),
             is_repeating: false,
             repeat_depth: 0,
@@ -405,7 +412,7 @@ impl HelixSimulator<NormalMode> {
             selection: collapsed_selection,
             history: self.history,
             redo_stack: self.redo_stack,
-            clipboard: self.clipboard,
+            registers: self.registers,
             repeat_buffer: self.repeat_buffer,
             is_repeating: self.is_repeating,
             repeat_depth: self.repeat_depth,
@@ -446,7 +453,7 @@ impl HelixSimulator<InsertMode> {
             selection: self.selection,
             history: self.history,
             redo_stack: self.redo_stack,
-            clipboard: self.clipboard,
+            registers: self.registers,
             repeat_buffer: self.repeat_buffer,
             is_repeating: self.is_repeating,
             repeat_depth: self.repeat_depth,

--- a/src/helix/simulator/register_file.rs
+++ b/src/helix/simulator/register_file.rs
@@ -1,0 +1,112 @@
+//! Named register storage for yank/paste/replace operations
+//!
+//! Mirrors Helix's register model: every clipboard-affecting command reads
+//! and writes a named register, and the *unnamed* register (bound to `'"'`,
+//! matching Helix's own default) is what plain `y`/`p`/`P`/`R` use when no
+//! `"<reg>` prefix is given. Keeping a single storage type with one lookup
+//! key means `""y` and `y` are the same operation by construction, rather
+//! than two code paths that could drift.
+
+use std::collections::HashMap;
+
+/// Register key used when no explicit register is selected.
+///
+/// Matches Helix, where the unnamed register is itself addressable as `"`
+/// (so `""y` and `y` are equivalent).
+pub const UNNAMED_REGISTER: char = '"';
+
+/// Storage for all named registers, including the unnamed default register.
+///
+/// # Examples
+///
+/// ```
+/// use helix_trainer::helix::simulator::RegisterFile;
+///
+/// let mut registers = RegisterFile::new();
+/// registers.set(None, "hello".to_string());
+/// registers.set(Some('a'), "world".to_string());
+///
+/// assert_eq!(registers.get(None), Some("hello"));
+/// assert_eq!(registers.get(Some('a')), Some("world"));
+/// assert_eq!(registers.get(Some('b')), None);
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct RegisterFile {
+    registers: HashMap<char, String>,
+}
+
+impl RegisterFile {
+    /// Create an empty register file (no register has been written to yet).
+    pub fn new() -> Self {
+        Self {
+            registers: HashMap::new(),
+        }
+    }
+
+    /// Read the contents of a register.
+    ///
+    /// `None` addresses the unnamed register, so `get(None)` is what plain
+    /// `p`/`P`/`R` read from.
+    pub fn get(&self, register: Option<char>) -> Option<&str> {
+        let key = register.unwrap_or(UNNAMED_REGISTER);
+        self.registers.get(&key).map(String::as_str)
+    }
+
+    /// Write content into a register, overwriting any previous content.
+    ///
+    /// `None` addresses the unnamed register, so `set(None, ...)` is what
+    /// plain `y` writes to.
+    pub fn set(&mut self, register: Option<char>, content: String) {
+        let key = register.unwrap_or(UNNAMED_REGISTER);
+        self.registers.insert(key, content);
+    }
+
+    /// Remove a register's content entirely.
+    pub fn clear(&mut self, register: char) {
+        self.registers.remove(&register);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unnamed_register_roundtrip() {
+        let mut registers = RegisterFile::new();
+        registers.set(None, "foo".to_string());
+        assert_eq!(registers.get(None), Some("foo"));
+    }
+
+    #[test]
+    fn named_register_is_independent_of_unnamed() {
+        let mut registers = RegisterFile::new();
+        registers.set(None, "default".to_string());
+        registers.set(Some('a'), "named".to_string());
+
+        assert_eq!(registers.get(None), Some("default"));
+        assert_eq!(registers.get(Some('a')), Some("named"));
+    }
+
+    #[test]
+    fn explicit_unnamed_key_matches_none() {
+        let mut registers = RegisterFile::new();
+        registers.set(Some(UNNAMED_REGISTER), "via-explicit-key".to_string());
+        assert_eq!(registers.get(None), Some("via-explicit-key"));
+    }
+
+    #[test]
+    fn unset_register_is_none() {
+        let registers = RegisterFile::new();
+        assert_eq!(registers.get(Some('z')), None);
+        assert_eq!(registers.get(None), None);
+    }
+
+    #[test]
+    fn clear_removes_register_content() {
+        let mut registers = RegisterFile::new();
+        registers.set(Some('a'), "content".to_string());
+        registers.clear('a');
+        assert_eq!(registers.get(Some('a')), None);
+    }
+}

--- a/src/input/handlers.rs
+++ b/src/input/handlers.rs
@@ -22,9 +22,12 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use std::borrow::Cow;
 
+use crate::ui::state::InputStateAccess;
 use crate::ui::{AppState, Message, Screen, state::TypedScreen};
 
-use super::typestate::{handle_insert_mode_input, map_key_to_helix_command, normalize_key_event};
+use super::typestate::{
+    InputStateMachine, handle_insert_mode_input, map_key_to_helix_command, normalize_key_event,
+};
 
 /// Handle keyboard events on profile and statistics screens
 pub fn handle_profile_stats_keys(key: KeyEvent, state: &AppState) -> Option<Message> {
@@ -308,6 +311,19 @@ fn is_gameplay_insert_mode(state: &AppState) -> bool {
     }
 }
 
+/// Get the gameplay `InputStateMachine` for the current screen, if any.
+///
+/// Works for both training mode (Task screen) and arcade mode (MiniGame
+/// screen). Used to check for a pending prefix/command-line state before
+/// routing keys that would otherwise bypass the state machine (Esc, arrows).
+fn gameplay_input_state(state: &AppState) -> Option<&InputStateMachine> {
+    match &state.screen {
+        TypedScreen::Task(task_data) => Some(task_data.input_state()),
+        TypedScreen::MiniGame(minigame_data) => Some(minigame_data.input_state()),
+        _ => None,
+    }
+}
+
 /// Map arrow keys to movement commands
 ///
 /// Returns the corresponding movement command if the key is an arrow key,
@@ -338,8 +354,13 @@ where
     } else {
         // Normal mode: check if arrow keys should be mapped to movement commands
         // Only map if no modifiers are pressed (to avoid conflicts with Ctrl+Arrow, Alt+Arrow, etc.)
+        // and no command-line is pending (its buffer needs raw arrow keys ignored,
+        // not letters appended - see the CommandLinePending handler's Stay-on-arrow rule).
         if state.config.persistent.enable_arrow_keys_in_normal_mode
             && key.modifiers.is_empty()
+            && gameplay_input_state(state)
+                .map(|s| s.pending_command_line().is_none())
+                .unwrap_or(true)
             && let Some(mapped_cmd) = map_arrow_to_movement(key.code)
         {
             return Some(make_message(Cow::Borrowed(mapped_cmd)));
@@ -370,11 +391,25 @@ fn key_to_command_string(key: KeyEvent) -> Option<Cow<'static, str>> {
     }
 
     // For unknown commands (prefix keys like 'g', 'm', 'f', etc.),
-    // normalize and return the character for the state machine to process
+    // normalize and return the character for the state machine to process.
+    // Guard is applied AFTER normalization so macOS Option-composed chars
+    // are judged on their post-normalization modifiers.
     let key = normalize_key_event(key);
 
     match key.code {
-        KeyCode::Char(c) => Some(Cow::Owned(c.to_string())),
+        // Only bare ASCII chars fall through here: known ALT/CTRL commands
+        // are already returned above by `map_key_to_helix_command`, so an
+        // ALT/CTRL-carrying char reaching this arm is unmapped and must be
+        // dropped rather than silently serialized as the bare character
+        // (previously: unmapped Alt-x reached the state machine as plain
+        // "x", executing `select line` instead of being ignored).
+        KeyCode::Char(c)
+            if c.is_ascii()
+                && !key.modifiers.contains(KeyModifiers::ALT)
+                && !key.modifiers.contains(KeyModifiers::CONTROL) =>
+        {
+            Some(Cow::Owned(c.to_string()))
+        }
         KeyCode::Enter => Some(Cow::Borrowed("Enter")),
         KeyCode::Tab => Some(Cow::Borrowed("Tab")),
         _ => None,
@@ -533,8 +568,17 @@ pub fn handle_minigame_keys(key: KeyEvent, state: &AppState) -> Option<Message> 
             return handle_gameplay_input(key, state, Message::MiniGameCommand);
         }
 
-        // Normal mode - Esc pauses, other keys are commands
+        // Normal mode - Esc cancels a pending prefix/command-line state
+        // (count, g, m, register-select, command-line, ...) if one is
+        // active; otherwise it pauses. Without this, a pending state traps
+        // every keystroke until it resolves or times out, costing lives.
         if key.code == KeyCode::Esc {
+            let has_pending_state = gameplay_input_state(state)
+                .map(|s| s.is_prefix_state())
+                .unwrap_or(false);
+            if has_pending_state {
+                return handle_gameplay_input(key, state, Message::MiniGameCommand);
+            }
             return Some(Message::PauseMiniGame);
         }
 
@@ -1486,6 +1530,23 @@ mod tests {
             let key = KeyEvent::new(KeyCode::Home, KeyModifiers::NONE);
             assert_eq!(key_to_command_string(key), None);
         }
+
+        /// Regression test: an unmapped Alt-modified key must be dropped by
+        /// the fallback, not silently serialized as the bare character. Prior
+        /// to this fix, an unmapped Alt-z would reach the state machine as
+        /// plain "z", executing whatever "z" resolves to (view mode prefix)
+        /// instead of being ignored as an unrecognized command.
+        #[test]
+        fn test_unmapped_alt_key_is_dropped_not_serialized_as_bare_char() {
+            let key = KeyEvent::new(KeyCode::Char('z'), KeyModifiers::ALT);
+            assert_eq!(key_to_command_string(key), None);
+        }
+
+        #[test]
+        fn test_unmapped_ctrl_key_is_dropped_not_serialized_as_bare_char() {
+            let key = KeyEvent::new(KeyCode::Char('z'), KeyModifiers::CONTROL);
+            assert_eq!(key_to_command_string(key), None);
+        }
     }
 
     mod handle_category_filters_keys_tests {
@@ -1576,6 +1637,90 @@ mod tests {
         fn test_unknown_key_returns_none() {
             let key = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE);
             assert_eq!(handle_category_filters_keys(key), None);
+        }
+    }
+
+    // Arcade Esc-routing tests (S4a): Esc must cancel a pending prefix
+    // state instead of pausing, and must still pause when nothing is
+    // pending (the pre-existing behavior for every other state).
+    mod minigame_esc_routing_tests {
+        use super::*;
+        use crate::config::Difficulty;
+        use crate::minigame::MiniGameSession;
+        use crate::testing::ScenarioBuilder;
+        use crate::ui::state::{InputStateAccess, MiniGameData};
+        use std::sync::Arc;
+
+        fn playing_minigame_state() -> AppState {
+            let mut state = create_test_app_state();
+
+            let scenario = ScenarioBuilder::new()
+                .id("test_minigame")
+                .difficulty(Difficulty::Beginner)
+                .build();
+            let mut session = MiniGameSession::new(Arc::new(vec![scenario]), None);
+            session.start();
+            session.tick_countdown();
+            session.tick_countdown();
+            session.tick_countdown();
+            assert!(session.state().is_playing());
+
+            state.game.minigame_session = Some(session);
+            state.screen = TypedScreen::MiniGame(MiniGameData::default());
+            state
+        }
+
+        #[test]
+        fn esc_with_no_pending_state_pauses() {
+            let state = playing_minigame_state();
+            let key = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
+            assert_eq!(
+                handle_minigame_keys(key, &state),
+                Some(Message::PauseMiniGame)
+            );
+        }
+
+        #[test]
+        fn esc_with_pending_count_cancels_instead_of_pausing() {
+            let mut state = playing_minigame_state();
+            if let TypedScreen::MiniGame(data) = &mut state.screen {
+                let result = data
+                    .input_state_mut()
+                    .process_key(KeyEvent::new(KeyCode::Char('3'), KeyModifiers::NONE));
+                assert!(matches!(
+                    result,
+                    crate::input::typestate::HandlerResult::Transition(_)
+                ));
+                assert!(data.input_state().is_prefix_state());
+            }
+
+            let esc_msg =
+                handle_minigame_keys(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE), &state);
+            // Esc while a count is pending must route through the state
+            // machine (Cancel), not pause the game.
+            assert!(
+                matches!(esc_msg, Some(Message::MiniGameCommand(_))),
+                "expected Esc to route as a MiniGameCommand (cancel) while a prefix state is pending, got {:?}",
+                esc_msg
+            );
+        }
+
+        #[test]
+        fn esc_with_pending_register_cancels_instead_of_pausing() {
+            let mut state = playing_minigame_state();
+            if let TypedScreen::MiniGame(data) = &mut state.screen {
+                data.input_state_mut()
+                    .process_key(KeyEvent::new(KeyCode::Char('"'), KeyModifiers::NONE));
+                assert!(data.input_state().is_prefix_state());
+            }
+
+            let esc_msg =
+                handle_minigame_keys(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE), &state);
+            assert!(
+                matches!(esc_msg, Some(Message::MiniGameCommand(_))),
+                "expected Esc to route as a MiniGameCommand (cancel) while RegisterPending, got {:?}",
+                esc_msg
+            );
         }
     }
 }

--- a/src/input/typestate/handlers/base.rs
+++ b/src/input/typestate/handlers/base.rs
@@ -68,6 +68,16 @@ impl InputHandler<BaseState> for KeyHandler {
                 HandlerResult::Transition(InputState::ReplaceCharPending)
             }
 
+            // Named register selection - transition to register pending
+            (KeyCode::Char('"'), false) => HandlerResult::Transition(InputState::RegisterPending),
+
+            // Command-line mode - transition to command-line pending
+            (KeyCode::Char(':'), false) => {
+                HandlerResult::Transition(InputState::CommandLinePending {
+                    buffer: String::new(),
+                })
+            }
+
             // Count prefix - digits 1-9 start a count
             (KeyCode::Char(c @ '1'..='9'), false) => {
                 let count = c

--- a/src/input/typestate/handlers/command_line.rs
+++ b/src/input/typestate/handlers/command_line.rs
@@ -1,0 +1,226 @@
+//! CommandLinePending handler
+//!
+//! Accumulates a `:`-prefixed command-line buffer. The simulator never
+//! enters a "command mode" — this handler only collects text; the assembled
+//! `:<buffer>` string is executed atomically once, on Enter.
+//!
+//! Character input is read directly from the crossterm `KeyEvent` rather
+//! than round-tripping through `command_to_key_event`/`parse_key_code`,
+//! since that helper's single-byte gate silently turns any non-ASCII
+//! character (and macOS Option-compositions) into a literal space.
+//!
+//! Enter validates the assembled command via `CommandLine::parse` before
+//! emitting `Execute`, mirroring `RegisterOpPending`'s validate-before-Execute
+//! pattern. Without this, a parse error (e.g. `:nope`, `:goto abc`) would
+//! propagate as an `Err` all the way up through `execute_command_any_mode` ->
+//! `GameSession::record_action(_with_count)` -> `ui::update` -> the event
+//! loop -> `main`'s return value, terminating the whole application on a
+//! simple typo.
+
+use std::borrow::Cow;
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use super::{InputHandler, KeyHandler};
+use crate::helix::simulator::command_line::CommandLine;
+use crate::input::typestate::{
+    handler_result::HandlerResult, input_state::InputState, state_types::CommandLinePending,
+};
+use crate::security::limits::MAX_COMMAND_LINE_LEN;
+
+impl InputHandler<CommandLinePending> for KeyHandler {
+    fn handle_key(state: &CommandLinePending, key: KeyEvent) -> HandlerResult {
+        match key.code {
+            KeyCode::Esc => HandlerResult::Cancel,
+
+            KeyCode::Backspace => {
+                if state.buffer.is_empty() {
+                    HandlerResult::Cancel
+                } else {
+                    let mut buffer = state.buffer.clone();
+                    buffer.pop();
+                    HandlerResult::Transition(InputState::CommandLinePending { buffer })
+                }
+            }
+
+            KeyCode::Enter => {
+                if state.buffer.is_empty() {
+                    HandlerResult::Cancel
+                } else {
+                    let cmd = format!(":{}", state.buffer);
+                    match CommandLine::parse(&cmd) {
+                        Ok(_) => HandlerResult::Execute(Cow::Owned(cmd)),
+                        // Invalid command (unknown name, bad arity, non-numeric
+                        // argument, ...): cancel rather than handing an `Err`
+                        // to the executor, which has no recovery path for it.
+                        Err(_) => HandlerResult::Cancel,
+                    }
+                }
+            }
+
+            KeyCode::Char(c)
+                if (c.is_ascii_graphic() || c == ' ')
+                    && !key.modifiers.contains(KeyModifiers::ALT)
+                    && !key.modifiers.contains(KeyModifiers::CONTROL)
+                    && state.buffer.len() < MAX_COMMAND_LINE_LEN =>
+            {
+                let mut buffer = state.buffer.clone();
+                buffer.push(c);
+                HandlerResult::Transition(InputState::CommandLinePending { buffer })
+            }
+
+            // Unrecognised key (arrows, F-keys, non-ASCII, over-length, or a
+            // modifier-carrying char): never cancel on this, just ignore it.
+            _ => HandlerResult::Stay,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state(buffer: &str) -> CommandLinePending {
+        CommandLinePending {
+            buffer: buffer.to_string(),
+        }
+    }
+
+    fn char_key(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn appends_printable_chars() {
+        let result = KeyHandler::handle_key(&state("goto"), char_key(' '));
+        assert_eq!(
+            result,
+            HandlerResult::Transition(InputState::CommandLinePending {
+                buffer: "goto ".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn backspace_pops_last_char() {
+        let result = KeyHandler::handle_key(
+            &state("goto"),
+            KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE),
+        );
+        assert_eq!(
+            result,
+            HandlerResult::Transition(InputState::CommandLinePending {
+                buffer: "got".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn backspace_on_empty_buffer_cancels() {
+        let result = KeyHandler::handle_key(
+            &state(""),
+            KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE),
+        );
+        assert_eq!(result, HandlerResult::Cancel);
+    }
+
+    #[test]
+    fn enter_on_empty_buffer_cancels() {
+        let result = KeyHandler::handle_key(
+            &state(""),
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
+        assert_eq!(result, HandlerResult::Cancel);
+    }
+
+    #[test]
+    fn enter_on_nonempty_buffer_executes() {
+        let result = KeyHandler::handle_key(
+            &state("goto 3"),
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
+        assert_eq!(result, HandlerResult::Execute(Cow::Borrowed(":goto 3")));
+    }
+
+    /// Regression test: an invalid command must cancel, not `Execute`. Before
+    /// this fix, `Execute(":nope")` would propagate `CommandLine::parse`'s
+    /// `Err` all the way up to `main`'s return value and exit the process.
+    #[test]
+    fn enter_on_invalid_command_cancels_instead_of_executing() {
+        let result = KeyHandler::handle_key(
+            &state("nope"),
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
+        assert_eq!(result, HandlerResult::Cancel);
+    }
+
+    #[test]
+    fn enter_on_wrong_arity_cancels() {
+        let result = KeyHandler::handle_key(
+            &state("goto"),
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
+        assert_eq!(result, HandlerResult::Cancel);
+
+        let result = KeyHandler::handle_key(
+            &state("goto 1 2"),
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
+        assert_eq!(result, HandlerResult::Cancel);
+    }
+
+    #[test]
+    fn enter_on_non_numeric_argument_cancels() {
+        let result = KeyHandler::handle_key(
+            &state("goto abc"),
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
+        assert_eq!(result, HandlerResult::Cancel);
+    }
+
+    #[test]
+    fn escape_cancels() {
+        let result = KeyHandler::handle_key(
+            &state("goto 3"),
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+        );
+        assert_eq!(result, HandlerResult::Cancel);
+    }
+
+    #[test]
+    fn alt_and_ctrl_chars_are_ignored_not_cancelled() {
+        let alt_key = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::ALT);
+        assert_eq!(
+            KeyHandler::handle_key(&state("go"), alt_key),
+            HandlerResult::Stay
+        );
+
+        let ctrl_key = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+        assert_eq!(
+            KeyHandler::handle_key(&state("go"), ctrl_key),
+            HandlerResult::Stay
+        );
+    }
+
+    #[test]
+    fn non_ascii_char_is_ignored_not_cancelled() {
+        let result = KeyHandler::handle_key(&state("go"), char_key('é'));
+        assert_eq!(result, HandlerResult::Stay);
+    }
+
+    #[test]
+    fn arrow_key_is_ignored_not_cancelled() {
+        let result = KeyHandler::handle_key(
+            &state("go"),
+            KeyEvent::new(KeyCode::Left, KeyModifiers::NONE),
+        );
+        assert_eq!(result, HandlerResult::Stay);
+    }
+
+    #[test]
+    fn buffer_length_is_capped() {
+        let full = "x".repeat(MAX_COMMAND_LINE_LEN);
+        let result = KeyHandler::handle_key(&state(&full), char_key('y'));
+        assert_eq!(result, HandlerResult::Stay);
+    }
+}

--- a/src/input/typestate/handlers/mod.rs
+++ b/src/input/typestate/handlers/mod.rs
@@ -4,10 +4,12 @@
 //! The handlers are dispatched based on the current state.
 
 mod base;
+mod command_line;
 pub mod count;
 mod find;
 mod goto;
 mod match_mode;
+mod register;
 mod replace;
 mod text_object;
 mod unmatched;

--- a/src/input/typestate/handlers/register.rs
+++ b/src/input/typestate/handlers/register.rs
@@ -1,0 +1,133 @@
+//! RegisterPending and RegisterOpPending handlers
+//!
+//! Handles input after the `"` prefix for named-register-scoped clipboard
+//! operations:
+//! - `"` - select a register (waiting for the register character)
+//! - `"{register}` - register selected (waiting for y/p/P/R)
+//!
+//! Register scope is deliberately limited to the four commands that read or
+//! write a register in this trainer (`y`, `p`, `P`, `R`); any other key
+//! cancels rather than executing a bare command, keeping `"<reg><op>` an
+//! atomic 3-key sequence with no partial side effects.
+
+use std::borrow::Cow;
+
+use crossterm::event::{KeyCode, KeyEvent};
+
+use super::{InputHandler, KeyHandler};
+use crate::input::typestate::{
+    handler_result::HandlerResult,
+    input_state::InputState,
+    state_types::{RegisterOpPending, RegisterPending},
+};
+
+// ============================================================================
+// RegisterPending handler (after '"')
+// ============================================================================
+
+impl InputHandler<RegisterPending> for KeyHandler {
+    fn handle_key(_state: &RegisterPending, key: KeyEvent) -> HandlerResult {
+        match key.code {
+            // Accept any character as the register name
+            KeyCode::Char(c) => {
+                HandlerResult::Transition(InputState::RegisterOpPending { register: c })
+            }
+            // Escape - cancel
+            KeyCode::Esc => HandlerResult::Cancel,
+            // Other keys - cancel
+            _ => HandlerResult::Cancel,
+        }
+    }
+}
+
+// ============================================================================
+// RegisterOpPending handler (after '"{register}')
+// ============================================================================
+
+impl InputHandler<RegisterOpPending> for KeyHandler {
+    fn handle_key(state: &RegisterOpPending, key: KeyEvent) -> HandlerResult {
+        match key.code {
+            // Only y/p/P/R are register-scoped in this trainer
+            KeyCode::Char(op @ ('y' | 'p' | 'P' | 'R')) => {
+                let cmd = format!("\"{}{}", state.register, op);
+                HandlerResult::Execute(Cow::Owned(cmd))
+            }
+            // Any other key - cancel (including Escape)
+            _ => HandlerResult::Cancel,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::KeyModifiers;
+
+    fn key(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn register_pending_transitions_to_op_pending() {
+        let result = KeyHandler::handle_key(&RegisterPending, key('a'));
+        assert_eq!(
+            result,
+            HandlerResult::Transition(InputState::RegisterOpPending { register: 'a' })
+        );
+    }
+
+    #[test]
+    fn register_pending_escape_cancels() {
+        let result = KeyHandler::handle_key(
+            &RegisterPending,
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+        );
+        assert_eq!(result, HandlerResult::Cancel);
+    }
+
+    #[test]
+    fn register_op_pending_accepts_yank() {
+        let state = RegisterOpPending { register: 'a' };
+        let result = KeyHandler::handle_key(&state, key('y'));
+        assert_eq!(result, HandlerResult::Execute(Cow::Borrowed("\"ay")));
+    }
+
+    #[test]
+    fn register_op_pending_accepts_paste_after_before_and_replace() {
+        let state = RegisterOpPending { register: 'b' };
+        assert_eq!(
+            KeyHandler::handle_key(&state, key('p')),
+            HandlerResult::Execute(Cow::Borrowed("\"bp"))
+        );
+        assert_eq!(
+            KeyHandler::handle_key(&state, key('P')),
+            HandlerResult::Execute(Cow::Borrowed("\"bP"))
+        );
+        assert_eq!(
+            KeyHandler::handle_key(&state, key('R')),
+            HandlerResult::Execute(Cow::Borrowed("\"bR"))
+        );
+    }
+
+    #[test]
+    fn register_op_pending_rejects_out_of_scope_operator() {
+        let state = RegisterOpPending { register: 'a' };
+        // 'd' is not register-scoped in this trainer (see architect handoff)
+        assert_eq!(
+            KeyHandler::handle_key(&state, key('d')),
+            HandlerResult::Cancel
+        );
+        assert_eq!(
+            KeyHandler::handle_key(&state, key('x')),
+            HandlerResult::Cancel
+        );
+    }
+
+    #[test]
+    fn register_op_pending_escape_cancels() {
+        let state = RegisterOpPending { register: 'a' };
+        let result =
+            KeyHandler::handle_key(&state, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert_eq!(result, HandlerResult::Cancel);
+    }
+}

--- a/src/input/typestate/input_state.rs
+++ b/src/input/typestate/input_state.rs
@@ -36,6 +36,12 @@ pub enum InputState {
     FindCharPending { find_type: FindType },
     /// After 'r' - waiting for replacement character
     ReplaceCharPending,
+    /// After '"' - waiting for register character
+    RegisterPending,
+    /// After '"{register}' - waiting for operator character (y/p/P/R)
+    RegisterOpPending { register: char },
+    /// After ':' - accumulating a command-line buffer
+    CommandLinePending { buffer: String },
     /// After digit 1-9 - building count prefix
     CountPending { count: usize },
     /// After '[' - waiting for unmatched previous command second key
@@ -90,6 +96,8 @@ impl InputState {
                 | Self::SurroundDeletePending
                 | Self::SurroundReplaceFromPending
                 | Self::SurroundReplaceToPending { .. }
+                | Self::RegisterPending
+                | Self::RegisterOpPending { .. }
         )
     }
 
@@ -142,6 +150,9 @@ impl InputState {
             Self::TextObjectInsidePending => "TEXT_OBJECT_INSIDE_PENDING",
             Self::FindCharPending { .. } => "FIND_CHAR_PENDING",
             Self::ReplaceCharPending => "REPLACE_CHAR_PENDING",
+            Self::RegisterPending => "REGISTER_PENDING",
+            Self::RegisterOpPending { .. } => "REGISTER_OP_PENDING",
+            Self::CommandLinePending { .. } => "COMMAND_LINE_PENDING",
             Self::CountPending { .. } => "COUNT_PENDING",
             Self::UnmatchedPrevPending => "UNMATCHED_PREV_PENDING",
             Self::UnmatchedNextPending => "UNMATCHED_NEXT_PENDING",

--- a/src/input/typestate/key_mapping.rs
+++ b/src/input/typestate/key_mapping.rs
@@ -142,9 +142,13 @@ pub fn parse_helix_key_string(s: &str) -> Option<KeyEvent> {
 
 /// Parse the key code from a string, updating modifiers for uppercase letters
 fn parse_key_code(s: &str, modifiers: &mut KeyModifiers) -> Option<KeyCode> {
-    // Single character (byte length check is correct for ASCII-only key inputs)
-    if s.len() == 1 {
-        let c = s.chars().next()?;
+    // Single character - counts chars, not bytes, so a non-ASCII char (which
+    // is multi-byte in UTF-8) is correctly rejected as "not a single key"
+    // rather than silently falling through to the space fallback.
+    let mut chars = s.chars();
+    if let Some(c) = chars.next()
+        && chars.next().is_none()
+    {
         // Uppercase ASCII letter implies Shift modifier
         if c.is_ascii_uppercase() {
             *modifiers |= KeyModifiers::SHIFT;

--- a/src/input/typestate/mod.rs
+++ b/src/input/typestate/mod.rs
@@ -61,10 +61,11 @@ pub use key_mapping::{
     command_to_key_event, handle_insert_mode_input, map_key_to_helix_command, normalize_key_event,
     parse_helix_key_string,
 };
-pub use state_machine::{InputStateMachine, SurroundPreview};
+pub use state_machine::{InputStateMachine, RegisterPreview, SurroundPreview};
 pub use state_types::{
-    BaseState, CountPending, FindCharPending, FindType, GotoPending, HandlerState, MatchPending,
-    ReplaceCharPending, SurroundAddPending, SurroundDeletePending, SurroundReplaceFromPending,
+    BaseState, CommandLinePending, CountPending, FindCharPending, FindType, GotoPending,
+    HandlerState, MatchPending, RegisterOpPending, RegisterPending, ReplaceCharPending,
+    SurroundAddPending, SurroundDeletePending, SurroundReplaceFromPending,
     SurroundReplaceToPending, TextObjectAroundPending, TextObjectInsidePending,
     UnmatchedNextPending, UnmatchedPrevPending, ViewPending,
 };

--- a/src/input/typestate/state_machine.rs
+++ b/src/input/typestate/state_machine.rs
@@ -72,6 +72,19 @@ impl InputStateMachine {
                 key,
             ),
             InputState::ReplaceCharPending => KeyHandler::handle_key(&ReplaceCharPending, key),
+            InputState::RegisterPending => KeyHandler::handle_key(&RegisterPending, key),
+            InputState::RegisterOpPending { register } => KeyHandler::handle_key(
+                &RegisterOpPending {
+                    register: *register,
+                },
+                key,
+            ),
+            InputState::CommandLinePending { buffer } => KeyHandler::handle_key(
+                &CommandLinePending {
+                    buffer: buffer.clone(),
+                },
+                key,
+            ),
             InputState::CountPending { count } => {
                 KeyHandler::handle_key(&CountPending { count: *count }, key)
             }
@@ -128,6 +141,30 @@ impl InputStateMachine {
         }
     }
 
+    /// Get info about a pending register-select sequence, for UI feedback.
+    ///
+    /// Returns `None` outside of `"`/`"<reg>` input.
+    pub fn pending_register(&self) -> Option<RegisterPreview> {
+        match &self.state {
+            InputState::RegisterPending => Some(RegisterPreview::SelectingRegister),
+            InputState::RegisterOpPending { register } => {
+                Some(RegisterPreview::AwaitingOperator(*register))
+            }
+            _ => None,
+        }
+    }
+
+    /// Get the in-progress `:`-prefixed command-line buffer, if pending.
+    ///
+    /// Returns the text typed after the colon (not including the colon
+    /// itself), for rendering a live prompt line.
+    pub fn pending_command_line(&self) -> Option<&str> {
+        match &self.state {
+            InputState::CommandLinePending { buffer } => Some(buffer.as_str()),
+            _ => None,
+        }
+    }
+
     /// Get a preview character for surround operations
     ///
     /// Returns Some(char) when in a state that should show bracket preview:
@@ -152,4 +189,13 @@ pub enum SurroundPreview {
     Replace(char),
     /// Preview for surround delete - shows which brackets will be deleted
     Delete(char),
+}
+
+/// State of a pending named-register selection sequence, for UI feedback.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegisterPreview {
+    /// Waiting for the register character after `"`.
+    SelectingRegister,
+    /// Register selected; waiting for the operator (y/p/P/R).
+    AwaitingOperator(char),
 }

--- a/src/input/typestate/state_types.rs
+++ b/src/input/typestate/state_types.rs
@@ -86,6 +86,24 @@ impl FindType {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ReplaceCharPending;
 
+/// Waiting for the register character after '"' (named register selection)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RegisterPending;
+
+/// Waiting for the operator character after '"{register}' (y/p/P/R)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RegisterOpPending {
+    /// The register selected to scope the upcoming operator
+    pub register: char,
+}
+
+/// Accumulating a `:`-prefixed command-line buffer
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandLinePending {
+    /// Buffer contents typed after the leading ':'
+    pub buffer: String,
+}
+
 /// Building a count prefix (digits 1-9, then 0-9)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CountPending {
@@ -121,6 +139,9 @@ impl private::Sealed for TextObjectAroundPending {}
 impl private::Sealed for TextObjectInsidePending {}
 impl private::Sealed for FindCharPending {}
 impl private::Sealed for ReplaceCharPending {}
+impl private::Sealed for RegisterPending {}
+impl private::Sealed for RegisterOpPending {}
+impl private::Sealed for CommandLinePending {}
 impl private::Sealed for CountPending {}
 impl private::Sealed for UnmatchedPrevPending {}
 impl private::Sealed for UnmatchedNextPending {}
@@ -202,6 +223,24 @@ impl HandlerState for FindCharPending {
 impl HandlerState for ReplaceCharPending {
     fn state_name() -> &'static str {
         "REPLACE_CHAR_PENDING"
+    }
+}
+
+impl HandlerState for RegisterPending {
+    fn state_name() -> &'static str {
+        "REGISTER_PENDING"
+    }
+}
+
+impl HandlerState for RegisterOpPending {
+    fn state_name() -> &'static str {
+        "REGISTER_OP_PENDING"
+    }
+}
+
+impl HandlerState for CommandLinePending {
+    fn state_name() -> &'static str {
+        "COMMAND_LINE_PENDING"
     }
 }
 

--- a/src/input/typestate/tests/count_handler_tests.rs
+++ b/src/input/typestate/tests/count_handler_tests.rs
@@ -72,6 +72,21 @@ fn test_count_pending_overflow_protection() {
     }
 }
 
+/// M4: `3"ay` cancels rather than combining a count with a register
+/// selection - `'"'` has no arm in `is_count_compatible_command`, so it
+/// falls to the "invalid command" branch, same as any other incompatible
+/// key. Verifies the state resets to `Base` (no leaked pending state), as
+/// the architect's plan explicitly asked for.
+#[test]
+fn test_count_pending_register_prefix_cancels() {
+    let state = CountPending { count: 3 };
+    let result = KeyHandler::handle_key(
+        &state,
+        KeyEvent::new(KeyCode::Char('"'), KeyModifiers::NONE),
+    );
+    assert!(matches!(result, HandlerResult::Cancel));
+}
+
 #[test]
 fn test_count_pending_clamps_at_max() {
     // Test that count is clamped to MAX_COUNT

--- a/src/input/typestate/tests/state_machine_tests.rs
+++ b/src/input/typestate/tests/state_machine_tests.rs
@@ -79,6 +79,40 @@ fn test_state_machine_cancel_returns_to_base() {
     assert!(sm.state().is_base());
 }
 
+/// M4: `3"ay` cancels at the count->register boundary (`'"'` is not a
+/// count-compatible command) and leaves no pending state.
+#[test]
+fn test_state_machine_count_then_register_cancels_to_base() {
+    let mut sm = InputStateMachine::new();
+
+    sm.process_key(KeyEvent::new(KeyCode::Char('3'), KeyModifiers::NONE));
+    assert!(sm.state().is_count_pending());
+
+    let result = sm.process_key(KeyEvent::new(KeyCode::Char('"'), KeyModifiers::NONE));
+    assert!(result.is_cancel());
+    assert!(sm.state().is_base());
+
+    // The register/op characters that would have followed are now plain
+    // Base-state input, not part of a leaked pending sequence.
+    let result = sm.process_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE));
+    assert!(result.is_execute());
+}
+
+/// M4: `"a3y` cancels at the register-op boundary (a digit is not a
+/// register-scoped operator) and leaves no pending state.
+#[test]
+fn test_state_machine_register_then_digit_cancels_to_base() {
+    let mut sm = InputStateMachine::new();
+
+    sm.process_key(KeyEvent::new(KeyCode::Char('"'), KeyModifiers::NONE));
+    sm.process_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE));
+    assert!(sm.state().is_waiting_for_char()); // RegisterOpPending
+
+    let result = sm.process_key(KeyEvent::new(KeyCode::Char('3'), KeyModifiers::NONE));
+    assert!(result.is_cancel());
+    assert!(sm.state().is_base());
+}
+
 #[test]
 fn test_state_machine_reset() {
     let mut sm = InputStateMachine::new();

--- a/src/minigame/session.rs
+++ b/src/minigame/session.rs
@@ -840,12 +840,15 @@ impl MiniGameSession {
             let optimal_count = scenario.scenario.scoring.optimal_count.get();
             let optimal_time_per_command = scenario.time_limit / optimal_count as u32;
 
-            // Record each unique command used
+            // Record each unique command used, normalized to the same card
+            // id training mode uses (`"ay` -> `"y`, `:g 3` -> `:goto`) so
+            // arcade and training practice of the same skill share one card.
             let mut recorded_commands = std::collections::HashSet::new();
             for command in actions {
-                if recorded_commands.insert(command.clone()) {
+                let normalized = crate::helix::commands::normalize_command_id(command).into_owned();
+                if recorded_commands.insert(normalized.clone()) {
                     tracker.record_attempt(
-                        command,
+                        &normalized,
                         time_per_command,
                         success,
                         optimal_time_per_command,
@@ -1285,6 +1288,48 @@ mod tests {
             let (row, _col) = scenario.current_cursor();
             assert_eq!(row, 2, "Cursor should be on last line (row 2)");
         }
+    }
+
+    /// Regression test: `record_to_fsrs` is the one normalization call site
+    /// the original plan missed (per the critic's M2/M3 finding). Without
+    /// normalizing before dedup+record, `"ay` and `"by` would mint two
+    /// separate FSRS cards instead of collapsing to one `"y` card.
+    #[test]
+    fn test_record_to_fsrs_normalizes_register_ops_to_one_card() {
+        let scenario = ScenarioBuilder::new()
+            .id("test_register_fsrs")
+            .setup_content("alpha beta")
+            .target_content("zzz")
+            .optimal_count(1)
+            .difficulty(Difficulty::Beginner)
+            .build();
+
+        let scenarios = Arc::new(vec![scenario]);
+        let mut session = MiniGameSession::new(scenarios, None);
+        session.start();
+        session.tick_countdown();
+        session.tick_countdown();
+        session.tick_countdown();
+        assert!(session.state.is_playing());
+
+        session.handle_command("\"ay").unwrap();
+        session.handle_command("\"by").unwrap();
+
+        let mut tracker = PerformanceTracker::new();
+        session.record_to_fsrs(&mut tracker, true);
+
+        assert!(
+            tracker.get_performance("\"y").is_some(),
+            "expected the normalized '\"y' card to exist"
+        );
+        assert!(
+            tracker.get_performance("\"ay").is_none(),
+            "raw '\"ay' must not exist as its own card"
+        );
+        assert!(
+            tracker.get_performance("\"by").is_none(),
+            "raw '\"by' must not exist as its own card"
+        );
     }
 
     #[test]

--- a/src/security.rs
+++ b/src/security.rs
@@ -208,6 +208,13 @@ pub mod limits {
     /// Maximum command sequence length
     pub const MAX_COMMAND_SEQUENCE_LENGTH: usize = 100;
 
+    /// Maximum length of the `:`-prefixed command-line buffer
+    ///
+    /// `InputState` is cloned on every keystroke transition, so this bounds
+    /// the per-keystroke clone cost (O(n²) in the worst case) as well as the
+    /// rendered prompt line length.
+    pub const MAX_COMMAND_LINE_LEN: usize = 256;
+
     /// Command timeout
     pub const COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
 

--- a/src/ui/render/category_filters.rs
+++ b/src/ui/render/category_filters.rs
@@ -20,6 +20,7 @@ fn category_display_name(category: &ScenarioCategory) -> &'static str {
         ScenarioCategory::Selection => "Selection",
         ScenarioCategory::TextObjects => "Text Objects",
         ScenarioCategory::Advanced => "Advanced",
+        ScenarioCategory::Registers => "Registers",
         ScenarioCategory::Multi => "Multi",
         ScenarioCategory::Other => "Other",
     }
@@ -35,6 +36,7 @@ fn category_icon(category: &ScenarioCategory) -> &'static str {
         ScenarioCategory::Selection => "##",
         ScenarioCategory::TextObjects => "{}",
         ScenarioCategory::Advanced => "++",
+        ScenarioCategory::Registers => "\"\"",
         ScenarioCategory::Multi => "**",
         ScenarioCategory::Other => "..",
     }
@@ -321,6 +323,10 @@ mod tests {
             category_display_name(&ScenarioCategory::Advanced),
             "Advanced"
         );
+        assert_eq!(
+            category_display_name(&ScenarioCategory::Registers),
+            "Registers"
+        );
         assert_eq!(category_display_name(&ScenarioCategory::Multi), "Multi");
         assert_eq!(category_display_name(&ScenarioCategory::Other), "Other");
     }
@@ -335,6 +341,7 @@ mod tests {
         assert!(!category_icon(&ScenarioCategory::Selection).is_empty());
         assert!(!category_icon(&ScenarioCategory::TextObjects).is_empty());
         assert!(!category_icon(&ScenarioCategory::Advanced).is_empty());
+        assert!(!category_icon(&ScenarioCategory::Registers).is_empty());
         assert!(!category_icon(&ScenarioCategory::Multi).is_empty());
         assert!(!category_icon(&ScenarioCategory::Other).is_empty());
     }
@@ -348,6 +355,7 @@ mod tests {
         assert_eq!(category_icon(&ScenarioCategory::Selection), "##");
         assert_eq!(category_icon(&ScenarioCategory::TextObjects), "{}");
         assert_eq!(category_icon(&ScenarioCategory::Advanced), "++");
+        assert_eq!(category_icon(&ScenarioCategory::Registers), "\"\"");
         assert_eq!(category_icon(&ScenarioCategory::Multi), "**");
         assert_eq!(category_icon(&ScenarioCategory::Other), "..");
     }
@@ -406,8 +414,9 @@ mod tests {
             create_test_scenario_with_category("s5", ScenarioCategory::Selection),
             create_test_scenario_with_category("s6", ScenarioCategory::TextObjects),
             create_test_scenario_with_category("s7", ScenarioCategory::Advanced),
-            create_test_scenario_with_category("s8", ScenarioCategory::Multi),
-            create_test_scenario_with_category("s9", ScenarioCategory::Other),
+            create_test_scenario_with_category("s8", ScenarioCategory::Registers),
+            create_test_scenario_with_category("s9", ScenarioCategory::Multi),
+            create_test_scenario_with_category("s10", ScenarioCategory::Other),
         ];
 
         let mut state = AppState {
@@ -442,7 +451,7 @@ mod tests {
 
         let mut state = create_state_with_all_categories();
         state.screen = TypedScreen::CategoryFilters(CategoryFiltersData {
-            selected_index: 8, // Last item (9 categories, 0-indexed)
+            selected_index: 9, // Last item (10 categories, 0-indexed)
             return_to: crate::ui::state::ReturnDestination::Menu,
         });
 

--- a/src/ui/render/helpers.rs
+++ b/src/ui/render/helpers.rs
@@ -72,3 +72,25 @@ pub(super) fn inner_rect(outer: Rect) -> Rect {
 
 // Re-export find_surrounding_brackets from helix module
 pub(super) use crate::helix::find_surrounding_brackets;
+
+/// Build a live feedback string for an in-progress `"`-register selection or
+/// `:`-command-line buffer, so the user can see what they're typing.
+///
+/// Returns an empty string when neither is pending. Shared between Training
+/// (`task.rs`) and Arcade (`minigame.rs`) rendering, since both screens'
+/// `InputStateMachine` can be in either pending state.
+pub(super) fn pending_input_indicator(
+    input_state: &crate::input::typestate::InputStateMachine,
+) -> String {
+    if let Some(buffer) = input_state.pending_command_line() {
+        return format!(" :{} ", buffer);
+    }
+    if let Some(preview) = input_state.pending_register() {
+        use crate::input::typestate::RegisterPreview;
+        return match preview {
+            RegisterPreview::SelectingRegister => " [Register: _] ".to_string(),
+            RegisterPreview::AwaitingOperator(r) => format!(" [Register: {}] ", r),
+        };
+    }
+    String::new()
+}

--- a/src/ui/render/minigame.rs
+++ b/src/ui/render/minigame.rs
@@ -47,7 +47,7 @@ pub(super) fn render_minigame(frame: &mut Frame, state: &AppState) {
     if session.state().is_countdown() {
         render_countdown(frame, area, session);
     } else if session.state().is_playing() {
-        render_playing(frame, area, session);
+        render_playing(frame, area, session, &minigame_data.input_state);
         // Show key history popup after first keypress (reset on scenario transitions)
         // Reserve space for the Timer + Stats bars (3 + 3) so the popup never
         // overlaps them.
@@ -55,7 +55,13 @@ pub(super) fn render_minigame(frame: &mut Frame, state: &AppState) {
             super::popups::render_key_history_popup(frame, minigame_data.key_history.keys(), 6);
         }
     } else if session.state().is_transition() {
-        render_transition(frame, area, session, minigame_data.last_xp_earned);
+        render_transition(
+            frame,
+            area,
+            session,
+            minigame_data.last_xp_earned,
+            &minigame_data.input_state,
+        );
     } else if session.state().is_paused() {
         render_paused(frame, area, session);
     } else if session.state().is_game_over() {
@@ -123,7 +129,12 @@ fn render_countdown(frame: &mut Frame, area: Rect, session: &crate::minigame::Mi
 }
 
 /// Render playing screen with active scenario
-fn render_playing(frame: &mut Frame, area: Rect, session: &crate::minigame::MiniGameSession) {
+fn render_playing(
+    frame: &mut Frame,
+    area: Rect,
+    session: &crate::minigame::MiniGameSession,
+    input_state: &crate::input::typestate::InputStateMachine,
+) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -135,8 +146,11 @@ fn render_playing(frame: &mut Frame, area: Rect, session: &crate::minigame::Mini
         ])
         .split(area);
 
-    // Title + controls
-    let title_line = Line::from(vec![
+    // Title + controls, with live feedback for an in-progress '"'-register
+    // selection or ':'-command-line buffer (both live in Arcade mode too -
+    // see the Esc-cancel and reset_input_state wiring in input/handlers.rs).
+    let pending_text = super::helpers::pending_input_indicator(input_state);
+    let mut title_spans = vec![
         Span::styled(
             mode_title(session),
             Style::default()
@@ -145,8 +159,17 @@ fn render_playing(frame: &mut Frame, area: Rect, session: &crate::minigame::Mini
         ),
         Span::raw("        "),
         Span::styled("[Esc] Pause", Style::default().fg(Color::Gray)),
-    ]);
-    let title = Paragraph::new(title_line)
+    ];
+    if !pending_text.is_empty() {
+        title_spans.push(Span::raw("  "));
+        title_spans.push(Span::styled(
+            pending_text,
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    let title = Paragraph::new(Line::from(title_spans))
         .alignment(Alignment::Center)
         .block(Block::default().borders(Borders::ALL));
     frame.render_widget(title, chunks[0]);
@@ -354,9 +377,10 @@ fn render_transition(
     area: Rect,
     session: &crate::minigame::MiniGameSession,
     last_xp: Option<u64>,
+    input_state: &crate::input::typestate::InputStateMachine,
 ) {
     // Render playing screen as background (shows final editor state)
-    render_playing(frame, area, session);
+    render_playing(frame, area, session, input_state);
 
     // Render popup overlay on top using shared function
     let is_success = session.state().transition_success().unwrap_or(true);
@@ -579,6 +603,52 @@ mod tests {
 
         let result = terminal.draw(|f| render_minigame(f, &state));
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_render_minigame_playing_shows_pending_command_line() {
+        use ratatui::buffer::Buffer;
+
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        let scenarios = Arc::new(vec![create_test_scenario("s1")]);
+        let mut session = MiniGameSession::new(scenarios, None);
+        session.start();
+        session.tick_countdown();
+        session.tick_countdown();
+        session.tick_countdown();
+        assert!(session.state().is_playing());
+
+        let mut state = AppState::new(
+            vec![],
+            UserProfile::new(),
+            ProfileStorage::for_test(),
+            PerformanceTracker::new(),
+        );
+        let mut minigame_data = MiniGameData::default();
+        minigame_data
+            .input_state
+            .process_key(crossterm::event::KeyEvent::new(
+                crossterm::event::KeyCode::Char(':'),
+                crossterm::event::KeyModifiers::NONE,
+            ));
+        assert_eq!(minigame_data.input_state.pending_command_line(), Some(""));
+        state.screen = TypedScreen::MiniGame(minigame_data);
+        state.game.minigame_session = Some(session);
+
+        // Regression: must not panic when a command-line/register pending
+        // state is live during Arcade rendering, and must actually render
+        // the indicator text somewhere in the frame.
+        let result = terminal.draw(|f| render_minigame(f, &state));
+        assert!(result.is_ok());
+
+        let buffer: &Buffer = terminal.backend().buffer();
+        let rendered: String = buffer.content.iter().map(|cell| cell.symbol()).collect();
+        assert!(
+            rendered.contains(':'),
+            "expected the pending ':' command-line buffer to be visible in the rendered frame"
+        );
     }
 
     #[test]

--- a/src/ui/render/task.rs
+++ b/src/ui/render/task.rs
@@ -208,9 +208,13 @@ pub(super) fn render_task_screen(frame: &mut Frame, state: &AppState) {
             String::new()
         };
 
+        // Live feedback for an in-progress '"'-register selection or
+        // ':'-command-line buffer, so the user can see what they're typing.
+        let pending_text = super::helpers::pending_input_indicator(&task_data.input_state);
+
         let instructions = Paragraph::new(format!(
-            "{}{}| Ctrl-Q: Abandon | Ctrl-C: Quit",
-            hint_indicator, last_cmd_text
+            "{}{}{}| Ctrl-Q: Abandon | Ctrl-C: Quit",
+            pending_text, hint_indicator, last_cmd_text
         ))
         .style(Style::default().fg(Color::Gray))
         .alignment(Alignment::Center)

--- a/src/ui/state/handlers/minigame.rs
+++ b/src/ui/state/handlers/minigame.rs
@@ -362,6 +362,9 @@ pub(in crate::ui::state) fn handle_minigame_next_scenario(
     state.ui.show_key_history = false;
     if let TypedScreen::MiniGame(ref mut data) = state.screen {
         data.clear_key_history();
+        // A pending prefix/register/command-line state from the previous
+        // scenario must not leak into the next one's fresh input.
+        data.reset_input_state();
     }
     Ok(HandlerOutcome::Stay)
 }
@@ -1359,6 +1362,47 @@ mod tests {
         let outcome = handle_minigame_next_scenario(&mut state).unwrap();
 
         assert!(matches!(outcome, HandlerOutcome::Stay));
+    }
+
+    /// Regression test for S4b: a half-typed prefix/register/command-line
+    /// state must not leak into the next scenario after
+    /// `handle_minigame_next_scenario` advances.
+    #[test]
+    fn test_handle_minigame_next_scenario_resets_pending_input_state() {
+        let mut state = create_test_state();
+        start_minigame(&mut state);
+
+        if let Some(ref mut session) = state.game.minigame_session {
+            session.tick_countdown();
+            session.tick_countdown();
+            session.tick_countdown();
+            session.advance_to_next();
+        }
+
+        // Leave a pending register-select state, as if the player started
+        // typing `"a` right before the transition kicked in.
+        if let TypedScreen::MiniGame(ref mut data) = state.screen {
+            data.input_state_mut()
+                .process_key(crossterm::event::KeyEvent::new(
+                    crossterm::event::KeyCode::Char('"'),
+                    crossterm::event::KeyModifiers::NONE,
+                ));
+            assert!(data.input_state().is_prefix_state());
+        } else {
+            panic!("expected MiniGame screen");
+        }
+
+        handle_minigame_next_scenario(&mut state).unwrap();
+
+        if let TypedScreen::MiniGame(ref data) = state.screen {
+            assert!(
+                data.input_state().state().is_base(),
+                "pending input state must reset when advancing to the next scenario, got {:?}",
+                data.input_state().state()
+            );
+        } else {
+            panic!("expected MiniGame screen");
+        }
     }
 
     #[test]

--- a/src/ui/state/handlers/quests.rs
+++ b/src/ui/state/handlers/quests.rs
@@ -13,16 +13,22 @@ use std::time::Duration;
 ///
 /// Shared between training and arcade modes.
 /// Updates command practice and exploration quests.
+///
+/// Normalizes register ops (`"ay` -> `"y`) and command-line invocations
+/// (`:g 3` -> `:goto`) before tracking, so quest matching (exact equality)
+/// and FSRS see the same command id for the same skill.
 pub fn track_command_for_quests(state: &mut AppState, command: &str) {
+    let normalized = crate::helix::commands::normalize_command_id(command);
+
     // Track for exploration quests
     state
         .progress
         .commands_used_today
-        .insert(command.to_string());
+        .insert(normalized.to_string());
 
     // Update command progress in quests
     let profile = &mut state.progress.profile;
-    QuestTracker::update_command_progress(&mut profile.daily_quests, command);
+    QuestTracker::update_command_progress(&mut profile.daily_quests, &normalized);
 }
 
 /// Track scenario completion for quests

--- a/tests/scenario_validation.rs
+++ b/tests/scenario_validation.rs
@@ -12,6 +12,7 @@ use helix_trainer::game::command_context::{
     ParsedCommand, extract_count_and_command, parse_command_buffer,
 };
 use helix_trainer::game::{GameSession, PlayableScenario};
+use helix_trainer::helix::simulator::command_line::CommandLine;
 
 #[test]
 fn test_all_scenarios_load_successfully() {
@@ -121,6 +122,20 @@ fn validate_commands_ui_style(commands: &[String]) -> Result<(), String> {
             continue;
         }
 
+        // Handle ':'-prefixed command-line invocations - these are assembled
+        // atomically by `CommandLinePending` (not resolved char-by-char through
+        // the KeyTrie, which has no notion of a command-line buffer), so
+        // validate them by parsing directly instead.
+        if cmd.starts_with(':') {
+            if let Err(e) = CommandLine::parse(cmd) {
+                return Err(format!(
+                    "Command {} '{}': :-command failed to parse: {:?}",
+                    i, cmd, e
+                ));
+            }
+            continue;
+        }
+
         // In insert mode, single characters are text input, not commands
         if in_insert_mode {
             // Only single chars are valid in insert mode (text input)
@@ -183,6 +198,34 @@ fn validate_single_command(cmd: &str) -> Result<(), String> {
 
     // Buffer should have resolved by now
     Err("Never completed".to_string())
+}
+
+#[test]
+fn test_all_scenario_command_line_entries_parse() {
+    let loader = ScenarioLoader::new();
+    let scenarios = loader
+        .load_from_embedded("en")
+        .expect("Failed to load embedded scenarios");
+
+    let mut checked = 0;
+    for scenario in &scenarios {
+        for cmd in &scenario.solution.commands {
+            if let Some(colon_cmd) = cmd.strip_prefix(':').map(|_| cmd) {
+                CommandLine::parse(colon_cmd).unwrap_or_else(|e| {
+                    panic!(
+                        "scenario '{}': ':' entry '{}' failed to parse: {:?}",
+                        scenario.id, colon_cmd, e
+                    )
+                });
+                checked += 1;
+            }
+        }
+    }
+
+    assert!(
+        checked > 0,
+        "expected at least one ':'-prefixed solution entry across all scenarios"
+    );
 }
 
 #[test]

--- a/tests/ui_multi_key_commands.rs
+++ b/tests/ui_multi_key_commands.rs
@@ -336,3 +336,162 @@ fn test_undo_integration() {
     // Note: Redo functionality (ctrl-r, U) is not yet implemented in HelixSimulator
     // The redo() method is currently a placeholder
 }
+
+#[test]
+fn test_register_yank_paste_multi_key() {
+    // "ay yanks into register a; a later plain 'y' overwrites only the
+    // default register; "ap then proves register a survived independently.
+    let scenario =
+        create_test_scenario("test_register", "alpha beta", (0, 0), "aalpha beta", (0, 1));
+
+    let mut state = create_test_app_state(vec![scenario.clone()]);
+    update(&mut state, Message::StartScenario(0)).unwrap();
+
+    // '"' - transitions to RegisterPending
+    update(&mut state, Message::ExecuteCommand(Cow::Borrowed("\""))).unwrap();
+    if let TypedScreen::Task(task_data) = &state.screen {
+        assert!(matches!(
+            task_data.input_state().state(),
+            helix_trainer::input::typestate::InputState::RegisterPending
+        ));
+    } else {
+        panic!("Should be on Task screen");
+    }
+
+    // 'a' - selects register a, transitions to RegisterOpPending
+    update(&mut state, Message::ExecuteCommand(Cow::Borrowed("a"))).unwrap();
+    if let TypedScreen::Task(task_data) = &state.screen {
+        assert!(matches!(
+            task_data.input_state().state(),
+            helix_trainer::input::typestate::InputState::RegisterOpPending { register: 'a' }
+        ));
+        // Nothing executed yet
+        assert_eq!(task_data.session.current_content(), "alpha beta");
+    } else {
+        panic!("Should be on Task screen");
+    }
+
+    // 'y' - completes "ay, yanking the char under cursor ('a') into register a
+    update(&mut state, Message::ExecuteCommand(Cow::Borrowed("y"))).unwrap();
+    if let TypedScreen::Task(task_data) = &state.screen {
+        assert!(task_data.input_state().state().is_base());
+        assert_eq!(task_data.session.current_content(), "alpha beta");
+    } else {
+        panic!("Should be on Task screen (scenario incomplete)");
+    }
+
+    // Overwrite the default register - must not disturb register a
+    update(&mut state, Message::ExecuteCommand(Cow::Borrowed("y"))).unwrap();
+
+    // '"' -> 'a' -> 'p' pastes register a's content ('a') after the cursor
+    update(&mut state, Message::ExecuteCommand(Cow::Borrowed("\""))).unwrap();
+    update(&mut state, Message::ExecuteCommand(Cow::Borrowed("a"))).unwrap();
+    update(&mut state, Message::ExecuteCommand(Cow::Borrowed("p"))).unwrap();
+
+    if state.ui.completion_time.is_some() {
+        let pending = state.game.pending_completed_session.as_ref();
+        assert!(pending.is_some(), "Should have pending completed session");
+        assert_eq!(pending.unwrap().current_content(), "aalpha beta");
+    } else if let TypedScreen::Task(task_data) = &state.screen {
+        assert!(task_data.input_state().state().is_base());
+        assert_eq!(task_data.session.current_content(), "aalpha beta");
+    } else {
+        panic!("Should be on Task screen (or completed) after the register sequence");
+    }
+}
+
+#[test]
+fn test_register_op_cancels_on_out_of_scope_operator() {
+    // Register scope is limited to y/p/P/R; any other operator cancels back
+    // to Base rather than executing a bare command.
+    let scenario = create_test_scenario("test_register_cancel", "hello", (0, 0), "world", (0, 0));
+
+    let mut state = create_test_app_state(vec![scenario.clone()]);
+    update(&mut state, Message::StartScenario(0)).unwrap();
+
+    update(&mut state, Message::ExecuteCommand(Cow::Borrowed("\""))).unwrap();
+    update(&mut state, Message::ExecuteCommand(Cow::Borrowed("a"))).unwrap();
+    // 'd' is not register-scoped - should cancel, not delete anything
+    update(&mut state, Message::ExecuteCommand(Cow::Borrowed("d"))).unwrap();
+
+    if let TypedScreen::Task(task_data) = &state.screen {
+        assert!(task_data.input_state().state().is_base());
+        assert_eq!(task_data.session.current_content(), "hello");
+    } else {
+        panic!("Should be on Task screen");
+    }
+}
+
+#[test]
+fn test_command_line_goto_multi_key() {
+    // ':' -> "goto 3" -> Enter assembles and executes ":goto 3" atomically.
+    let scenario = create_test_scenario(
+        "test_command_line",
+        "line1\nline2\nline3\nline4",
+        (0, 0),
+        "line1\nline2\nline3\nline4",
+        (2, 0),
+    );
+
+    let mut state = create_test_app_state(vec![scenario.clone()]);
+    update(&mut state, Message::StartScenario(0)).unwrap();
+
+    update(&mut state, Message::ExecuteCommand(Cow::Borrowed(":"))).unwrap();
+    if let TypedScreen::Task(task_data) = &state.screen {
+        assert_eq!(task_data.input_state().pending_command_line(), Some(""));
+    } else {
+        panic!("Should be on Task screen");
+    }
+
+    for c in "goto 3".chars() {
+        let owned = c.to_string();
+        update(&mut state, Message::ExecuteCommand(Cow::Owned(owned))).unwrap();
+    }
+    if let TypedScreen::Task(task_data) = &state.screen {
+        assert_eq!(
+            task_data.input_state().pending_command_line(),
+            Some("goto 3")
+        );
+        // Nothing executed yet - the buffer only assembles until Enter
+        assert_eq!(task_data.session.current_cursor(), (0, 0));
+    } else {
+        panic!("Should be on Task screen");
+    }
+
+    update(&mut state, Message::ExecuteCommand(Cow::Borrowed("Enter"))).unwrap();
+
+    // ':goto 3' reaches the target cursor exactly, so the scenario completes
+    // immediately; the completed session lives in `pending_completed_session`
+    // while the screen stays on Task for the success popup (see
+    // `process_session_result`), matching the pattern other multi-key tests
+    // in this file use to check post-completion state.
+    if state.ui.completion_time.is_some() {
+        let pending = state.game.pending_completed_session.as_ref();
+        assert!(pending.is_some(), "Should have pending completed session");
+        assert_eq!(pending.unwrap().current_cursor(), (2, 0));
+    } else if let TypedScreen::Task(task_data) = &state.screen {
+        assert!(task_data.input_state().state().is_base());
+        assert_eq!(task_data.session.current_cursor(), (2, 0));
+    } else {
+        panic!("Should be on Task screen (or completed) after ':goto 3'");
+    }
+}
+
+#[test]
+fn test_command_line_escape_cancels_buffer() {
+    let scenario = create_test_scenario("test_cmdline_cancel", "hello", (0, 0), "world", (0, 0));
+
+    let mut state = create_test_app_state(vec![scenario.clone()]);
+    update(&mut state, Message::StartScenario(0)).unwrap();
+
+    update(&mut state, Message::ExecuteCommand(Cow::Borrowed(":"))).unwrap();
+    update(&mut state, Message::ExecuteCommand(Cow::Borrowed("g"))).unwrap();
+    update(&mut state, Message::ExecuteCommand(Cow::Borrowed("Escape"))).unwrap();
+
+    if let TypedScreen::Task(task_data) = &state.screen {
+        assert!(task_data.input_state().state().is_base());
+        assert_eq!(task_data.session.current_content(), "hello");
+    } else {
+        panic!("Should be on Task screen");
+    }
+}


### PR DESCRIPTION
## Summary

- Named registers: `"<reg><op>` (e.g. `"ay`, `"ap`) scopes `y`/`p`/`P`/`R` to a named register instead of the default one, via a new `RegisterFile` on the simulator. Unnamed `y`/`p`/`P`/`R` are unchanged and remain equivalent to `""y`/`""p`/`""P`/`""R`.
- Command-line mode: `:` opens a command-line prompt. Only `:goto N` (alias `:g N`) is implemented, transcribed from real Helix `:goto` semantics (1-based line number, clamped to the last real line, `:goto 0` is a silent no-op, cursor moves to line start). `:s`/`:g`-as-global do not exist in Helix (that's Vim syntax) and were never in scope; `:clear-register` and `:sort` were evaluated and dropped since neither is verifiable against the snapshot-based scenario completion model.
- Two new scenarios (one named-register, one `:goto`), plus the `ScenarioCategory::Registers` category and a shared `normalize_command_id` choke point so register/command-line variants mint one FSRS/quest card, not several.

Bundled fixes surfaced during review (all covered by new regression tests):
- An invalid command-line entry (e.g. `:q`, `:goto abc`) previously propagated an uncaught error all the way out of the event loop and terminated the app; it now cancels back to normal mode instead.
- A related bug made the insert-mode `:` guard reject a literal typed colon (same crash path); the guard now only matches assembled multi-char command-line strings.
- Arcade mode's Esc now cancels a pending prefix/register/command-line state instead of always pausing the game (behavior change, documented in CHANGELOG), and input state is reset between arcade scenarios so a half-typed buffer can't leak into the next one.
- An unmapped Alt/Ctrl-modified key no longer silently falls back to executing its bare character.
- A byte/char-length confusion in the new register dispatch and command normalization that could panic on a multi-byte register character.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (1913 passed)
- [x] `cargo nextest run scenario` (234 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace`
- [x] `cargo test --doc`
- [x] Went through architect → critic (two rounds) → developer → tester/perf/security/impl-critic → code review (two rounds) before merge; security and impl-critic independently found and confirmed the same app-crash bug, now fixed with regression tests

Fixes #282