### PR TITLE
ci: skip full test/build matrix on docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,41 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      # true when files that affect compiled behavior changed: source, scenarios
+      # (compile-time embedded, see src/config/scenarios.rs), locales (compile-time
+      # codegen via rust_i18n::i18n! in src/lib.rs), manifests, or the CI workflow itself.
+      run-heavy: ${{ steps.filter.outputs.rust == 'true' || steps.filter.outputs.ci == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Filter changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            rust:
+              - 'src/**'
+              - 'scenarios/**'
+              - 'locales/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'build.rs'
+              - 'tests/**'
+              - 'benches/**'
+              - '.cargo/**'
+              - 'rust-toolchain*'
+            ci:
+              - '.github/workflows/**'
+
   test:
     name: Test Suite
+    needs: [changes]
+    if: needs.changes.outputs.run-heavy == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -105,6 +138,8 @@ jobs:
 
   msrv:
     name: Check MSRV
+    needs: [changes]
+    if: needs.changes.outputs.run-heavy == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -136,6 +171,8 @@ jobs:
 
   build:
     name: Build
+    needs: [changes]
+    if: needs.changes.outputs.run-heavy == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -247,6 +284,8 @@ jobs:
 
   coverage:
     name: Generate Coverage Report
+    needs: [changes]
+    if: needs.changes.outputs.run-heavy == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -297,24 +336,56 @@ jobs:
   gate:
     name: CI Gate
     if: always()
-    needs: [test, fmt, clippy, security, msrv, build, coverage]
+    needs: [changes, test, fmt, clippy, security, msrv, build, coverage]
     runs-on: ubuntu-latest
     steps:
       - name: Check all jobs
         run: |
-          results=(
-            "${{ needs.test.result }}"
-            "${{ needs.fmt.result }}"
-            "${{ needs.clippy.result }}"
-            "${{ needs.security.result }}"
-            "${{ needs.msrv.result }}"
-            "${{ needs.build.result }}"
-            "${{ needs.coverage.result }}"
-          )
-          for result in "${results[@]}"; do
+          # `changes` and the always-on jobs (fmt/clippy/security) must succeed outright.
+          # test/msrv/build/coverage are gated behind changes.outputs.run-heavy: a
+          # "skipped" result is only acceptable for them when run-heavy is exactly
+          # "false", i.e. the path filter deliberately excluded the job. If run-heavy
+          # was "true" (or the changes job itself failed), "skipped" here means the
+          # job never ran despite being required, so it must fail the gate.
+          changes_result="${{ needs.changes.result }}"
+          run_heavy="${{ needs.changes.outputs.run-heavy }}"
+
+          if [[ "$changes_result" != "success" ]]; then
+            echo "::error::changes detection job failed or was cancelled"
+            exit 1
+          fi
+
+          fail=0
+
+          check_required() {
+            local name="$1" result="$2"
             if [[ "$result" != "success" ]]; then
-              echo "::error::One or more CI jobs failed or were cancelled"
-              exit 1
+              echo "::error::$name failed or was cancelled"
+              fail=1
             fi
-          done
-          echo "All CI jobs passed"
+          }
+
+          check_gated() {
+            local name="$1" result="$2"
+            if [[ "$result" == "success" ]]; then
+              return
+            fi
+            if [[ "$result" == "skipped" && "$run_heavy" == "false" ]]; then
+              return
+            fi
+            echo "::error::$name failed, was cancelled, or was skipped unexpectedly"
+            fail=1
+          }
+
+          check_required "fmt" "${{ needs.fmt.result }}"
+          check_required "clippy" "${{ needs.clippy.result }}"
+          check_required "security" "${{ needs.security.result }}"
+          check_gated "test" "${{ needs.test.result }}"
+          check_gated "msrv" "${{ needs.msrv.result }}"
+          check_gated "build" "${{ needs.build.result }}"
+          check_gated "coverage" "${{ needs.coverage.result }}"
+
+          if [[ "$fail" -ne 0 ]]; then
+            exit 1
+          fi
+          echo "All CI jobs passed (or were correctly skipped for docs-only changes)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ProfileStorage::save` now also `fsync`s the profile directory itself (Unix only) after the atomic rename, so the directory-entry update — not just the file's contents — survives a power loss, not only a process crash or kill; the doc comment on `save` no longer overclaims what the pre-existing atomic-rename protection covered (#297)
 - Two instances of the trainer running against the same profile now warn the user on startup instead of silently overwriting each other's progress: `ProfileStorage` maintains an advisory PID lock file (`profile.json.lock`) refreshed on every save; a stale lock left by a crashed process is reclaimed silently, but a lock held by a genuinely live process surfaces a notification, checked both when the profile loads successfully and when it fails and falls back to a fresh profile — the latter being the highest-stakes case, since a fresh fallback profile can otherwise clobber a genuinely live instance's real profile on the next save (#298). `ProfileStorage::delete` now also removes the lock file so a deleted profile doesn't leave a stale one behind.
 
+### CI
+
+- Added a `changes` job (`dorny/paths-filter`) to `ci.yml` that skips the 3-OS `test` matrix, `msrv`, the 3-OS `build` matrix, and `coverage` when a push/PR only touches docs/metadata (no `src/`, `scenarios/`, `locales/`, manifests, or workflow files changed); `fmt`/`clippy`/`security` remain always-on since they're cheap and also cover config files like `Cargo.toml`. Any change under `.github/workflows/**` still forces every job to run. The `gate` job's pass/fail check now accepts a `skipped` result for the gated jobs only when the path filter deliberately excluded them, so a real failure or an unexpected skip still fails the gate.
+
 ### Changed
 
 - **BREAKING**: `ScoringConfig.optimal_count` is now `NonZeroUsize` instead of `usize`; TOML layout is unchanged, but zero rejection now happens at parse time, so `optimal_count = 0` now surfaces as "Failed to load scenario file..." instead of "Operation failed..." (#277)


### PR DESCRIPTION
## Summary

- Add a `changes` job (`dorny/paths-filter@v3`) that classifies changed paths into `rust` (`src/**`, `scenarios/**`, `locales/**`, manifests, `tests/**`, `benches/**`, `.cargo/**`, `rust-toolchain*`) and `ci` (`.github/workflows/**`).
- Gate the 3-OS `test` matrix, `msrv`, the 3-OS `build` matrix, and `coverage` behind `run-heavy` (`rust || ci`), so a docs-only PR no longer triggers the full matrix.
- `fmt`, `clippy`, `security` stay always-on since they're cheap and cover config drift (`Cargo.toml`) that a docs-only filter wouldn't catch.
- Any change under `.github/workflows/**` still forces the full run, so pipeline regressions are never silently skipped.
- Rework the final `gate` job: always-on jobs must be `success`; gated jobs accept `skipped` only when `run-heavy == 'false'`, so an unexpected skip (upstream failure/cancellation) still fails the gate instead of passing silently.

`scenarios/**` and `locales/**` are classified as `rust`-affecting because both are compiled in (embedded scenario loader, `rust_i18n::i18n!` codegen), not treated as docs.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins`
- [ ] Confirm on GitHub Actions that a docs-only PR skips test/msrv/build/coverage and the gate still passes
- [ ] Confirm a source-touching PR still runs everything and the gate still passes