### PR TITLE
docs(specs): consolidate retroactive SDD packages into specs/

### DIFF
--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -1,0 +1,84 @@
+---
+aliases:
+  - Specifications Index
+  - Specs Overview
+tags:
+  - moc
+  - sdd
+created: 2026-08-08
+status: moc
+---
+
+# Specifications
+
+> [!abstract]
+> Map of Content for all helix-trainer project specifications. Each entry
+> links to a feature spec with its current phase and status. This index
+> was last reconciled 2026-08-09 against actual merged implementation
+> state — see each package's README.md for the retroactive-documentation
+> methodology.
+
+## Active Specs
+
+(none — all specs below are either fully documented against shipped code or
+superseded)
+
+## Completed Specs
+
+| Feature | Phase | Status |
+|---------|-------|--------|
+| [[fsrs-proptest-coverage-gap/README\|FSRS Scheduler Property-Based Test Coverage Gap]] | review | implemented (partial scope — see [[fsrs-proptest-coverage-gap/BRD#Residual Gap\|Residual Gap]]) |
+| [[arcade-game-mode-variety/README\|Arcade Game Mode Variety]] | rejected | NO-GO — full decision-record package, not built |
+| [[register-command-mode-support/README\|Named Register and Command-Line (`:`) Mode Support]] | review | implemented (command-line mode narrower than drafted — `:goto`/`:g` only, no `:s` substitute) |
+| [[arcade-gamification-session-fixes/spec\|Arcade Gamification Session Bookkeeping Fixes]] | specify (lightweight, per SDD scaling guidance) | implemented |
+
+## Project Foundation
+
+- [[constitution]] — non-negotiable project principles. Created 2026-08-09,
+  synthesized from `.claude/CLAUDE.md` and `.claude/rules/*.md` (which
+  already documented these conventions informally).
+
+## Reconciliation Notes (2026-08-09)
+
+This index was retroactively reconciled against actual merged
+implementation state, then consolidated from working drafts under
+`.local/specs/` into this git-tracked `specs/` tree. Summary of what
+changed and why:
+
+- **fsrs-proptest-coverage-gap** — was a `.local/specs/` draft describing a
+  then-unresolved testing gap. Resolved by commit `33bdaa1`. Full
+  BRD/SRS/NFR/plan/tasks/README package added, documenting a **partial**
+  resolution: `src/learning/performance.rs` gained proptest coverage (and a
+  real bug was found/fixed as a result); `src/learning/scheduler.rs` did
+  not, and remains an open residual gap.
+- **arcade-game-mode-variety** — a reflex-drill arcade mechanic (issue
+  #264) was proposed twice: once as a `.local/specs/` draft
+  (`002-arcade-game-mode-variety`), and once as a full, independently-run
+  BRD → SRS → NFR → spec → plan → tasks pipeline that reached NO-GO. Only
+  the complete, already-committed package lives here; the earlier draft
+  remains in `.local/specs/002-arcade-game-mode-variety/spec.md` (main
+  checkout only, gitignored) purely as a historical artifact — this
+  package's README/SRS/spec cross-reference it explicitly and it is not
+  duplicated in this tree. Commit `623e0a8` (double-XP/streak/level-up
+  fixes, #322) was investigated as a possible match for this feature and
+  found to be **unrelated** — a separate, previously undocumented set of
+  gamification bug fixes, now covered by **arcade-gamification-session-fixes**.
+- **register-command-mode-support** — was a `.local/specs/` draft
+  researching named registers and a command-line mode. Resolved by commit
+  `1ba668d`. Full BRD/SRS/NFR/plan/tasks/README package added. Named
+  registers shipped essentially as drafted; command-line mode shipped
+  **narrower** than drafted (`:goto`/`:g` line navigation only — no `:s`
+  substitute, no `EditorMode::CommandMode` variant), a deliberate,
+  documented scope decision made during implementation.
+- **arcade-gamification-session-fixes** (new) — commit `623e0a8` (double
+  XP on arcade replay, zero-streak freeze guard, missing review-session
+  level-up notification) had no spec anywhere in the repository prior to
+  this pass. Given a lightweight spec.md per this project's SDD scaling
+  guidance for small, independent bug fixes (3 single-guard-clause
+  changes, 6 files, no new architecture) — a full BRD/SRS/NFR/plan/tasks
+  package would be disproportionate.
+
+## See Also
+
+- [[constitution]] — project principles
+- `.claude/CLAUDE.md` — architecture reference

--- a/specs/arcade-gamification-session-fixes/spec.md
+++ b/specs/arcade-gamification-session-fixes/spec.md
@@ -1,0 +1,169 @@
+---
+aliases:
+  - Arcade Gamification Session Fixes
+  - Double XP / Streak Freeze / Review Level-Up Fixes
+tags:
+  - sdd
+  - spec
+  - gamification
+  - minigame
+  - bug-fix
+  - status/implemented
+created: 2026-08-09
+status: implemented
+related:
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+---
+
+# Feature: Arcade Gamification Session Bookkeeping Fixes
+
+> [!info] Metadata
+> **Resolved by**: commit `623e0a8` — "fix(gamification): stop double XP on
+> arcade replay, guard zero-streak freeze, notify review level-ups (#322)",
+> closing issues #317, #319, #318
+> **Status**: Implemented
+> **Depth**: Lightweight spec only, per this project's SDD scaling
+> guidance ("small bug fix → 3-5 sentences + acceptance criteria") — three
+> independent single-guard-clause fixes, 6 files, 179/-9 lines, no new
+> types or architecture. A full BRD/SRS/NFR/plan/tasks package would be
+> disproportionate. This document exists to fill a genuine documentation
+> gap: this work was previously undocumented in any spec, BRD, or decision
+> record anywhere in the repository.
+
+> [!note] Not the Same Feature as `002-arcade-game-mode-variety`
+> This is unrelated to GitHub issue #264 ("Arcade Game Mode Variety" — a
+> proposed reflex-drill minigame mechanic, rejected NO-GO; see
+> `specs/arcade-game-mode-variety/`). This spec covers three narrow
+> gamification bookkeeping bugs in the *existing* `Arcade`/review-session
+> code paths, not a new game mode.
+
+## 1. Overview
+
+### Problem Statement
+
+Three independent gamification bookkeeping defects existed in the arcade
+minigame and FSRS review-session paths:
+
+1. **Double XP on arcade replay** (#317) — `handle_minigame_back_to_menu`
+   (`src/ui/state/handlers/minigame.rs`) unconditionally re-ran
+   `handle_minigame_game_over` whenever a `minigame_session` existed, with
+   no check for whether game-over bookkeeping had already run. Since
+   `handle_minigame_timeout` already runs it once when lives are depleted
+   (without clearing `minigame_session`), pressing the back-to-menu key at
+   the game-over screen re-awarded XP, re-incremented
+   `minigame_games_played`, and re-recorded an FSRS failure a second time
+   on the same session.
+2. **Zero-streak freeze guard** (#319) — `StreakManager::update_streak`
+   (`src/gamification/streak.rs`) consumed an available streak freeze and
+   emitted a `StreakFreezeUsed` notification on any missed day, without
+   checking whether `current_streak` was actually nonzero — silently
+   burning a freeze "protecting" a streak that was never active.
+3. **Missing review-session level-up notification** (#318) —
+   `handle_next_review_command` (`src/ui/state/handlers/review.rs`) called
+   `profile.add_xp(xp)` and discarded the returned `leveled_up` boolean, so
+   a level crossed purely by FSRS review-session XP produced no
+   `NotificationType::LevelUp`, inconsistent with the training-mode and
+   arcade-mode XP paths, which do notify.
+
+### Goal
+
+Each of the three bugs is fixed with a single additional guard condition,
+verified by a dedicated regression test, with no change to public API
+surface or data model.
+
+### Out of Scope
+
+- Any change to XP formula, streak-freeze earning rules, or level
+  thresholds — only the bookkeeping/guard logic around existing rules
+- Arcade game-mode variety (`002-arcade-game-mode-variety`, unrelated,
+  separately researched and rejected)
+
+## 2. Acceptance Criteria (as shipped)
+
+```
+GIVEN an arcade minigame session has already reached the GameOver state
+  (via handle_minigame_timeout, which ran game-over bookkeeping once)
+WHEN  the player then triggers MiniGameBackToMenu (Esc/m/Ctrl-q)
+THEN  handle_minigame_game_over does NOT run again for that session — no
+      additional XP, games-played increment, or FSRS-failure record occurs
+```
+Test: `test_minigame_back_to_menu_after_game_over_does_not_double_award`
+(`src/ui/state/handlers/minigame.rs`).
+
+```
+GIVEN a user profile whose current_streak is 0 (never started, or already
+  broken) and a streak freeze is available
+WHEN  a missed-day streak check runs
+THEN  the freeze is NOT consumed and no StreakFreezeUsed notification is shown
+```
+Tests: `test_streak_freeze_not_consumed_when_streak_already_zero`
+(`src/gamification/streak.rs`),
+`test_handle_profile_ready_no_freeze_used_for_never_started_streak`
+(`src/data_handling.rs`).
+
+```
+GIVEN a review session's completion XP award crosses a level threshold
+WHEN  the review session completes
+THEN  a NotificationType::LevelUp notification is shown reporting the new
+      level, consistent with the training-mode and arcade-mode XP paths
+```
+Tests: `test_review_session_completion_notifies_on_level_up`,
+`test_review_session_completion_no_level_up_notification_without_level_up`
+(`src/ui/state/tests/review_tests.rs`).
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN the player returns to the menu from the arcade game-over screen AND the minigame session has already reached the `GameOver` state THE SYSTEM SHALL NOT re-run game-over XP, games-played, or FSRS-failure bookkeeping for that session | must |
+| FR-002 | WHEN a streak-freeze check occurs on a missed day AND the user's `current_streak` is already 0 THE SYSTEM SHALL NOT consume the available streak freeze and SHALL NOT emit a `StreakFreezeUsed` notification | must |
+| FR-003 | WHEN a review session's completion XP award causes the profile to cross a level threshold THE SYSTEM SHALL emit a `LevelUp` notification reporting the new level, consistent with the training-mode and arcade-mode XP paths | must |
+
+All three implemented as-is, no deviation, no residual gap — confirmed by
+the six regression tests listed above.
+
+## 4. Data Model
+
+No new persistent entities. No changes to `Profile`, `CardState`, or
+`MiniGameStats` schema — only guard conditions on existing fields
+(`is_game_over()`, `current_streak`, `leveled_up` return value).
+
+## 5. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Player quits mid-game (before `GameOver` state) via back-to-menu | `handle_minigame_game_over` still runs exactly once — the guard only suppresses the *second* run, not the first |
+| User has never had an active streak but has a freeze from some other earned source | Freeze is preserved (not silently consumed), per FR-002 |
+| Review session XP does not cross a level boundary | No `LevelUp` notification shown — the existing no-op path, verified by `test_review_session_completion_no_level_up_notification_without_level_up` |
+
+## 6. Success Criteria
+
+| ID | Metric | Target | Actual |
+|----|--------|--------|--------|
+| SC-001 | Regression tests pass for all 3 fixes | 6/6 new tests pass | Met |
+| SC-002 | No regression in `cargo nextest run --workspace --all-features --lib --bins` | 100% pass | Met (per CHANGELOG entry) |
+| SC-003 | CHANGELOG.md documents all three fixes under their issue numbers | 3/3 entries present | Met — #317, #318, #319 all present under `[Unreleased]` |
+
+## 7. Agent Boundaries
+
+### Always (without asking)
+- Run the full check suite after any change touching
+  `src/gamification/streak.rs`, `src/ui/state/handlers/minigame.rs`, or
+  `src/ui/state/handlers/review.rs`
+- Preserve the guard conditions added here when refactoring these handlers
+
+### Never
+- Remove the `is_game_over()` guard in `handle_minigame_back_to_menu`
+  without an equivalent replacement — doing so reintroduces double-XP
+- Remove the `was_streak > 0` guard in `StreakManager::update_streak`
+  without an equivalent replacement — doing so reintroduces the zero-streak
+  freeze bug
+
+## 8. See Also
+
+- [[constitution]] — project principles
+- [[MOC-specs]] — all specifications
+- CHANGELOG.md — `[Unreleased]` section, entries for #317, #318, #319
+- `specs/arcade-game-mode-variety/` — unrelated feature, do not confuse (see note above)
+- `.local/specs/002-arcade-game-mode-variety/spec.md` — the actually-related-by-name-only draft, superseded, also unrelated to this fix

--- a/specs/constitution.md
+++ b/specs/constitution.md
@@ -1,0 +1,187 @@
+---
+aliases:
+  - Project Principles
+  - helix-trainer Constitution
+tags:
+  - sdd
+  - constitution
+created: 2026-08-09
+status: permanent
+---
+
+# Project Constitution
+
+> [!important]
+> Non-negotiable principles governing ALL development in helix-trainer.
+> Every specification, plan, and task MUST comply with this document.
+> Derived from the existing project conventions in `.claude/CLAUDE.md` and
+> `.claude/rules/*.md` (checked into the repo) rather than invented from
+> scratch — this document formalizes what the project already practices.
+> Update this file only through explicit team decision.
+
+## I. Architecture
+
+- Single-binary TUI: **ratatui** + **crossterm** rendering, **tokio** async
+  runtime (2 worker threads). No client/server split, no HTTP API.
+- State management follows the **Elm Architecture** (`src/ui/state/`):
+  `AppState` is the single source of truth; `TypedScreen` is a type-safe
+  enum of all screens; `Message` is an exhaustive enum of all events; `update()`
+  is a pure function — all state mutations flow through it.
+- The Helix editor is simulated, never faked: all in-editor command
+  execution routes through `HelixSimulator`/`AnyModeSimulator`
+  (`src/helix/`), which wraps real `helix-core` (upstream tag 25.07.1).
+  Bespoke coordinate/string-diff shortcuts that bypass the simulator are
+  forbidden — this is the single most load-bearing invariant in the
+  codebase and is referenced by every feature spec that touches input.
+- Multi-key input sequences (counts, `g`/`z`/`m` leader keys, registers,
+  command-line mode) are modeled with the **typestate pattern**
+  (`src/input/typestate/`) — zero-sized marker structs plus
+  `InputStateMachine::process_key` dispatch. New pending-input states MUST
+  follow this pattern; no parallel/ad-hoc state-tracking mechanism is
+  permitted.
+- Background I/O (scenario loading, profile persistence) is spawned via
+  `data_loader::spawn_data_loaders` and communicates with `AppState`
+  exclusively over `mpsc::channel` messages — never by mutating shared
+  state from a background task directly.
+- Rendering (`src/ui/render/`) is pure: no side effects, no state
+  mutation, computed entirely from `AppState`.
+
+## II. Technology Stack
+
+- Language: Rust, MSRV per `Cargo.toml` `rust-version` (1.89 at time of
+  writing).
+- TUI: `ratatui` + `crossterm`.
+- Async runtime: `tokio` (2 worker threads).
+- Spaced repetition: `fsrs` crate, wrapped by `src/learning/`.
+- i18n: `rust-i18n` with compile-time codegen (`locales/`), invoked via
+  `rust_i18n::i18n!("locales", fallback = "en")` in `lib.rs`.
+- Optional audio: `rodio`, feature-gated behind `audio` (requires
+  `libasound2-dev` on Linux).
+- Config/scenario data: TOML (`scenarios/en/<category>/*.toml`), user
+  profile/config: JSON under `~/.config/helix-trainer/`.
+- YAML tooling (when needed): `fast-yaml` (`fy` CLI) exclusively — never
+  hand-edit YAML without validating via `fy` afterward.
+
+## III. Testing (NON-NEGOTIABLE)
+
+- Framework: `cargo nextest` (`cargo nextest run --workspace
+  --all-features --lib --bins`), plus `cargo test --doc` for doc-tests.
+- Every shipped scenario TOML file must pass `cargo nextest run scenario`
+  (validates via `tests/scenario_validation.rs` that the declared
+  `solution.commands` actually completes the scenario through
+  `HelixSimulator`).
+- **Property-based testing** (`proptest`, declared in `[dev-dependencies]`)
+  is the required tool for deterministic-given-fixed-inputs logic — FSRS
+  scheduling invariants, difficulty-controller selection determinism. Any
+  declared-but-unused test dependency is a defect, not a neutral state (see
+  `specs/fsrs-proptest-coverage-gap/`): if `proptest` is
+  declared, it must be exercised somewhere with a traceable invariant, or
+  removed together with any documentation claiming otherwise.
+- Property tests must be deterministic and reproducible: never read live
+  wall-clock time (`Utc::now()`) as a generator input or baseline inside a
+  proptest body — inject a fixed/fake clock so shrunk failures reproduce.
+- Colocate unit tests (including property tests) in `#[cfg(test)]` modules
+  within the module under test, unless the module grows large enough to
+  warrant a dedicated `_tests.rs`/`_proptest.rs` submodule.
+- Prefer regression tests with real dependencies (real `HelixSimulator`
+  execution, real `fsrs` state transitions) over mocks — this project has
+  no service boundaries to mock across.
+- Audio (`--features audio`) is compile-checked (`cargo check --features
+  audio`) but not executed in CI (no sound device); Windows-specific
+  `KeyEventKind::Release` filtering is a known regression class
+  (`fix/182`) and must stay covered.
+
+## IV. Code Style
+
+- Follow existing patterns in the codebase before introducing new ones —
+  check `src/minigame/`, `src/game/`, `src/input/typestate/` for the
+  established idiom (typestate, sealed traits, exhaustive `match`) before
+  adding a parallel mechanism.
+- `#![forbid(unsafe_code)]` is set in both `main.rs` and `lib.rs` and MUST
+  remain forbidden project-wide — no exceptions, no `#[allow(unsafe_code)]`
+  overrides.
+- Every `pub` type, trait, function, and method must have a `///` doc
+  comment explaining *what* and *why*, not merely restating the name;
+  non-trivial public APIs need a runnable `# Examples` doc-test.
+  Feature-gated items get `#[cfg_attr(docsrs, doc(cfg(...)))]`.
+- Do not add redundant comments — only explain cyclomatically or
+  cognitively complex blocks.
+- Follow DRY: search for existing implementations (Grep/Glob) and reuse
+  established patterns before writing new functionality.
+- For MVP-stage work: implement only the minimum necessary functionality,
+  no syntactic sugar, no premature abstraction or optimization. Before
+  v1.0.0, backward compatibility is not a constraint — prefer clean code
+  over deprecation shims; document breaking changes in `CHANGELOG.md`.
+- Non-exhaustive `match`/`matches!` wildcards (`_ => ...`) over an enum
+  that models a closed, growable set (e.g. `MiniGameMode`) are a defect
+  class this project has hit before (see
+  `specs/arcade-game-mode-variety/appendix-spinoffs.md`, Spin-off B) — new
+  code should match exhaustively over enum variants so adding a variant is
+  a compile error at every call site, not a silent runtime fallthrough.
+
+## V. Security
+
+- All user-facing input validation and error types route through
+  `src/security.rs` (`UserError`, `SecurityError`) — never panic on
+  malformed user input (invalid register names, malformed command-line
+  expressions, oversized input) and never silently no-op it either.
+- Never commit secrets, API keys, or credentials. This project has no
+  external services/API keys in scope today; if any are ever introduced,
+  they must go through the vault mechanism described in the user's global
+  tooling conventions, never `.env` files or shell profiles.
+- Bound untrusted input length explicitly (e.g. `security::limits::
+  MAX_COMMAND_LINE_LEN`) rather than relying on incidental limits.
+
+## VI. Performance
+
+- The animation/tick interval used by `event_loop::run_async_event_loop`
+  is the baseline for "perceptible lag" — any new per-frame or per-tick
+  logic must not introduce lag perceptible against that baseline.
+- No real-time, per-frame game loop exists today; `event_loop.rs` ticks
+  are predicate-polling (timeout checks, transition auto-advance), not a
+  dedicated session clock. Introducing one is an architectural decision
+  requiring explicit design, not an incidental addition.
+
+## VII. Simplicity
+
+- Prefer extending an existing enum variant / existing subsystem (e.g. a
+  new `MiniGameMode` variant, a new typestate pending-state) over
+  introducing a parallel top-level type that duplicates session/timer/
+  scoring/state-machine machinery already provided by `GameSession`/
+  `MiniGameSession`.
+- New dependencies require justification and must pass `cargo deny check`
+  with no new advisories.
+- Scope narrowing during implementation is acceptable and expected when
+  the full ambition of a draft spec proves disproportionate to its
+  priority/evidence (e.g. command-line mode shipped as `:goto`/`:g` only,
+  not full `:s` substitute) — retroactive specs must document the actual
+  shipped scope, not silently imply the original scope was fully met.
+
+## VIII. Git Workflow
+
+- Commit messages: [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/#specification)
+  per `.claude/rules/commits-and-issues.md` — `type(scope): imperative,
+  present-tense description`, no period, no AI/co-author mentions, no
+  emoji.
+- Branch naming per `.claude/rules/branching.md`: `feat/{issue}-{slug}`,
+  `fix/{issue}-{slug}`, `hotfix/{issue}-{slug}`, `chore/{slug}`.
+- All changes land via PR into `main`; sync with `main` via `git fetch
+  origin main && git rebase origin/main` before opening a PR.
+- Before every commit/push/PR: `cargo +nightly fmt --check`, `cargo
+  clippy --all-targets --all-features --workspace -- -D warnings`, `cargo
+  nextest run --workspace --all-features --lib --bins`, and the rustdoc
+  gate (`RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc
+  --no-deps`). If new/modified scenario TOML files are included, also run
+  `cargo nextest run scenario`.
+- Every GitHub issue carries exactly one `P0`-`P4` priority label plus up
+  to 4 classification labels, per `.claude/rules/commits-and-issues.md`.
+- `CHANGELOG.md` `[Unreleased]` section is updated at the end of every
+  implementation phase/PR.
+
+## See Also
+
+- [[MOC-specs]] — all specifications
+- `.claude/CLAUDE.md` — architecture reference this constitution formalizes
+- `.claude/rules/commits-and-issues.md` — commit/issue conventions
+- `.claude/rules/branching.md` — branch naming and pre-PR checklist
+- `.claude/rules/continuous-improvement.md` — subsystem map and testing notes

--- a/specs/fsrs-proptest-coverage-gap/BRD.md
+++ b/specs/fsrs-proptest-coverage-gap/BRD.md
@@ -1,0 +1,205 @@
+---
+aliases:
+  - FSRS Proptest Coverage BRD
+  - Issue 263 BRD
+tags:
+  - brd
+  - testing
+  - learning-scheduler
+  - status/implemented
+created: 2026-08-09
+project: "helix-trainer"
+status: implemented
+related:
+  - "[[spec]]"
+  - "[[SRS]]"
+  - "[[NFR]]"
+  - "[[plan]]"
+---
+
+# FSRS Scheduler Property-Based Test Coverage Gap: Business Requirements Document
+
+> [!abstract]
+> Records the business rationale for closing a documented testing-practice
+> gap — `proptest` declared but unused against the FSRS scheduler — and the
+> outcome after implementation. This is a retroactive record: written after
+> commit `33bdaa1` shipped, to document what was decided and what actually
+> landed against the original finding in [[spec]].
+
+## Executive Summary
+
+`.claude/rules/continuous-improvement.md` claimed FSRS scheduling used
+`proptest` for property-based coverage. It did not — `proptest` was declared
+in `Cargo.toml` but had zero real usages anywhere in the codebase. This
+finding (issue #263) was resolved by adding two property tests to
+`src/learning/performance.rs`, which in turn surfaced and fixed a live
+correctness bug. The companion module, `src/learning/scheduler.rs`, was left
+uncovered — the resolution is **partial**, not complete, relative to the
+original finding's full scope.
+
+## Problem Statement
+
+- **What problem existed?** A stated testing practice
+  ("use proptest for property-based coverage" of FSRS scheduling) had zero
+  backing implementation. `proptest = "1.11"` sat as dead weight in
+  `[dev-dependencies]`.
+- **Who was affected?** Maintainers and coding agents relying on
+  `.claude/rules/continuous-improvement.md` as ground truth for what safety
+  nets exist before proposing changes to `src/learning/`.
+- **Impact of not solving it**: false confidence in FSRS correctness beyond
+  what example-based tests actually verified; continued unused dependency
+  surface.
+
+## Decision
+
+> [!important] GO — Path (a): add coverage
+> The team chose to implement property-based coverage rather than remove the
+> dependency. Commit `33bdaa1` (2026-08-09) added two `proptest!` blocks to
+> `src/learning/performance.rs`, closing issue #263. It was bundled in the
+> same commit with an unrelated CI-hardening fix for issue #295 (root-CI
+> false-positive test, see [[plan#Bundled Unrelated Change]]).
+
+## What Was Implemented
+
+Two property tests were added to `src/learning/performance.rs`
+(`#[cfg(test)] mod tests`), both using a fixed clock so results are
+deterministic and reproducible:
+
+| Property | Invariant |
+|---|---|
+| `prop_fsrs_state_transition_is_deterministic` | Running an identical simulated review sequence twice against independently constructed `PerformanceTracker`s yields bit-identical `stability`, `difficulty`, `state`, `reps`, `lapses`, `scheduled_days`, `due`, and `retrievability` |
+| `prop_fsrs_state_stays_in_bounds` | After every simulated attempt in an arbitrary rating/duration/elapsed-day sequence: `difficulty ∈ [1.0, 10.0]`, `stability > 0.0`, `retrievability ∈ [0.0, 1.0]` |
+
+Both use `proptest`'s default configuration (256 cases; no explicit
+`ProptestConfig` override was added). Generators are inline tuple/range
+strategies over `(success: bool, duration_secs: 1..90, optimal_secs: 1..90,
+elapsed_days: 0..365)`, composed via `prop::collection::vec(.., 1..12)` or
+`1..20` attempts per case.
+
+## Bug Found By This Work
+
+Writing `prop_fsrs_state_stays_in_bounds` surfaced a real defect:
+`update_fsrs_state` was passing a hardcoded `-0.5` as the decay parameter to
+`fsrs::current_retrievability`, when the correct value is the raw positive
+`w[20]` FSRS weight (the crate negates it internally). The wrong sign
+produced NaN retrievability under some generated inputs, which `serde_json`
+serializes as `null`; the derived `Deserialize` on `CommandPerformance`
+therefore failed outright on load, meaning **an affected user's
+`profile.json` would become permanently unloadable**. Fixed in the same
+commit by reading `fsrs::DEFAULT_PARAMETERS[20]` instead of a hardcoded
+literal, plus a custom deserializer (`Option<f32>` → `unwrap_or(1.0)`) so any
+already-corrupted `null` value on disk self-heals on next load rather than
+hard-failing. This is exactly the class of regression the original finding
+argued property testing would catch that example-based tests would not.
+
+## Residual Gap
+
+> [!warning] Not Fully Resolved
+> `src/learning/scheduler.rs` (`Scheduler`, `ReviewItem` `Ord`/`PartialOrd`,
+> `get_due_reviews`, `get_review_queue`) received **zero** property-test
+> coverage from this commit — the diff to that file is empty. FR-004 and
+> FR-005 from [[spec]] remain unimplemented. The
+> `.claude/rules/continuous-improvement.md` claim, taken literally, is
+> therefore still not fully backed by implementation: it is now true for the
+> FSRS *state-transition* half of the scheduler subsystem, but not for the
+> *priority-queue/due-review-selection* half.
+
+This is recorded here rather than silently treated as fully resolved, per
+this project's convention that retroactive specs must document actual
+shipped scope, not the original ambition (see [[constitution#VII. Simplicity]]).
+
+## Target Users
+
+### Primary Users
+helix-trainer maintainers who need to trust FSRS scheduling correctness
+before shipping changes to `src/learning/`.
+
+### Secondary Users
+Coding agents (including future SDD pipeline runs) that read
+`.claude/rules/continuous-improvement.md` as ground truth.
+
+### Stakeholders
+Project maintainers balancing test-suite completeness against P4 priority
+(this was a process/coverage gap, not a user-facing defect, prior to the
+retrievability bug being found).
+
+## Functional Requirements
+
+See [[SRS]] for the full FR-001..007 list with per-requirement verdicts.
+Summary: FR-003 (determinism) fully satisfied; FR-001 (bounds) satisfied via
+a differently-scoped property than originally drafted; FR-002, FR-004, FR-005
+not implemented; FR-006 not applicable (path (a) was chosen, not (b));
+FR-007 (colocation convention) satisfied.
+
+## Non-Functional Requirements
+
+See [[NFR]] for NFR-001..004, all verified against the shipped tests.
+
+## Scope & Boundaries
+
+### In Scope (of what shipped)
+- Property-test coverage for `PerformanceTracker`/FSRS state-transition
+  determinism and bounds in `src/learning/performance.rs`
+- Fixing the retrievability sign bug and its `null`-deserialization
+  consequence, discovered via this work
+
+### Out of Scope (of what shipped, contrary to the original finding's ask)
+
+> [!danger] Explicit Gaps
+> - `src/learning/scheduler.rs` — `ReviewItem` ordering and due-review
+>   queue-bound property tests (FR-004, FR-005) were not implemented
+> - Due-date-not-earlier-than-review-timestamp property (FR-002) was not
+>   implemented as a standalone property test — the code comment added at
+>   the call site argues it is "correct by construction," which is an
+>   assertion, not a verified property
+> - `.claude/rules/continuous-improvement.md` was not reworded to scope the
+>   claim precisely to what is actually covered
+
+## Constraints & Assumptions
+
+### Technical Constraints
+Property tests must not read live wall-clock time (satisfied — both use a
+`FakeClock` fixed at `2030-01-01T00:00:00Z`).
+
+### Business Constraints
+P4 priority; this was addressed opportunistically alongside an unrelated
+CI-hardening commit rather than as a scheduled, standalone PR.
+
+### Assumptions
+
+> [!warning] Assumptions
+> - The residual `scheduler.rs` gap is assumed acceptable at current
+>   priority unless a future finding elevates it (e.g. a real scheduling bug
+>   that property testing would have caught)
+> - `proptest`'s default case count (256) is assumed sufficient for CI time
+>   budgets; no evidence of CI slowdown was found in the researched commit
+
+## Success Criteria
+
+See [[SRS#3.2 Success Criteria]] for the metric-by-metric actual outcome.
+
+## Open Questions
+
+> [!question] Unresolved Items
+> - [ ] Should `src/learning/scheduler.rs` property coverage (FR-004,
+>       FR-005) be filed as a follow-up P4 finding, given the residual gap
+>       documented above?
+> - [ ] Should `.claude/rules/continuous-improvement.md` be reworded now to
+>       avoid overclaiming coverage it does not have for `scheduler.rs`?
+
+## Glossary
+
+| Term | Definition |
+|------|-----------|
+| Path (a) / Path (b) | The two resolution options from the original finding: (a) add proptest coverage, (b) remove the unused dependency. Path (a) was chosen. |
+| `FakeClock` | Test helper providing a fixed, advanceable timestamp so time-dependent logic is deterministic under proptest |
+| Retrievability | FSRS-computed probability `[0.0, 1.0]` that a memory is still recallable at a given point in time |
+
+## See Also
+
+- [[spec]] — original problem statement and retroactive resolution summary
+- [[SRS]] — functional requirements, marked with implementation verdicts
+- [[NFR]] — non-functional requirements, verified against shipped tests
+- [[plan]] — as-built architecture, bundled unrelated change, residual work
+- [[tasks]] — retroactive task breakdown
+- [[constitution]] — project principles (testing standards, Section III)

--- a/specs/fsrs-proptest-coverage-gap/NFR.md
+++ b/specs/fsrs-proptest-coverage-gap/NFR.md
@@ -1,0 +1,113 @@
+---
+aliases:
+  - FSRS Proptest Coverage NFR
+  - Issue 263 NFR
+tags:
+  - nfr
+  - requirements/non-functional
+  - testing
+  - learning-scheduler
+  - status/implemented
+created: 2026-08-09
+project: "helix-trainer"
+status: implemented
+standard: "ISO/IEC 25010:2011"
+related:
+  - "[[BRD]]"
+  - "[[SRS]]"
+---
+
+# FSRS Scheduler Property-Based Test Coverage Gap: Non-Functional Requirements Specification
+
+> [!abstract]
+> Verifies NFR-001..004 from the draft spec against the property tests
+> actually shipped in commit `33bdaa1`.
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+Records the quality-attribute requirements attached to the FSRS proptest
+work and verifies each against the shipped implementation.
+
+### 1.2 Scope
+
+Four NFRs were drafted; this document does not add new ones. Sections of the
+ISO 25010 model not raised by the draft (Functional Suitability beyond what
+[[SRS]] covers, Compatibility, Portability) are omitted.
+
+> [!note] Not Applicable
+> Compatibility and Portability are omitted — this is test-only, in-process
+> code with no cross-system or cross-platform surface beyond what the rest
+> of the project already targets.
+
+### 1.3 Definitions
+
+| Term | Definition |
+|------|-----------|
+| `ProptestConfig` | proptest's per-test configuration struct, controlling case count, shrinking iterations, etc. |
+| Shrinking | proptest's automatic minimization of a failing generated input to the smallest reproducing counterexample |
+
+### 1.4 References
+
+- [[BRD]] — Business Requirements Document
+- [[SRS]] — Software Requirements Specification
+- ISO/IEC 25010:2011
+
+### 1.5 Priority and Trade-offs
+
+Maintainability (test coverage confidence) was prioritized over
+minimizing CI time; no `ProptestConfig` override was added, so both
+property blocks run at proptest's default 256 cases each. This was an
+implicit trade-off, not an explicitly documented one in the commit.
+
+## 2. Maintainability
+
+### 2.1 Testability
+
+| ID | Requirement | Target | Status |
+|----|------------|--------|--------|
+| NFR-001 | New property tests must run within CI time budgets; bound `ProptestConfig` case counts rather than leaving them unbounded | No `cargo nextest` slowdown attributable to the new tests | **Partially met.** No explicit `ProptestConfig` override was added — both blocks use the implicit default (256 cases). This satisfies "runs within CI budgets" in practice (no evidence of slowdown found), but does not satisfy the letter of "bound... rather than leaving them unbounded" as an explicit, intentional choice. |
+| NFR-002 | Property test invariants must be traceable back to the specific FSRS/scheduler behavior they verify, via doc comments referencing this spec | Each property documented with rationale | **Met for the two properties that exist** — `prop_fsrs_state_transition_is_deterministic` and `prop_fsrs_state_stays_in_bounds` carry doc comments explaining the invariant. **Not applicable** to FR-002/004/005, which were never implemented, so there is nothing to trace for those. |
+
+## 3. Reliability
+
+### 3.1 Determinism (originally scoped under Maintainability as NFR-003)
+
+| ID | Requirement | Target | Status |
+|----|------------|--------|--------|
+| NFR-003 | Property tests must not read live wall-clock time; any time baseline must be injected/fixed so shrunk failures reproduce deterministically | No `Utc::now()` calls inside property test bodies | **Met.** Both property tests use `FakeClock::at("2030-01-01T00:00:00Z")` plus `clock.advance_days(elapsed_days)` rather than live time. |
+
+## 4. Maintainability (continued)
+
+### 4.1 Dependency Hygiene
+
+| ID | Requirement | Target | Status |
+|----|------------|--------|--------|
+| NFR-004 | `cargo deny check` must pass afterward with no new advisories or license issues, regardless of resolution path chosen | Clean `cargo deny check` | **Met** — no new dependency was introduced; `proptest = "1.11"` was already declared and audited. |
+
+## 5. Verification Matrix
+
+| ID | Method | Environment | Status |
+|----|--------|-------------|--------|
+| NFR-001 | Manual review of `ProptestConfig` usage; CI timing observation | CI | Implicit default in use; no measured regression found, but not an explicit bound |
+| NFR-002 | Doc-comment review on the two shipped properties | Local | Pass for the 2 that exist |
+| NFR-003 | Code inspection for `Utc::now()`/live-clock reads inside `proptest!` bodies | Local | Pass — `FakeClock` used throughout |
+| NFR-004 | `cargo deny check` | CI | Pass |
+
+## 6. Open Questions
+
+> [!question] Unresolved Quality Requirements
+> - [ ] Should an explicit `ProptestConfig { cases: N, .. }` be added to both
+>       property tests now, to convert NFR-001 from "implicitly fine" to
+>       "explicitly bounded," per the letter of the original requirement?
+> - [ ] If `scheduler.rs` coverage is added as a follow-up (see
+>       [[BRD#Residual Gap]]), should NFR-001..004 be re-verified against
+>       those new tests specifically, or are they assumed to inherit the
+>       same conventions established here?
+
+## See Also
+
+- [[BRD]] — business rationale (source)
+- [[SRS]] — functional requirements and verdicts
+- [[spec]] — original problem statement

--- a/specs/fsrs-proptest-coverage-gap/README.md
+++ b/specs/fsrs-proptest-coverage-gap/README.md
@@ -1,0 +1,80 @@
+---
+aliases:
+  - FSRS Proptest Coverage — Retroactive Record
+  - Issue 263 Retroactive Record
+tags:
+  - sdd
+  - decision-record
+  - testing
+  - learning-scheduler
+  - status/implemented
+created: 2026-08-09
+status: implemented
+related:
+  - "[[BRD]]"
+  - "[[SRS]]"
+  - "[[NFR]]"
+  - "[[spec]]"
+  - "[[plan]]"
+  - "[[tasks]]"
+---
+
+# Retroactive Record: FSRS Scheduler Property-Based Test Coverage Gap (GitHub Issue #263)
+
+> [!important] Status: IMPLEMENTED (partial scope)
+> This package documents work that already shipped in commit `33bdaa1`
+> before this SDD package was written. It is retroactive: the pipeline was
+> run backward from the merged code to reconstruct requirements,
+> verification, and residual gaps — not forward from spec to implementation.
+
+## What This Package Is
+
+A full BRD → SRS → NFR → spec → plan → tasks pipeline, run against a
+continuous-improvement finding (issue #263: `proptest` declared but unused
+against FSRS scheduling logic), documented after the fact against what
+commit `33bdaa1` actually implemented.
+
+## Headline Finding
+
+`.claude/rules/continuous-improvement.md` claimed proptest coverage for FSRS
+scheduling. It had none. Commit `33bdaa1` added two property tests to
+`src/learning/performance.rs` (state-transition determinism and bounds
+invariants), which in the process **found and fixed a real bug**: a
+hardcoded decay sign error that produced NaN retrievability under some
+inputs, which serialized as JSON `null` and made the affected user's
+`profile.json` permanently unloadable. A self-healing deserializer was added
+alongside the fix.
+
+**The resolution is partial.** `src/learning/scheduler.rs` — the other half
+of the original finding's scope (`ReviewItem` ordering, due-review queue
+selection) — received zero property-test coverage. See
+[[BRD#Residual Gap]] and [[plan#Residual Work]].
+
+## Traceability
+
+| Finding | SRS Impact | NFR Status | Outcome |
+|---|---|---|---|
+| Proptest declared, unused, in `Cargo.toml` | FR-003 (determinism) fully met; FR-001 (bounds) met via a differently-scoped property | NFR-001 (case-count bounding) partially met — implicit default, not explicit; NFR-003 (determinism of the tests themselves) fully met | 2 property tests shipped in `performance.rs` |
+| Real bug surfaced by the bounds property | N/A — not a drafted requirement | N/A | Sign-error fix + self-healing deserializer + regression test |
+| `scheduler.rs` half of the original scope | FR-002, FR-004, FR-005 not implemented | N/A | Documented as residual work, not scheduled |
+
+## Package Contents
+
+- [[BRD]] — business rationale, decision (path (a): add coverage), and the
+  residual gap
+- [[SRS]] — FR-001..007 marked with actual implementation verdicts
+- [[NFR]] — NFR-001..004 verified against the shipped tests
+- [[spec]] — original problem statement plus a retroactive resolution
+  summary
+- [[plan]] — as-built architecture, bundled unrelated CI-hardening change,
+  and recommended follow-up scope
+- [[tasks]] — retroactive task breakdown (T001-T003 completed, T004
+  recommended but not scheduled)
+
+## See Also
+
+- `specs/MOC-specs.md` — specifications index
+- [[constitution]] — project principles, Section III (Testing)
+- `src/learning/performance.rs` — covered
+- `src/learning/scheduler.rs` — uncovered, see Residual Work
+- `.claude/rules/continuous-improvement.md` — source of the original claim, still not fully accurate

--- a/specs/fsrs-proptest-coverage-gap/SRS.md
+++ b/specs/fsrs-proptest-coverage-gap/SRS.md
@@ -1,0 +1,239 @@
+---
+aliases:
+  - FSRS Proptest Coverage SRS
+  - Issue 263 SRS
+tags:
+  - srs
+  - requirements/functional
+  - testing
+  - learning-scheduler
+  - status/implemented
+created: 2026-08-09
+project: "helix-trainer"
+status: implemented
+standard: "ISO/IEC/IEEE 29148:2018"
+related:
+  - "[[BRD]]"
+  - "[[NFR]]"
+---
+
+# FSRS Scheduler Property-Based Test Coverage Gap: Software Requirements Specification
+
+> [!abstract]
+> Functional requirements as originally drafted for issue #263, each marked
+> against the actual implementation in commit `33bdaa1`. Traceable to
+> [[BRD]].
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+Records the functional requirements originally drafted for FSRS
+property-test coverage and evaluates each against what commit `33bdaa1`
+actually shipped, so a future reader can see precisely what is verified,
+what is not, and why.
+
+### 1.2 Scope
+
+Covers property-based test coverage of `src/learning/scheduler.rs` and
+`src/learning/performance.rs` only. Does not cover the `fsrs` crate's
+internal algorithm, nor the unrelated CI-hardening fix bundled in the same
+commit (documented in [[plan#Bundled Unrelated Change]] for completeness).
+
+### 1.3 Definitions, Acronyms, and Abbreviations
+
+| Term | Definition |
+|------|-----------|
+| `Scheduler` | Due-review priority queue and selection logic, `src/learning/scheduler.rs` |
+| `ReviewItem` | Priority-queue entry for a due review, `src/learning/scheduler.rs` |
+| `PerformanceTracker` | Per-command FSRS-derived performance record manager, `src/learning/performance.rs` |
+| `CardState` | Application-managed lifecycle state of a practiced command |
+| `FakeClock` | Test-only fixed/advanceable clock used to keep property tests deterministic |
+| `proptest!` | The `proptest` crate's macro for declaring a property-based test |
+
+### 1.4 References
+
+- [[BRD]] — Business Requirements Document
+- [[NFR]] — Non-Functional Requirements Specification
+- `.claude/rules/continuous-improvement.md` — source of the original claim
+
+### 1.5 Document Overview
+
+Section 3 lists FR-001 through FR-007 as drafted, each with an
+implementation verdict and evidence. Section 4 is the verification matrix
+against the actual shipped tests.
+
+## 2. Overall Description
+
+### 2.1 Product Perspective
+
+`src/learning/` is the FSRS spaced-repetition subsystem of the single-binary
+helix-trainer TUI. This work added test coverage only — no new
+user-observable functionality.
+
+### 2.2 Product Functions
+
+No new functional area. One correctness bug (retrievability sign error) was
+found and fixed as a byproduct — see [[BRD#Bug Found By This Work]].
+
+### 2.3 User Classes and Characteristics
+
+Unchanged from [[BRD#Target Users]].
+
+### 2.4 Operating Environment
+
+Unchanged — CI via `cargo nextest run --workspace --all-features --lib --bins`.
+
+### 2.5 Design and Implementation Constraints
+
+Property tests must not read live wall-clock time (NFR-003).
+
+### 2.6 Assumptions and Dependencies
+
+See [[BRD#Assumptions]].
+
+## 3. Specific Requirements
+
+### 3.1 Functional Requirements — Verdict
+
+> [!info] Traceability
+> Traces to the draft spec's Functional Requirements section ([[spec#3. Functional Requirements]]).
+
+**FR-001** — WHEN a property test runs the FSRS review-state transition
+across arbitrary valid `(stability, difficulty, elapsed_days, rating)`
+inputs THE SYSTEM SHALL assert that resulting `stability` and `difficulty`
+values remain non-negative and finite.
+
+- *Priority*: must
+- *Verdict*: **Implemented differently.** No test isolates the four raw
+  parameters directly. Instead, `prop_fsrs_state_stays_in_bounds`
+  (`src/learning/performance.rs`) drives the invariant end-to-end through
+  `PerformanceTracker::record_attempt` over arbitrary rating/duration/
+  elapsed-day sequences, asserting `difficulty ∈ [1.0, 10.0]` and
+  `stability > 0.0`. There is no explicit NaN/Inf assertion, but the sign
+  bug that was the concrete source of NaN values in practice was fixed in
+  the same commit.
+
+**FR-002** — WHEN a property test computes a due date from a review event
+with an arbitrary valid interval THE SYSTEM SHALL assert the computed due
+date is not earlier than the review timestamp it was derived from.
+
+- *Priority*: must
+- *Verdict*: **Not implemented.** No proptest asserts `due >= review_time`.
+  A code comment near the due-date computation argues it is "correct by
+  construction" (`due = last_review + scheduled_days`, both non-negative by
+  type), used as the rationale for omitting the property.
+
+**FR-003** — WHEN a property test feeds an identical sequence of review
+ratings into two independently constructed tracker instances THE SYSTEM
+SHALL assert both converge to bitwise-identical resulting state.
+
+- *Priority*: must
+- *Verdict*: **Fully implemented.**
+  `prop_fsrs_state_transition_is_deterministic` runs the same simulated
+  sequence twice via a `run()` closure and asserts equality of `stability`,
+  `difficulty`, `state`, `reps`, `lapses`, `scheduled_days`, `due`, and
+  `retrievability`.
+
+**FR-004** — WHEN a property test generates arbitrary `ReviewItem` values
+(including edge-case `priority` floats) and compares them via `Ord`/
+`PartialOrd` THE SYSTEM SHALL assert the ordering is total, transitive, and
+consistent with `BinaryHeap`'s max-heap contract.
+
+- *Priority*: must
+- *Verdict*: **Not implemented.** `src/learning/scheduler.rs` was not
+  touched by commit `33bdaa1` (confirmed: empty diff against that file).
+  `ReviewItem::Ord` already uses `total_cmp` (pre-existing code) but has
+  zero property-test coverage.
+
+**FR-005** — WHEN a property test runs `Scheduler::get_due_reviews`/
+`get_review_queue` with an arbitrarily generated set of tracked commands
+THE SYSTEM SHALL assert only commands with `due <= now` are returned, and
+the queue never exceeds its requested size limit.
+
+- *Priority*: must
+- *Verdict*: **Not implemented.** Same as FR-004 — `scheduler.rs` untouched.
+
+**FR-006** — IF resolution path (b) — removal — is selected THEN THE SYSTEM
+SHALL remove `proptest`, clean up the TODO, and update the documentation
+claim.
+
+- *Priority*: must
+- *Verdict*: **Not applicable.** Path (a) was chosen.
+
+**FR-007** — WHERE new property tests are added THE SYSTEM SHALL colocate
+them in `#[cfg(test)]` modules within `scheduler.rs`/`performance.rs` (or a
+dedicated submodule).
+
+- *Priority*: should
+- *Verdict*: **Implemented (scope-limited).** New tests live in the existing
+  `#[cfg(test)] mod tests` in `src/learning/performance.rs` — colocated, no
+  new submodule needed. Not applicable to `scheduler.rs` since no coverage
+  was added there.
+
+**Net**: 2 of 5 "must" FRs fully/adequately satisfied (FR-001 partially/
+differently, FR-003 fully); FR-002, FR-004, FR-005 not implemented. FR-007
+satisfied. The commit resolved the *state-transition* half of the original
+finding's scope but left the *priority-queue/due-selection* half completely
+uncovered.
+
+### 3.2 Success Criteria
+
+| ID | Metric | Verdict |
+|----|--------|---------|
+| SC-001 | `rg -n "proptest!"` matches in `src/learning/` | **Met** — 1 module (`performance.rs`), 2 `proptest!` blocks |
+| SC-002 | FR-001..005 implemented as passing property tests, 5/5 | **Partially met** — 2/5 (see FR verdicts above) |
+| SC-003 | `cargo nextest run --workspace --all-features --lib --bins` passes, no flakes | **Met** |
+| SC-004 | continuous-improvement.md claim never contradicted by codebase state | **Not fully met** — see [[BRD#Residual Gap]] |
+| SC-005 | `cargo deny check` passes, no new advisories | **Met** — no new dependency was added |
+
+### 3.3 Logical Data Requirements
+
+No new persistent entities. Existing types exercised by the new property
+tests:
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `CardState` | Application-managed lifecycle state of a practiced command | `New`, `Learning`, `Review`, `Relearning` |
+| Tracked command performance record | Per-command FSRS-derived state | `stability`, `difficulty`, `state`, `retrievability`, `reps`, `lapses`, `scheduled_days`, `due` |
+| `ReviewItem` (uncovered) | Priority-queue entry for due reviews (`src/learning/scheduler.rs`) | `id`, `due`, `priority` |
+
+## 4. Verification and Validation
+
+### 4.1 Verification Matrix
+
+| Requirement | Method | Criteria | Status |
+|------------|--------|----------|--------|
+| FR-001 | `prop_fsrs_state_stays_in_bounds` | `difficulty ∈ [1,10]`, `stability > 0`, `retrievability ∈ [0,1]` after every attempt | **Pass, scoped narrower than drafted (no explicit NaN/Inf assertion)** |
+| FR-002 | — | Due date `>= review_time` | **Not run — no test exists** |
+| FR-003 | `prop_fsrs_state_transition_is_deterministic` | Two independent trackers converge to identical state given identical input | **Pass** |
+| FR-004 | — | `ReviewItem` total/transitive `Ord`, no panics | **Not run — no test exists** |
+| FR-005 | — | `get_due_reviews`/`get_review_queue` bounds correctness | **Not run — no test exists** |
+| FR-006 | N/A | N/A | **Not applicable** |
+| FR-007 | Code review | Colocated in `#[cfg(test)]` | **Pass** |
+
+### 4.2 Acceptance Test Outline
+
+`cargo nextest run --workspace --all-features --lib --bins` runs both new
+`proptest!` blocks (default 256 cases each) as part of the standard suite —
+no separate invocation required. A regression test,
+`test_deserialize_null_retrievability_recovers_as_one`, was added alongside
+to lock in the self-healing behavior for already-corrupted `profile.json`
+data from the sign bug found during this work.
+
+## 5. Appendices
+
+### 5.1 Traceability Matrix
+
+| BRD Section | SRS Requirement(s) | NFR Requirement(s) |
+|----------------|--------------------|--------------------|
+| [[BRD#What Was Implemented]] | FR-001 (differently-scoped), FR-003 (full), FR-007 | NFR-001, NFR-003 (met) |
+| [[BRD#Residual Gap]] | FR-002, FR-004, FR-005 (not implemented) | NFR-002 (partially met — invariants that exist are traceable; the missing ones are not documented as deferred in-code) |
+| [[BRD#Bug Found By This Work]] | N/A — discovered via FR-001's property, not a drafted requirement | N/A |
+
+## See Also
+
+- [[BRD]] — business rationale, decision, and residual gap (source)
+- [[NFR]] — non-functional requirements
+- [[plan]] — as-built architecture and residual-work recommendation
+- [[spec]] — original problem statement

--- a/specs/fsrs-proptest-coverage-gap/plan.md
+++ b/specs/fsrs-proptest-coverage-gap/plan.md
@@ -1,0 +1,183 @@
+---
+aliases:
+  - FSRS Proptest Coverage Plan
+tags:
+  - sdd
+  - plan
+  - testing
+  - learning-scheduler
+  - status/implemented
+created: 2026-08-09
+status: implemented
+related:
+  - "[[spec]]"
+  - "[[BRD]]"
+  - "[[constitution]]"
+---
+
+# Technical Plan: FSRS Scheduler Property-Based Test Coverage Gap (As-Built)
+
+> [!info] References
+> **Spec**: [[spec]]
+> This document is retroactive — it describes the architecture and testing
+> approach actually implemented in commit `33bdaa1`, plus the residual work
+> a future PR would need to complete the original finding's full scope.
+
+## 1. Architecture
+
+### Approach
+
+No production architecture changed — this is test-only work confined to
+`src/learning/performance.rs`'s existing `#[cfg(test)] mod tests` module.
+Two `proptest!` blocks were added using inline tuple/range strategies
+(no `prop_compose!` macros), driving the same public API
+(`PerformanceTracker::record_attempt`) that existing example-based tests
+already exercise — chosen over testing internal transition functions
+directly, so the properties verify the same surface real callers use.
+
+### Component Diagram
+
+```mermaid
+graph TD
+    A[proptest strategy: attempt_strategy] --> B[PerformanceTracker::record_attempt]
+    B --> C[FSRS MemoryState transition via fsrs crate]
+    C --> D[CardState + stability/difficulty/retrievability]
+    D --> E1[prop_fsrs_state_transition_is_deterministic]
+    D --> E2[prop_fsrs_state_stays_in_bounds]
+    F[scheduler.rs: ReviewItem Ord, get_due_reviews] -.uncovered.-> G[No property test]
+```
+
+### Key Design Decisions
+
+| Decision | Choice | Rationale | Alternatives Considered |
+|----------|--------|-----------|------------------------|
+| Where to add coverage | `performance.rs` only, not `scheduler.rs` | Unclear from the commit; the residual gap is not explained in the commit message or CHANGELOG | Full FR-001..005 coverage across both files, as originally drafted |
+| Test surface | Public API (`record_attempt`) rather than internal transition function | Matches existing example-based test style in the same file; verifies the same contract callers depend on | Testing `update_fsrs_state`/internal transition helper directly |
+| Clock handling | `FakeClock` fixed baseline + `advance_days` | Satisfies NFR-003 (determinism); consistent with existing test infrastructure in the module | Reading real `Utc::now()` (rejected — non-deterministic shrinking) |
+| Case count | proptest default (256), no `ProptestConfig` override | Simplicity; no evidence CI time was a concern at review time | Explicit lower bound e.g. `cases = 64` for faster CI |
+
+## 2. Project Structure
+
+```
+src/learning/
+├── performance.rs      # PerformanceTracker, CardState — 2 new proptest! blocks
+│                        # added to existing #[cfg(test)] mod tests
+│                        # + custom deserializer for retrievability self-heal
+└── scheduler.rs         # Scheduler, ReviewItem — UNCHANGED, still uncovered
+```
+
+## 3. Data Model
+
+No new types. The bug fix added a custom deserializer for one existing field:
+
+```rust
+// src/learning/performance.rs (illustrative, as-built)
+fn deserialize_retrievability<'de, D>(deserializer: D) -> Result<f32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let opt: Option<f32> = Option::deserialize(deserializer)?;
+    Ok(opt.unwrap_or(1.0))
+}
+```
+
+Applied via `#[serde(deserialize_with = "deserialize_retrievability")]` on
+the `retrievability` field, so a previously-corrupted `null` value in an
+existing `profile.json` self-heals to `1.0` on next load instead of failing
+deserialization outright.
+
+### Migrations
+
+None — JSON persistence is schema-less at the file level; the deserializer
+change is backward-compatible with both old (`null`-corrupted) and new
+(valid float) profile files.
+
+## 4. API Design
+
+Not applicable — no new public API; both `proptest!` blocks are
+`#[cfg(test)]`-only.
+
+## 5. Integration Points
+
+None — self-contained within `src/learning/performance.rs`'s test module.
+
+## 6. Security
+
+No change to `src/security.rs`. Not applicable.
+
+## 7. Testing Strategy
+
+| Level | Framework | What Is Tested | Coverage |
+|-------|-----------|-----------------|----------|
+| Property | `proptest` (default config, 256 cases) | FSRS state-transition determinism (`prop_fsrs_state_transition_is_deterministic`); FSRS bounds invariants (`prop_fsrs_state_stays_in_bounds`) | `performance.rs` only |
+| Regression (example-based) | `#[test]` | `test_deserialize_null_retrievability_recovers_as_one` — locks in the self-heal behavior for the discovered bug | `performance.rs` |
+| **Gap** | — | `ReviewItem` `Ord`/`PartialOrd` total-order property (FR-004); `get_due_reviews`/`get_review_queue` bounds property (FR-005); due-date-not-earlier-than-review property (FR-002) | **None — `scheduler.rs` untested by proptest** |
+
+## 8. Performance Considerations
+
+Two property blocks at 256 cases each add a small, bounded amount of CI
+time; no explicit measurement was captured in the researched commit. If
+`scheduler.rs` coverage is added later, the same default-config approach
+should be re-evaluated against actual CI wall-clock impact before assuming
+it is free.
+
+## 9. Rollout Plan
+
+Already shipped as part of commit `33bdaa1` (2026-08-09), merged via PR
+#330. No feature flag or phased rollout — test-only change, immediately
+active in CI on merge.
+
+## 10. Constitution Compliance
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| III. Testing — proptest required for deterministic-given-fixed-inputs logic, if declared | Partially compliant | `performance.rs` now compliant; `scheduler.rs` (same subsystem, same "deterministic given fixed inputs" characterization) is not — see Residual Work below |
+| III. Testing — no live wall-clock in property tests | Compliant | `FakeClock` used throughout |
+| III. Testing — colocated `#[cfg(test)]` modules | Compliant | No new submodule introduced |
+| VIII. Git Workflow — full check suite before commit | Assumed compliant (not independently re-verified as part of this retroactive plan) | — |
+
+## 11. Residual Work
+
+> [!warning] Recommended Follow-up (Not Yet Scheduled)
+> To fully close the original finding's scope, a follow-up would need to add
+> `proptest!` coverage to `src/learning/scheduler.rs` for:
+> 1. `ReviewItem`'s `Ord`/`PartialOrd` — total order, transitivity, no panic
+>    on `NaN`-adjacent `priority` values (FR-004)
+> 2. `Scheduler::get_due_reviews`/`get_review_queue` — only `due <= now`
+>    items returned, queue never exceeds its size limit (FR-005)
+> 3. Optionally, a standalone due-date-not-earlier-than-review-timestamp
+>    property in `performance.rs` (FR-002), even though the "correct by
+>    construction" argument is plausible, to make the guarantee verified
+>    rather than asserted
+>
+> This residual gap should be filed as its own finding/spec if pursued,
+> rather than silently assumed closed by this record.
+
+## 12. Bundled Unrelated Change
+
+Commit `33bdaa1` also contains an unrelated CI-hardening fix (issue #295,
+`src/gamification/storage.rs`, test-only): the previous approach to
+simulating a save failure (`chmod 0555` on the temp directory) silently
+no-ops under a root CI runner, since root ignores permission bits — making
+`test_failed_save_does_not_corrupt_existing_profile` a false-positive pass.
+The fix instead pre-creates a directory at the exact temp-file path
+`ProfileStorage::save` will next use (predictable from `std::process::id()`
++ a suffix counter), so `fs::File::create` deterministically fails
+regardless of privilege level. This is noted here for completeness since it
+shares a commit with the FSRS work, but it is not part of this finding's
+scope and required no separate spec.
+
+## 13. Risks and Mitigations
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|-------------|------------|
+| A future reader assumes `.claude/rules/continuous-improvement.md`'s proptest claim is fully backed, given this record exists | Wasted effort assuming `scheduler.rs` safety net exists when it does not | Medium | [[BRD#Residual Gap]] and this section's Residual Work explicitly flag the gap |
+| `scheduler.rs` ships a real ordering/queue-bound bug that proptest would have caught | Incorrect due-review selection reaching users | Low-Medium | Residual Work item recommends follow-up coverage |
+
+## See Also
+
+- [[spec]] — original problem statement
+- [[BRD]] — business rationale and residual gap
+- [[SRS]] — FR-by-FR verdict
+- [[tasks]] — retroactive task breakdown
+- [[constitution]] — project principles, Section III (Testing)

--- a/specs/fsrs-proptest-coverage-gap/spec.md
+++ b/specs/fsrs-proptest-coverage-gap/spec.md
@@ -1,0 +1,221 @@
+---
+aliases:
+  - FSRS Proptest Coverage Gap
+  - Proptest Dead Dependency Finding
+tags:
+  - sdd
+  - spec
+  - research
+  - testing
+  - learning-scheduler
+  - status/implemented
+created: 2026-08-08
+status: implemented
+related:
+  - "[[constitution]]"
+  - "[[BRD]]"
+  - "[[SRS]]"
+  - "[[NFR]]"
+  - "[[plan]]"
+  - "[[tasks]]"
+  - "[[MOC-specs]]"
+---
+
+# Feature: FSRS Scheduler Property-Based Test Coverage Gap
+
+> [!info] Metadata
+> **Author**: rust-ci-analyst (continuous-improvement finding)
+> **Resolved by**: commit `33bdaa1` — "test: harden root-CI failure injection and
+> add FSRS proptest coverage (#330)", closing issue #263
+> **Priority**: P4
+> **Finding type**: research (process/testing gap)
+> **Status**: Implemented, partial scope — see [[SRS]] for the FR-by-FR verdict.
+> This document is retroactive: it was drafted before implementation and is
+> preserved below as the original problem statement, with a Resolution
+> section appended describing what actually shipped.
+
+## 1. Overview
+
+### Problem Statement
+
+The project's own continuous-improvement guidance
+(`.claude/rules/continuous-improvement.md`) states: "FSRS scheduling is
+deterministic given fixed inputs — use proptest for property-based coverage."
+The workspace `Cargo.toml` declares `proptest = "1.11"` under
+`[dev-dependencies]` (line 45), signaling intent to use it.
+
+A codebase-wide search (`rg -n "proptest" --type rust -g '!target' .`) at the
+time this spec was drafted found only a single reference: a doc comment in
+`src/minigame/challenge.rs:160` reading "Consider adding proptest for
+comprehensive verification of deterministic..." There were zero `proptest!`
+macro invocations, zero property test modules, and zero actual usage anywhere
+in the codebase.
+
+FSRS scheduling logic lives in `src/learning/scheduler.rs` (`Scheduler`,
+`ReviewItem` priority/ordering) and `src/learning/performance.rs`
+(`CardState`, `PerformanceTracker`, FSRS `MemoryState` transitions via the
+`fsrs` crate). Both modules relied exclusively on example-based unit tests —
+exactly the kind of deterministic-given-fixed-inputs logic proptest is meant
+to cover.
+
+This was a real gap between documented/stated testing practice and actual
+test coverage: `proptest` was dead weight in `Cargo.toml`, and the FSRS
+scheduler carried less correctness confidence than the project's own
+documentation implied to future maintainers and coding agents relying on
+`.claude/rules/continuous-improvement.md` as ground truth.
+
+### Goal
+
+Either (a) `src/learning/scheduler.rs` and the FSRS-related state transitions
+in `src/learning/performance.rs` gain property-based test coverage using the
+declared `proptest` dependency, with invariants matching the documented
+practice, or (b) the `proptest` dependency is removed from `Cargo.toml` and
+the claim in `.claude/rules/continuous-improvement.md` is corrected — so that
+stated practice and actual coverage are consistent again.
+
+### Out of Scope
+
+- Rewriting or redesigning the FSRS algorithm itself (the `fsrs` crate
+  internals are third-party and not under test here — only this project's
+  usage/wrapping of it).
+- General test-suite refactoring outside `src/learning/` and
+  `src/minigame/challenge.rs`'s scenario-selection determinism.
+- Adding proptest coverage to unrelated deterministic subsystems unless
+  resolution path (a) is chosen and extended later.
+
+## 2. User Stories
+
+### US-001: Maintainer confidence in FSRS correctness
+AS A helix-trainer maintainer
+I WANT the FSRS scheduler's core invariants verified across a wide range of
+generated inputs, not just hand-picked examples
+SO THAT I can trust scheduling behavior holds under conditions not
+anticipated by example-based tests.
+
+**Acceptance criteria:**
+```
+GIVEN the FSRS scheduler module (src/learning/scheduler.rs and the FSRS
+      transition logic in src/learning/performance.rs)
+WHEN  a maintainer runs `cargo nextest run --workspace --all-features --lib --bins`
+THEN  property-based tests execute alongside example-based unit tests and
+      fail loudly (with a shrunk minimal counterexample) if a documented
+      invariant is violated
+```
+
+**Status**: partially satisfied — see [[SRS#3.1 Functional Requirements — Verdict]]. `performance.rs` is covered; `scheduler.rs` is not.
+
+### US-002: Documentation matches reality
+AS A contributor or coding agent reading `.claude/rules/continuous-improvement.md`
+I WANT the stated testing practice to accurately reflect what is actually
+implemented in the codebase
+SO THAT I do not make false assumptions about existing safety nets.
+
+**Status**: still not fully satisfied after resolution — see [[BRD#Residual Gap]].
+
+### US-003: Lean dependency surface
+AS A maintainer concerned with build time and supply-chain surface
+I WANT no declared dependency to sit unused in `Cargo.toml`
+SO THAT every dependency has a demonstrable purpose.
+
+**Status**: satisfied — path (a) was chosen; `proptest` is now genuinely exercised.
+
+## 3. Functional Requirements
+
+Use EARS notation. Prefix with FR-NNN. These requirements apply **only if
+resolution path (a) — add coverage — is selected**; FR-006 covers path (b).
+See [[SRS]] for the actual verdict of each.
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN a property test runs the FSRS review-state transition across arbitrary valid `(stability, difficulty, elapsed_days, rating)` inputs THE SYSTEM SHALL assert that resulting `stability` and `difficulty` values remain non-negative and finite | must |
+| FR-002 | WHEN a property test computes a due date from a review event with an arbitrary valid interval THE SYSTEM SHALL assert the computed due date is not earlier than the review timestamp it was derived from | must |
+| FR-003 | WHEN a property test feeds an identical sequence of review ratings into two independently constructed `PerformanceTracker`/card-state instances THE SYSTEM SHALL assert both instances converge to bitwise-identical resulting state | must |
+| FR-004 | WHEN a property test generates arbitrary `ReviewItem` values and compares them via `Ord`/`PartialOrd` THE SYSTEM SHALL assert the ordering is total, transitive, and consistent with `BinaryHeap`'s max-heap contract | must |
+| FR-005 | WHEN a property test runs `Scheduler::get_due_reviews`/`get_review_queue` with an arbitrarily generated set of tracked commands THE SYSTEM SHALL assert only commands with `due <= now` are returned as due, and the queue never exceeds its requested size limit | must |
+| FR-006 | IF resolution path (b) — removal — is selected THEN THE SYSTEM SHALL remove `proptest` from `Cargo.toml`, clean up the TODO, and update the continuous-improvement doc | must |
+| FR-007 | WHERE new property tests are added THE SYSTEM SHALL colocate them in `#[cfg(test)]` modules within `src/learning/scheduler.rs` and `src/learning/performance.rs` | should |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Maintainability | New property tests must run within CI time budgets; bound `proptest::ProptestConfig` case counts rather than leaving them unbounded |
+| NFR-002 | Consistency | Property test invariants must be traceable back to the specific FSRS/scheduler behavior they verify |
+| NFR-003 | Determinism | Property tests must not read live wall-clock time; any time baseline must be injected/fixed |
+| NFR-004 | Dependency hygiene | `cargo deny check` must pass afterward with no new advisories |
+
+## 5. Data Model
+
+No new persistent entities. See [[SRS#3.3 Logical Data Requirements]] for
+the existing types this finding concerns.
+
+## 6. Edge Cases and Error Handling
+
+See [[SRS#4.1 Verification Matrix]] for which of these are actually covered
+by a shipped property test.
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Property test generates `priority = NaN` for `ReviewItem` | Ordering must use `total_cmp` and must not panic |
+| Property test generates zero elapsed days between reviews | FSRS transition must not produce negative stability/difficulty or a due date earlier than "now" |
+| Property test generates an extremely large elapsed-days value | FSRS transition must remain finite, no overflow/NaN, no panic |
+| Empty tracked-command set passed to `Scheduler::get_due_reviews`/`get_review_queue` | Must return an empty result, not panic |
+
+## 7. Success Criteria
+
+| ID | Metric | Target | Actual |
+|----|--------|--------|--------|
+| SC-001 | `rg -n "proptest!"` matches in `src/learning/` | >= 1 module | 1 module (`performance.rs`), 2 property blocks |
+| SC-002 | FR-001..005 implemented as passing property tests | 5/5 | 2/5 (FR-001 partial/differently, FR-003 full; FR-002/004/005 not implemented) |
+| SC-003 | `cargo nextest run --workspace --all-features --lib --bins` passes with new property tests | 100% pass, no flakes | Met |
+| SC-004 | Consistency between continuous-improvement.md claim and codebase | Never contradicted | Not fully met — see [[BRD#Residual Gap]] |
+| SC-005 | `cargo deny check` after resolution | Passes, no new advisories | Met (no new dependency added) |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Run `cargo nextest run --workspace --all-features --lib --bins` after any change here
+- Follow the existing colocated `#[cfg(test)]` module convention
+- Use a fixed/fake clock, never live `Utc::now()`, inside any new property test
+
+### Ask First
+- Extending this coverage to `src/learning/scheduler.rs` (FR-004/FR-005 remain unimplemented — see [[plan#Residual Work]])
+- Modifying `.claude/rules/continuous-improvement.md` wording
+
+### Never
+- Silently delete existing example-based unit tests to "replace" them with property tests
+- Modify `fsrs` crate internals to work around behavior discovered during property testing
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: should `src/learning/scheduler.rs` (FR-004, FR-005 — `ReviewItem` ordering, `get_due_reviews`/`get_review_queue` bounds) receive property-test coverage as a follow-up, given it remains fully untested by this resolution? See [[BRD#Residual Gap]].]
+- [NEEDS CLARIFICATION: should `.claude/rules/continuous-improvement.md` be reworded now to scope the proptest claim to "FSRS state-transition logic in `src/learning/performance.rs`" specifically, until/unless `scheduler.rs` coverage is added?]
+
+## 10. Resolution (Retroactive)
+
+Implemented by commit `33bdaa1` (2026-08-09), closing issue #263, bundled
+with an unrelated CI-hardening fix (issue #295) in the same commit. Path (a)
+— add coverage — was chosen. Full FR-by-FR verdict, property-test inventory,
+and residual gap are in [[SRS]] and [[BRD]]. Summary: `performance.rs` (FSRS
+state-transition determinism and bounds) is now covered by two property
+tests; `scheduler.rs` (`ReviewItem` ordering, due-review queue bounds) was
+**not** touched and remains uncovered — see [[plan#Residual Work]] for the
+recommended follow-up scope.
+
+A real correctness bug (retrievability decay sign error, causing NaN →
+`null` → permanently unloadable `profile.json`) was found and fixed as a
+direct result of writing this property-test coverage — see
+[[BRD#Bug Found By This Work]].
+
+## 11. See Also
+
+- [[constitution]] — project principles
+- [[BRD]] — business rationale, decision, and residual gap
+- [[SRS]] — FR-by-FR verdict and property-test inventory
+- [[NFR]] — non-functional requirement verdicts
+- [[plan]] — as-built architecture and residual work
+- [[tasks]] — retroactive task breakdown
+- [[MOC-specs]] — all specifications
+- `src/learning/scheduler.rs` — `Scheduler`, `ReviewItem` (uncovered)
+- `src/learning/performance.rs` — `CardState`, `PerformanceTracker` (covered)
+- `.claude/rules/continuous-improvement.md` — source of the proptest claim

--- a/specs/fsrs-proptest-coverage-gap/tasks.md
+++ b/specs/fsrs-proptest-coverage-gap/tasks.md
@@ -1,0 +1,158 @@
+---
+aliases:
+  - FSRS Proptest Coverage Tasks
+tags:
+  - sdd
+  - tasks
+  - testing
+  - learning-scheduler
+  - status/implemented
+created: 2026-08-09
+status: implemented
+related:
+  - "[[spec]]"
+  - "[[plan]]"
+---
+
+# Implementation Tasks: FSRS Scheduler Property-Based Test Coverage Gap (Retroactive)
+
+> [!info] References
+> **Spec**: [[spec]]
+> **Plan**: [[plan]]
+> **Total tasks**: 3 completed (commit `33bdaa1`), 1 recommended follow-up
+> (not scheduled)
+>
+> This is a retroactive breakdown of work already merged, reconstructed from
+> the diff for traceability — not a forward-looking plan that was followed
+> during implementation.
+
+## Progress
+
+- [x] T001: Add FSRS state-transition determinism property test
+- [x] T002: Add FSRS bounds property test and fix the sign bug it found
+- [x] T003: Add regression test for `null`-retrievability self-heal
+- [ ] T004 (follow-up, not scheduled): Add `scheduler.rs` property coverage
+
+---
+
+## Dependency Graph
+
+```mermaid
+graph TD
+    T001[T001: determinism property] --> T002[T002: bounds property + bug fix]
+    T002 --> T003[T003: null-retrievability regression test]
+    T003 -.optional follow-up.-> T004[T004: scheduler.rs coverage]
+```
+
+---
+
+### T001: Add FSRS State-Transition Determinism Property Test
+
+**Context**: Establish that `PerformanceTracker::record_attempt` is
+deterministic for a given rating sequence and clock, closing part of the
+gap between `.claude/rules/continuous-improvement.md`'s claim and actual
+coverage.
+**Spec reference**: [[spec#FR-003]]
+**Acceptance criteria**:
+- [x] `prop_fsrs_state_transition_is_deterministic` added to
+      `src/learning/performance.rs`'s `#[cfg(test)] mod tests`
+- [x] Uses a fixed `FakeClock`, never live `Utc::now()`
+- [x] Asserts equality of `stability`, `difficulty`, `state`, `reps`,
+      `lapses`, `scheduled_days`, `due`, `retrievability` across two
+      independently constructed trackers given the same input sequence
+**Dependencies**: none
+**Files**: `src/learning/performance.rs`
+**Complexity**: low
+
+---
+
+### T002: Add FSRS Bounds Property Test (Found and Fixed a Real Bug)
+
+**Context**: Verify `stability`/`difficulty`/`retrievability` stay within
+their FSRS-defined valid domains across arbitrary generated attempt
+sequences. Running this property surfaced a real defect.
+**Spec reference**: [[spec#FR-001]]
+**Acceptance criteria**:
+- [x] `prop_fsrs_state_stays_in_bounds` added, asserting
+      `difficulty ∈ [1.0, 10.0]`, `stability > 0.0`,
+      `retrievability ∈ [0.0, 1.0]` after every simulated attempt
+- [x] Bug found: `update_fsrs_state` passed a hardcoded `-0.5` decay to
+      `fsrs::current_retrievability` instead of `fsrs::DEFAULT_PARAMETERS[20]`,
+      producing NaN retrievability under some generated inputs
+- [x] Fix: hoist `const FSRS_PARAMS: [f32; 21] = fsrs::DEFAULT_PARAMETERS;`
+      and read `FSRS_PARAMS[20]`, applied at both `FSRS::new()` call sites
+**Dependencies**: T001 (shares the fixed-clock test infrastructure)
+**Files**: `src/learning/performance.rs`
+**Complexity**: medium (bug diagnosis + fix, not just test authoring)
+
+---
+
+### T003: Add Regression Test for `null`-Retrievability Self-Heal
+
+**Context**: The NaN bug found in T002 meant any already-affected user's
+`profile.json` would have `retrievability: null` on disk and fail to
+deserialize entirely. A custom deserializer was added so such files
+self-heal instead of hard-failing; this task locks that behavior in.
+**Spec reference**: [[BRD#Bug Found By This Work]]
+**Acceptance criteria**:
+- [x] Custom `deserialize_retrievability` deserializer added
+      (`Option<f32>` → `unwrap_or(1.0)`)
+- [x] `test_deserialize_null_retrievability_recovers_as_one` added and
+      passing
+**Dependencies**: T002
+**Files**: `src/learning/performance.rs`
+**Complexity**: low
+
+---
+
+### T004 (Follow-up, Not Scheduled): Add `scheduler.rs` Property Coverage
+
+**Context**: `src/learning/scheduler.rs` (`ReviewItem` ordering,
+`get_due_reviews`/`get_review_queue`) remains completely uncovered by
+proptest, per [[plan#Residual Work]]. This task is recorded for
+traceability but was **not** part of commit `33bdaa1` and has no assigned
+owner or timeline.
+**Spec reference**: [[spec#FR-004]], [[spec#FR-005]]
+**Acceptance criteria**:
+- [ ] Property test asserting `ReviewItem`'s `Ord`/`PartialOrd` is total,
+      transitive, and panic-free across arbitrary `priority` values
+      including edge-case floats
+- [ ] Property test asserting `get_due_reviews`/`get_review_queue` only
+      return items with `due <= now` and never exceed the requested size
+      limit, across arbitrarily generated tracked-command sets
+- [ ] Both use a fixed clock, consistent with `performance.rs`'s convention
+**Dependencies**: none (independent of T001-T003; same subsystem)
+**Files**: `src/learning/scheduler.rs`
+**Complexity**: low-medium
+
+---
+
+## Implementation Notes
+
+### Order of execution
+T001 → T002 → T003 is the order reconstructed from the commit's internal
+logic (write the determinism property first since it reuses the simplest
+harness, then the bounds property which surfaced the bug, then the
+regression test locking in the fix). T004 is independent and can be
+picked up separately at any time.
+
+### Common patterns
+Follow `performance.rs`'s established pattern: inline tuple/range
+`proptest` strategies (no `prop_compose!` needed for this shape),
+`FakeClock` for determinism, colocated in the existing `#[cfg(test)] mod
+tests` block.
+
+### Gotchas
+- Do not read `Utc::now()` inside any new property test body — use
+  `FakeClock` per NFR-003.
+- If T004 is picked up, `ReviewItem`'s existing `total_cmp`-based `Ord`
+  should be property-tested as-is first before considering any redesign —
+  the pre-existing implementation is believed correct, coverage is the gap,
+  not the algorithm.
+
+## See Also
+
+- [[spec]] — feature specification (retroactive)
+- [[plan]] — as-built architecture and residual work
+- [[BRD]] — business rationale
+- [[MOC-specs]] — all specifications

--- a/specs/register-command-mode-support/BRD.md
+++ b/specs/register-command-mode-support/BRD.md
@@ -1,0 +1,216 @@
+---
+aliases:
+  - Register and Command-Line Mode BRD
+  - Issue 282 BRD
+tags:
+  - brd
+  - helix-simulator
+  - input-system
+  - status/implemented
+created: 2026-08-09
+project: "helix-trainer"
+status: implemented
+related:
+  - "[[spec]]"
+  - "[[SRS]]"
+  - "[[NFR]]"
+  - "[[plan]]"
+---
+
+# Named Register and Command-Line Mode Support: Business Requirements Document
+
+> [!abstract]
+> Records the business rationale for closing a competitive-parity gap
+> (named registers and command-line mode, absent from the simulator) and the
+> outcome after implementation. Retroactive: written after commit `1ba668d`
+> shipped.
+
+## Executive Summary
+
+A parity scan against [S-Sigdel/vimhjkl](https://github.com/S-Sigdel/vimhjkl)
+found helix-trainer had zero simulator support for two real, documented
+Helix features: named registers (`"<reg>`) and command-line mode (`:`).
+Commit `1ba668d` closed this gap for named registers essentially as
+originally scoped, and for command-line mode with a **deliberately narrowed
+scope**: only `:goto N` (line-number navigation, alias `:g N`) shipped — not
+`:s` substitute, `:g` global-with-subcommand, or ranges, which the original
+research spec had targeted as the minimum command-line capability.
+
+## Problem Statement
+
+- **What problem existed?** helix-trainer taught a strict subset of Helix's
+  real command surface: no multi-slot register workflow, and no reachable
+  command-line surface at all (`EditorMode` only had `NormalMode`/
+  `InsertMode`).
+- **Who was affected?** Learners practicing intermediate/advanced Helix
+  workflows who would encounter `"<reg>` and `:` in real Helix usage but
+  never see them drilled in the trainer.
+- **Impact of not solving it**: a persistent, named competitive-parity gap
+  against a reference project (vimhjkl) that already drills the equivalent
+  Vim concepts.
+
+## Decision
+
+> [!important] GO — implemented with explicit scope narrowing
+> Named registers were implemented essentially as drafted. Command-line
+> mode was implemented at minimum viable scope (`:goto`/`:g N` only) rather
+> than the `:s` substitute originally targeted as the feature's minimum bar.
+> This narrowing is documented explicitly in `docs/HELIX_KEYBINDINGS.md`
+> (a "❌ everything else" disclaimer row), not left implicit.
+
+## What Was Implemented
+
+### Named Registers
+
+- `RegisterFile` (`src/helix/simulator/register_file.rs`) — a
+  `HashMap<char, String>` keyed by register name, with a reserved unnamed
+  register (`'"'`) as the default slot.
+- `HelixSimulator`'s prior single `clipboard: Option<String>` field was
+  replaced by `registers: RegisterFile` — a rename/generalization, not an
+  additive parallel structure.
+- New input-typestate states: `RegisterPending` (after `"`),
+  `RegisterOpPending { register: char }` (after `"<reg>`), dispatching to a
+  new `src/input/typestate/handlers/register.rs`.
+- Scope: `y` (yank), `p`/`P` (paste after/before), and — beyond the original
+  draft — `R` (replace-with-yanked) all honor an active register selection.
+  Any other key cancels the pending register state (resolves the draft's
+  open question about scope-beyond-yank-paste).
+- Default/unnamed register behavior is unchanged: plain `y`/`p`/`P`/`R`
+  read/write the unnamed slot exactly as before.
+
+### Command-Line Mode
+
+- New input-typestate state `CommandLinePending { buffer: String }`
+  (`:` entry), dispatching to `src/input/typestate/handlers/command_line.rs`.
+- New `CommandLine` type with a single variant, `Goto(usize)`
+  (`src/helix/simulator/command_line.rs`).
+- Accepted input: `:` followed by digits (goto line N), or `:g N` /
+  `:goto N` as explicit aliases. Enter confirms and moves the cursor;
+  Escape cancels with no document mutation; malformed input (non-digit,
+  out-of-range) produces `UserError::CommandFailed`, intercepted at
+  Enter-time and converted to a cancel rather than propagated as an error —
+  explicitly to prevent an app-crashing failure mode found during review.
+- `docs/HELIX_KEYBINDINGS.md` was updated with an explicit scope
+  disclaimer: only `:goto`/`:g` is implemented; everything else in Helix's
+  real command-line surface (`:s`, `:g` global, `:w`, `:sort`, ranges,
+  `:normal`) is marked unimplemented.
+- `:clear-register` and `:sort` were evaluated and explicitly dropped per
+  the commit message as "not verifiable against the snapshot-based scenario
+  completion model" — a scoping rationale the original draft did not
+  anticipate needing.
+
+> [!warning] Architectural Deviation from the Draft
+> `EditorMode` (`src/helix/simulator/mode.rs`) was **not** extended with a
+> new `CommandMode` variant, contrary to FR-005/NFR-002 in [[spec]].
+> Command-line entry lives entirely in the input-typestate layer
+> (`CommandLinePending`), not in the simulator's mode type. See
+> [[SRS#FR-005]] and [[plan#Key Design Decisions]] for the practical
+> consequence of this deviation.
+
+## Target Users
+
+Unchanged from the original draft: learners practicing intermediate/
+advanced Helix workflows; content maintainers adding scenario coverage;
+project maintainers evaluating parity against reference training projects.
+
+## Functional Requirements
+
+See [[SRS]] for the full FR-001..010 list with per-requirement verdicts.
+Summary: FR-001..004 (registers) satisfied as drafted or better (`R`
+added); FR-005 (command-line mode as an `EditorMode` variant) implemented
+differently (input-typestate only); FR-006 (`:s` substitute) **not
+satisfied — not implemented at all**; FR-007, FR-008, FR-009 satisfied;
+FR-010 satisfied via a different mechanism (`normalize_command_id`, not a
+`src/learning/` mapping table change).
+
+## Non-Functional Requirements
+
+See [[NFR]] for NFR-001..007, most satisfied; NFR-002 (command-line as an
+`EditorMode` variant) not satisfied per the architectural deviation above.
+
+## Scope & Boundaries
+
+### In Scope (of what shipped)
+- Named registers: select, yank, paste (after/before), replace
+- Command-line mode: goto-line navigation only (`:N`, `:goto N`, `:g N`)
+- New scenario categories: `scenarios/en/registers/` and a command-line goto
+  scenario under `scenarios/en/movement/`
+- `normalize_command_id()` for FSRS/quest command-taught tracking
+- Defensive hardening bundled in: Esc now cancels pending register/
+  command-line state in arcade mode; unmapped Alt/Ctrl keys no longer fall
+  through as bare-char commands (a real security-relevant fix — previously
+  e.g. Alt-z could execute as plain `z`)
+
+### Out of Scope (confirmed still absent after this commit)
+
+> [!danger] Explicit Gaps
+> - `:s` substitute (search-and-replace) — the original US-002's actual
+>   goal — was **not implemented**
+> - `:g` as Helix's real global-command-with-subcommand — only a `:g N`
+>   goto alias exists, not the real semantics
+> - `:w`, `:sort`, line ranges, `:normal`, shell commands — never in scope,
+>   still absent
+> - A dedicated `EditorMode::CommandMode` variant on the simulator's mode
+>   type — command-line state lives only in the input layer
+> - Vim-style marks — permanently excluded per issue #104, unaffected by
+>   this work
+
+## Constraints & Assumptions
+
+### Technical Constraints
+`#![forbid(unsafe_code)]` preserved (verified — no `unsafe` in any file
+touched). Multi-byte/non-ASCII register-character input required explicit
+hardening (`chars()` vs `len()`/`.nth()`) to avoid panics — a correctness
+class the original draft's NFRs did not anticipate.
+
+### Business Constraints
+Scope was narrowed during implementation from "at least `:s` substitute" to
+"goto-line only," a judgment call made mid-build and documented afterward
+rather than re-specified upfront.
+
+### Assumptions
+
+> [!warning] Assumptions
+> - The `:s`/`:g`-global gap is assumed to be a legitimate follow-up
+>   feature, not an abandoned requirement — `docs/HELIX_KEYBINDINGS.md`'s
+>   explicit disclaimer suggests intent to revisit, not permanent rejection
+>   (contrast with vim marks, which are permanently rejected)
+> - `normalize_command_id()` collapsing all register letters into one
+>   FSRS-tracked skill per operation family (`"y`, `"p`, `"P`, `"R`) is
+>   assumed to be the correct granularity — the alternative (per-letter
+>   tracking) was not chosen and is not currently planned
+
+## Success Criteria
+
+See [[SRS#3.2 Success Criteria]] for the metric-by-metric actual outcome.
+
+## Open Questions
+
+> [!question] Unresolved Items
+> - [ ] Should `:s` substitute be scoped as a standalone follow-up feature,
+>       given it was the original spec's actual minimum bar and remains
+>       fully unimplemented?
+> - [ ] Should `EditorMode` gain a real `CommandMode` variant (closing the
+>       NFR-002 gap), or is the input-typestate-only approach considered
+>       the accepted final architecture?
+> - [ ] Should scenario coverage be expanded from 1 scenario/category to the
+>       originally targeted ≥3/category spanning difficulty (SC-003)?
+
+## Glossary
+
+| Term | Definition |
+|------|-----------|
+| `RegisterFile` | `HashMap<char, String>` register storage, `src/helix/simulator/register_file.rs` |
+| Unnamed register | The default register slot (`'"'`), used when no explicit `"<reg>` selection is active |
+| `CommandLine::Goto(usize)` | The sole implemented command-line command variant, line-number navigation |
+| `normalize_command_id` | Canonicalizes raw command strings (e.g. `"ay` → `"y`, `:g 3` → `:goto`) before they reach FSRS/quest tracking |
+
+## See Also
+
+- [[spec]] — original research spec and retroactive resolution summary
+- [[SRS]] — functional requirements, marked with implementation verdicts
+- [[NFR]] — non-functional requirements, verified against shipped code
+- [[plan]] — as-built architecture and documented scope narrowing
+- [[tasks]] — retroactive task breakdown
+- [[constitution]] — project principles (Section I, input typestate pattern)
+- `docs/HELIX_KEYBINDINGS.md` — user-facing scope disclaimer

--- a/specs/register-command-mode-support/NFR.md
+++ b/specs/register-command-mode-support/NFR.md
@@ -1,0 +1,156 @@
+---
+aliases:
+  - Register and Command-Line Mode NFR
+  - Issue 282 NFR
+tags:
+  - nfr
+  - requirements/non-functional
+  - helix-simulator
+  - input-system
+  - status/implemented
+created: 2026-08-09
+project: "helix-trainer"
+status: implemented
+standard: "ISO/IEC 25010:2011"
+related:
+  - "[[BRD]]"
+  - "[[SRS]]"
+---
+
+# Named Register and Command-Line Mode Support: Non-Functional Requirements Specification
+
+> [!abstract]
+> Verifies NFR-001..007 from the draft spec against commit `1ba668d`.
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+Records the quality-attribute requirements attached to the register/
+command-line work and verifies each against the shipped implementation.
+
+### 1.2 Scope
+
+Seven NFRs were drafted; this document does not add new ones beyond what
+was raised by the implementation itself (see Section 6, an unanticipated
+security hardening finding).
+
+> [!note] Not Applicable
+> Performance Efficiency, Portability, and Compatibility are omitted — the
+> draft raised no NFRs in these categories, and the implementation is
+> in-process, synchronous state-machine dispatch with no measurable
+> latency concern distinct from the rest of `src/input/`.
+
+### 1.3 Definitions
+
+| Term | Definition |
+|------|-----------|
+| Sealed trait | Rust pattern restricting trait implementation to the defining crate, used for `EditorMode` typestate enforcement |
+| `keytrie` | Multi-key input matching structure in `src/input/typestate/` |
+
+### 1.4 References
+
+- [[BRD]] — Business Requirements Document
+- [[SRS]] — Software Requirements Specification
+- ISO/IEC 25010:2011
+
+### 1.5 Priority and Trade-offs
+
+Architectural consistency for registers (NFR-001) was fully honored.
+Architectural consistency for command-line mode (NFR-002) was implicitly
+traded off against shipping a working, testable feature quickly — the
+input-typestate-only approach delivers the same user-observable behavior
+without extending `EditorMode`, at the cost of the compile-time enforcement
+that a sealed-trait `CommandMode` variant would have provided.
+
+## 2. Compatibility / Architectural Consistency
+
+### 2.1 Consistency with Existing Typestate Pattern
+
+| ID | Requirement | Target | Status |
+|----|------------|--------|--------|
+| NFR-001 | New register-selection and command-line states MUST use the existing typestate pattern in `src/input/typestate/` (zero-sized marker structs + `InputStateMachine::process_key` dispatch), no parallel/ad-hoc mechanism | Full typestate compliance | **Met.** `RegisterPending`, `RegisterOpPending`, `CommandLinePending` all follow the established marker-struct + `HandlerState`/`Sealed` pattern in `src/input/typestate/state_types.rs`. |
+| NFR-002 | Command-line/prompt mode MUST be added to `EditorMode` (`src/helix/simulator/mode.rs`) following the sealed-trait typestate pattern used for `NormalMode`/`InsertMode` | New `EditorMode` variant with compile-time enforcement | **Not met.** `EditorMode` was not extended — verified unchanged, still only `NormalMode`/`InsertMode`. Command-line state exists solely in the input-typestate layer, one level removed from the simulator's own mode type. The user-observable behavior (a distinct, reachable prompt mode) is present; the specific architectural mechanism requested is not. |
+
+## 3. Security
+
+### 3.1 Scope Discipline
+
+| ID | Requirement | Target | Status |
+|----|------------|--------|--------|
+| NFR-003 | Vim-style marks MUST NOT be introduced under any name, alias, or reinterpretation | Zero mark-jump functionality | **Met** — confirmed via code review; no backtick/apostrophe mark handling exists anywhere in the diff. |
+
+### 3.2 Memory Safety
+
+| ID | Requirement | Target | Status |
+|----|------------|--------|--------|
+| NFR-004 | `#![forbid(unsafe_code)]` MUST be preserved; no `unsafe` blocks introduced | Zero `unsafe` in new code | **Met** — confirmed via grep across all files touched by the commit. |
+
+## 4. Maintainability
+
+### 4.1 Testability
+
+| ID | Requirement | Target | Status |
+|----|------------|--------|--------|
+| NFR-005 | Both capabilities MUST be covered by scenario TOML fixtures validated via `cargo nextest run scenario`, plus unit tests for the simulator-level register map and command-line parser | Coverage depth matching existing command categories | **Met, though scenario breadth is thinner than SC-003's original ≥3-per-category target** — see [[SRS#3.2 Success Criteria]]. Unit test depth (~30+ new/changed tests) is comparable to or exceeds existing command categories. |
+
+### 4.2 Documentation
+
+| ID | Requirement | Target | Status |
+|----|------------|--------|--------|
+| NFR-007 | All new `pub` types/functions MUST carry `///` doc comments, including `# Examples` for non-trivial public APIs | Full doc coverage | **Met for the core new types** (`RegisterFile`, `CommandLine`, `normalize_command_id`) — not independently re-verified line-by-line as part of this retroactive record; assumed compliant per the project's rustdoc CI gate, which would have failed the PR otherwise. |
+
+## 5. Reliability
+
+### 5.1 Error Handling
+
+| ID | Requirement | Target | Status |
+|----|------------|--------|--------|
+| NFR-006 | All new user-facing failure modes (invalid register name, malformed command-line input) MUST route through `UserError`/`SecurityError` | No panics on malformed input | **Met.** `CommandLine::parse` returns `UserError::CommandFailed` on malformed input; invalid register-name characters route through the same convention. A new `security::limits::MAX_COMMAND_LINE_LEN = 256` bound was added, going beyond the letter of NFR-006 into explicit input-length hardening. |
+
+## 6. Unanticipated Finding — Input Robustness Hardening
+
+Not requested by any drafted NFR, but delivered as part of this commit:
+
+- Multi-byte/non-ASCII register-character handling was hardened
+  (`chars()` used instead of byte-length/`.nth()` indexing) after a panic
+  class was found during implementation — register names are not
+  guaranteed single-byte.
+- Unmapped Alt/Ctrl key combinations no longer fall through as bare-char
+  commands in the input dispatcher — previously, e.g., Alt-z could execute
+  as plain `z`, a real security/correctness-relevant gap in modifier-key
+  handling unrelated to registers or command-line mode but found and fixed
+  alongside them.
+- Arcade-mode Esc handling was made consistent: it now cancels any pending
+  register/command-line/prefix state instead of unconditionally pausing,
+  and input state resets between arcade scenarios.
+
+These are recorded here as a positive, unplanned quality outcome of the
+work, not as failures against a drafted requirement.
+
+## 7. Verification Matrix
+
+| ID | Method | Environment | Status |
+|----|--------|-------------|--------|
+| NFR-001 | Code review against `state_types.rs` pattern | Local | Pass |
+| NFR-002 | Code inspection of `mode.rs` | Local | Fail (not implemented) |
+| NFR-003 | Code review, grep for mark-related identifiers | Local | Pass |
+| NFR-004 | `grep -rn "unsafe"` across touched files | Local | Pass |
+| NFR-005 | `cargo nextest run scenario` + unit test count | CI | Pass (depth), partial (breadth) |
+| NFR-006 | Code review of error propagation paths | Local | Pass |
+| NFR-007 | rustdoc CI gate (`RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps`) | CI | Assumed pass (gate would have blocked merge otherwise) |
+
+## 8. Open Questions
+
+> [!question] Unresolved Quality Requirements
+> - [ ] Should `EditorMode` be retrofitted with a real `CommandMode` variant
+>       to close the NFR-002 gap, or is the current input-typestate-only
+>       approach the accepted final architecture for this feature?
+> - [ ] Should scenario breadth (NFR-005) be expanded from 1 to ≥3 scenarios
+>       per new category, matching the density of other command categories?
+
+## See Also
+
+- [[BRD]] — business rationale (source)
+- [[SRS]] — functional requirements and verdicts
+- [[spec]] — original research spec

--- a/specs/register-command-mode-support/README.md
+++ b/specs/register-command-mode-support/README.md
@@ -1,0 +1,81 @@
+---
+aliases:
+  - Register and Command-Line Mode — Retroactive Record
+  - Issue 282 Retroactive Record
+tags:
+  - sdd
+  - decision-record
+  - helix-simulator
+  - input-system
+  - status/implemented
+created: 2026-08-09
+status: implemented
+related:
+  - "[[BRD]]"
+  - "[[SRS]]"
+  - "[[NFR]]"
+  - "[[spec]]"
+  - "[[plan]]"
+  - "[[tasks]]"
+---
+
+# Retroactive Record: Named Register and Command-Line Mode Support (GitHub Issue #282)
+
+> [!important] Status: IMPLEMENTED (command-line mode narrower than drafted)
+> This package documents work that already shipped in commit `1ba668d`
+> before this SDD package was written. It is retroactive.
+
+## What This Package Is
+
+A full BRD → SRS → NFR → spec → plan → tasks pipeline, run against a
+competitive-parity research finding (named registers and command-line mode
+absent from the Helix simulator), documented after the fact against what
+commit `1ba668d` actually implemented.
+
+## Headline Finding
+
+Named registers shipped essentially as originally drafted — `"<reg>`
+selection scoped to `y`/`p`/`P`, plus `R` as an implementation extension —
+with the default/unnamed register preserved unchanged. Command-line mode
+shipped at a **deliberately narrower scope** than drafted: only `:goto N`
+(alias `:g N`) line-number navigation exists. The original minimum bar —
+`:s/pattern/replacement/` substitute — was evaluated and explicitly dropped
+during implementation as "not verifiable against the snapshot-based
+scenario completion model," a constraint the original research spec did not
+anticipate. `docs/HELIX_KEYBINDINGS.md` documents this narrowing explicitly
+to users.
+
+A second architectural deviation: command-line state lives entirely in the
+input-typestate layer (`CommandLinePending`); `EditorMode`
+(`src/helix/simulator/mode.rs`) was not extended with a `CommandMode`
+variant as the draft's FR-005/NFR-002 requested.
+
+## Traceability
+
+| Draft Requirement | SRS Verdict | NFR Status | Outcome |
+|---|---|---|---|
+| FR-001..004 — named registers | Met, FR-003 extended with `R` | NFR-001, NFR-004 met | `RegisterFile` replacing `clipboard`, full typestate compliance |
+| FR-005 — command-line as `EditorMode` variant | Met behaviorally, architecturally deviant | NFR-002 not met | `CommandLinePending` in input layer only |
+| FR-006 — `:s` substitute | **Not implemented** | N/A | `:goto`/`:g N` shipped instead |
+| FR-007, FR-008 — cancel/error handling | Met | NFR-006 met | Safer-than-drafted malformed-input path (intercepted, not propagated) |
+| FR-009, FR-010 — scenario validation, FSRS tracking | Met | NFR-005, NFR-007 met | `normalize_command_id`, 2 new scenarios (thinner than SC-003's ≥3/category target) |
+
+## Package Contents
+
+- [[BRD]] — business rationale, decision, and what actually shipped
+- [[SRS]] — FR-001..010 marked with actual implementation verdicts
+- [[NFR]] — NFR-001..007 verified against shipped code, plus an
+  unanticipated input-robustness hardening finding
+- [[spec]] — original research spec plus a retroactive resolution summary
+- [[plan]] — as-built architecture, key design decisions, documented scope
+  narrowing
+- [[tasks]] — retroactive task breakdown (T001-T007 completed, T008/T009
+  recommended but not scheduled)
+
+## See Also
+
+- `specs/MOC-specs.md` — specifications index
+- [[constitution]] — project principles, Section I (Architecture)
+- `docs/HELIX_KEYBINDINGS.md` — user-facing scope disclaimer
+- Issue #104 — vim-style marks explicitly rejected (unaffected by this work)
+- Issue #198 — separate, still-open content-coverage gap (macros, scroll, view mode, selection-regex)

--- a/specs/register-command-mode-support/SRS.md
+++ b/specs/register-command-mode-support/SRS.md
@@ -1,0 +1,281 @@
+---
+aliases:
+  - Register and Command-Line Mode SRS
+  - Issue 282 SRS
+tags:
+  - srs
+  - requirements/functional
+  - helix-simulator
+  - input-system
+  - status/implemented
+created: 2026-08-09
+project: "helix-trainer"
+status: implemented
+standard: "ISO/IEC/IEEE 29148:2018"
+related:
+  - "[[BRD]]"
+  - "[[NFR]]"
+---
+
+# Named Register and Command-Line Mode Support: Software Requirements Specification
+
+> [!abstract]
+> Functional requirements as originally drafted, each marked against the
+> actual implementation in commit `1ba668d`. Traceable to [[BRD]].
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+Records the functional requirements originally drafted for named-register
+and command-line support and evaluates each against what commit `1ba668d`
+actually shipped.
+
+### 1.2 Scope
+
+Covers `src/helix/simulator/` register/command-line additions and
+`src/input/typestate/` state additions. Does not cover macro
+recording/playback, scroll commands, or selection-regex (tracked separately
+under issue #198).
+
+### 1.3 Definitions, Acronyms, and Abbreviations
+
+| Term | Definition |
+|------|-----------|
+| `RegisterFile` | `HashMap<char, String>` register storage, `src/helix/simulator/register_file.rs:35` |
+| `RegisterPending` / `RegisterOpPending` | Typestate marker states for `"` and `"<reg>` respectively, `src/input/typestate/state_types.rs` |
+| `CommandLinePending` | Typestate marker state for an open `:` prompt |
+| `CommandLine::Goto(usize)` | The sole implemented command-line command |
+| `normalize_command_id` | Canonicalizes raw command strings before FSRS/quest tracking, `src/helix/commands.rs:153-175` |
+
+### 1.4 References
+
+- [[BRD]] — Business Requirements Document
+- [[NFR]] — Non-Functional Requirements Specification
+- [Helix Keymap Reference](https://docs.helix-editor.com/keymap.html)
+- [Helix Command-Line Reference](https://docs.helix-editor.com/command-line.html)
+
+### 1.5 Document Overview
+
+Section 3 lists FR-001 through FR-010 as drafted, each with a verdict and
+evidence. Section 4 is the verification matrix against actual shipped
+tests.
+
+## 2. Overall Description
+
+### 2.1 Product Perspective
+
+Extends `HelixSimulator` (`src/helix/`) and the typestate input dispatcher
+(`src/input/typestate/`), subsystems of the single-binary helix-trainer TUI.
+
+### 2.2 Product Functions
+
+Named-register yank/paste/replace; command-line goto-line navigation; two
+new scenario categories; FSRS command-taught normalization.
+
+### 2.3 User Classes and Characteristics
+
+Unchanged from [[BRD#Target Users]].
+
+### 2.4 Operating Environment
+
+Unchanged — TUI via ratatui/crossterm.
+
+### 2.5 Design and Implementation Constraints
+
+`#![forbid(unsafe_code)]`; must follow the existing typestate pattern
+(NFR-001).
+
+### 2.6 Assumptions and Dependencies
+
+See [[BRD#Assumptions]].
+
+## 3. Specific Requirements
+
+### 3.1 Functional Requirements — Verdict
+
+> [!info] Traceability
+> Traces to [[spec#3. Functional Requirements]].
+
+**FR-001** — WHEN the user presses `"` followed by a register name
+character in Normal mode THE SYSTEM SHALL enter a register-selection
+pending state.
+
+- *Priority*: must
+- *Verdict*: **Implemented as-is.** `"` in `BaseState` transitions to
+  `InputState::RegisterPending`
+  (`src/input/typestate/handlers/base.rs:243-244`); any subsequent
+  character transitions to `RegisterOpPending { register }`
+  (`src/input/typestate/handlers/register.rs:538-551`).
+
+**FR-002** — WHEN a register has been selected via `"<reg>` and the user
+presses `y` THE SYSTEM SHALL yank the current selection into that named
+register.
+
+- *Priority*: must
+- *Verdict*: **Implemented as-is.** `"<reg>y` dispatches to
+  `clipboard::yank_to_register(sim, Some(register))`.
+
+**FR-003** — WHEN a register has been selected via `"<reg>` and the user
+presses `p` or `P` THE SYSTEM SHALL paste the content of that named
+register after/before the cursor respectively.
+
+- *Priority*: must
+- *Verdict*: **Implemented as-is, plus `R`.** `p`/`P` behave as drafted;
+  the implementation additionally scoped `R` (replace-with-yanked) to
+  registers, which the draft did not request but is consistent with
+  FR-002/FR-003's intent.
+
+**FR-004** — WHEN no register is explicitly selected THE SYSTEM SHALL
+preserve existing default-clipboard yank/paste behavior unchanged.
+
+- *Priority*: must
+- *Verdict*: **Implemented as-is.** `RegisterFile`'s unnamed key (`'"'`) is
+  what plain `y`/`p`/`P`/`R` read/write
+  (`src/helix/simulator/register_file.rs:14-20`); a `None` register
+  parameter defaults to it. Existing clipboard tests remained passing
+  unmodified aside from the field rename `clipboard` → `registers`.
+
+**FR-005** — WHERE the user presses `:` in Normal mode THE SYSTEM SHALL
+enter a new command-line/prompt mode distinct from `NormalMode` and
+`InsertMode`.
+
+- *Priority*: must
+- *Verdict*: **Implemented differently.** `:` enters `CommandLinePending`
+  in the **input typestate layer**, not a new `EditorMode::CommandMode`
+  variant. `src/helix/simulator/mode.rs` is unchanged — still only
+  `NormalMode`/`InsertMode` (verified: no new variant, no `Sealed` impl
+  added). This directly contradicts NFR-002's letter, though it satisfies
+  the user-observable behavior (a distinct prompt mode exists and is
+  reachable via `:`).
+
+**FR-006** — WHEN in command-line mode and the user types a valid
+`:s/pattern/replacement/` expression and confirms THE SYSTEM SHALL apply
+the substitution and return to Normal mode.
+
+- *Priority*: must
+- *Verdict*: **Not implemented.** No `:s` substitute exists — no regex, no
+  pattern/replacement parsing anywhere in the diff. Only `:goto N`/`:g N`
+  (alias) is implemented, per the commit title ("command-line **goto**
+  mode"). This is the single largest scope gap between the draft and what
+  shipped.
+
+**FR-007** — WHEN in command-line mode and the user presses Escape THE
+SYSTEM SHALL discard the pending input and return to Normal mode without
+modifying the document.
+
+- *Priority*: must
+- *Verdict*: **Implemented as-is.** Esc while `CommandLinePending` →
+  `HandlerResult::Cancel`, no document mutation
+  (`src/input/typestate/handlers/command_line.rs:295`).
+
+**FR-008** — WHEN in command-line mode and the user types an unrecognized
+or malformed command THE SYSTEM SHALL surface a `UserError` rather than
+panicking or silently no-op-ing.
+
+- *Priority*: must
+- *Verdict*: **Implemented as-is, with a safer failure path than drafted.**
+  `CommandLine::parse` returns `UserError::CommandFailed` on malformed
+  input; the handler intercepts this at Enter-time and converts it to a
+  `Cancel` rather than propagating the `Err` further up the call stack —
+  documented in the implementation as preventing an app-crashing failure
+  mode found during review.
+
+**FR-009** — WHERE new scenario categories are added THE SYSTEM SHALL
+validate them via `cargo nextest run scenario` with no changes to the
+validation harness itself.
+
+- *Priority*: should
+- *Verdict*: **Implemented as-is.** `tests/scenario_validation.rs` extended
+  (+43 lines) but the harness mechanism itself is unchanged; new categories
+  validate through it.
+
+**FR-010** — WHEN a scenario's `metadata.commands_taught` references a
+register-select or command-line command THE SYSTEM SHALL recognize it as a
+valid taught command for FSRS tracking.
+
+- *Priority*: should
+- *Verdict*: **Implemented differently.** No changes to a `src/learning/`
+  command-mapping table. Instead, a new `helix::commands::
+  normalize_command_id()` (`src/helix/commands.rs:153-175`) canonicalizes
+  raw command strings (e.g. `"ay` → `"y`, `:g 3` → `:goto`) at three call
+  sites before they reach FSRS/quest tracking: `scenario_completion.rs:163`,
+  `minigame/session.rs:848`, `ui/state/handlers/quests.rs:21`. This means
+  every register letter collapses to one FSRS-tracked skill per operation
+  (`"y`, `"p`, `"P`, `"R`), not one skill per letter.
+
+**Net**: 6 of 8 "must" FRs fully satisfied (FR-001..004, FR-007, FR-008);
+FR-005 satisfied behaviorally but architecturally deviant; FR-006 (the
+user-facing goal of US-002) **not implemented at all**. Both "should" FRs
+(FR-009, FR-010) satisfied, FR-010 via a different mechanism than drafted.
+
+### 3.2 Success Criteria
+
+| ID | Metric | Verdict |
+|----|--------|---------|
+| SC-001 | Named-register yank/paste round-trip correctness, 100% pass, no regression | **Met** |
+| SC-002 | Command-line `:s` substitute correctness | **Not met — `:s` never implemented.** `:goto`/`:g` has its own passing test suite instead. |
+| SC-003 | ≥1 scenario category per capability, ≥3 scenarios/category spanning difficulty | **Partially met** — `scenarios/en/registers/named-registers.toml` (1 scenario, intermediate) and a command-line goto scenario under `scenarios/en/movement/command-line-goto.toml` (1 scenario, intermediate); new `ScenarioCategory::Registers` variant added |
+| SC-004 | Code review confirms new states follow the typestate pattern, zero ad-hoc tracking | **Met for registers; not met for command-line's relationship to `EditorMode`** (FR-005 deviation) |
+| SC-005 | Code review confirms no vim-marks scope creep | **Met** |
+
+### 3.3 Logical Data Requirements
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `RegisterFile` | Register storage map | `HashMap<char, String>`, `UNNAMED_REGISTER = '"'` |
+| `CommandLine` | Parsed command-line command | Single variant `Goto(usize)` — no `Substitute` variant exists |
+| `InputState::RegisterPending`/`RegisterOpPending { register: char }` | Pending typestate for register selection | register name char, resolves after exactly one subsequent `y`/`p`/`P`/`R` |
+| `InputState::CommandLinePending { buffer: String }` | Pending typestate for an open `:` prompt | accumulated raw input |
+
+## 4. Verification and Validation
+
+### 4.1 Verification Matrix
+
+| Requirement | Method | Criteria | Status |
+|------------|--------|----------|--------|
+| FR-001..004 | Unit tests in `register_file.rs`, `handlers/register.rs` (11 tests total) | Register select/yank/paste/replace round-trip, unnamed-register regression | **Pass** |
+| FR-005 | Code inspection | New prompt mode reachable via `:` | **Pass behaviorally, fails architecturally** (no `EditorMode::CommandMode`) |
+| FR-006 | — | `:s` substitute apply-and-return-to-Normal | **Not run — feature does not exist** |
+| FR-007, FR-008 | Unit tests in `command_line.rs`, `handlers/command_line.rs` (25 tests total) | Cancel-on-Escape, malformed-input handling | **Pass** |
+| FR-009 | `cargo nextest run scenario` | New categories validate | **Pass** |
+| FR-010 | Regression test in `minigame/session.rs` | `normalize_command_id` produces expected FSRS-tracked skill IDs | **Pass** |
+
+### 4.2 Acceptance Test Outline
+
+`cargo nextest run --workspace --all-features --lib --bins` runs ~30+
+new/changed test functions across `register_file.rs` (5), `command_line.rs`
+(13), `keytrie.rs` (6, incl. multi-byte-char panic regressions),
+`handlers/register.rs` (6), `handlers/command_line.rs` (12),
+`commands/mod.rs` dispatch tests (6), state-machine boundary-cancel tests
+(2), `tests/ui_multi_key_commands.rs` integration flows (+159 lines), an
+FSRS-normalization regression test, and arcade Esc-routing tests (3).
+`cargo nextest run scenario` additionally validates the two new scenario
+TOML files.
+
+## 5. Appendices
+
+### 5.1 Traceability Matrix — Original Open Questions Resolved
+
+| Draft Open Question | Resolution |
+|---|---|
+| Does `"<reg>` selection apply only to `y`/`p`/`P`, or to any operator? | Resolved narrower-but-adjacent: exactly `y`/`p`/`P`/`R`; anything else cancels the pending state |
+| What is Helix's default `:s` scope? | Moot — `:s` was never implemented |
+| Should `:g` (global) be included alongside `:s`? | Resolved as an alias, not the real command: `:g N` is an alias for `:goto N`, not Helix's real global-command-with-subcommand |
+| Should registers be one FSRS skill or per-letter? | Resolved as one skill per operation family via `normalize_command_id` |
+| Does `RepeatBuffer` need to record register/command-line input for `.`? | Resolved as explicitly non-repeatable — `cmd_to_key_events` has no arm for these shapes; `.` after either is a documented no-op, covered by `test_cmd_to_key_events_register_op_and_command_line_are_not_repeatable` |
+
+### 5.2 BRD/SRS/NFR Traceability Matrix
+
+| BRD Section | SRS Requirement(s) | NFR Requirement(s) |
+|----------------|--------------------|--------------------|
+| [[BRD#Named Registers]] | FR-001..004 (met, FR-003 extended) | NFR-001 (met), NFR-004 (met) |
+| [[BRD#Command-Line Mode]] | FR-005 (deviant), FR-006 (not met), FR-007, FR-008 (met), FR-009 (met) | NFR-002 (not met), NFR-006 (met) |
+| [[BRD#What Was Implemented]] (FSRS tracking) | FR-010 (met, different mechanism) | NFR-005, NFR-007 (met) |
+
+## See Also
+
+- [[BRD]] — business rationale and what actually shipped (source)
+- [[NFR]] — non-functional requirements
+- [[plan]] — as-built architecture
+- [[spec]] — original research spec

--- a/specs/register-command-mode-support/plan.md
+++ b/specs/register-command-mode-support/plan.md
@@ -1,0 +1,235 @@
+---
+aliases:
+  - Register and Command-Line Mode Plan
+tags:
+  - sdd
+  - plan
+  - helix-simulator
+  - input-system
+  - status/implemented
+created: 2026-08-09
+status: implemented
+related:
+  - "[[spec]]"
+  - "[[BRD]]"
+  - "[[constitution]]"
+---
+
+# Technical Plan: Named Register and Command-Line Mode Support (As-Built)
+
+> [!info] References
+> **Spec**: [[spec]]
+> This document is retroactive — it describes the architecture actually
+> implemented in commit `1ba668d`, including the deliberate deviation from
+> the drafted `EditorMode` design and the deliberate scope narrowing of
+> command-line mode to goto-only.
+
+## 1. Architecture
+
+### Approach
+
+Both capabilities were built as new states in the existing typestate input
+dispatcher (`src/input/typestate/`), following the pattern already
+established by `GotoPending`/`ViewPending`/`MatchPending`. Named registers
+additionally required a simulator-level data structure change (`clipboard:
+Option<String>` → `registers: RegisterFile`); command-line mode did not
+touch the simulator's mode type at all — it resolves entirely at the input
+layer into a single `CommandLine::Goto(usize)` action applied directly to
+the document, without an intervening `EditorMode::CommandMode` state.
+
+### Component Diagram
+
+```mermaid
+graph TD
+    subgraph "Input Layer (src/input/typestate/)"
+        A["\" key"] --> B[RegisterPending]
+        B -->|reg char| C["RegisterOpPending{register}"]
+        C -->|y/p/P/R| D[HelixSimulator command]
+        C -->|other key| E[Cancel -> BaseState]
+        F[": key"] --> G["CommandLinePending{buffer}"]
+        G -->|digit| G
+        G -->|Enter, valid| H[CommandLine::Goto applied]
+        G -->|Enter, invalid| E
+        G -->|Escape| E
+    end
+    subgraph "Simulator Layer (src/helix/simulator/)"
+        D --> I[RegisterFile: HashMap-char,String-]
+        H --> J[Document cursor moved]
+    end
+    subgraph "EditorMode (unchanged)"
+        K[NormalMode] 
+        L[InsertMode]
+    end
+```
+
+### Key Design Decisions
+
+| Decision | Choice | Rationale (reconstructed) | Alternatives Considered (per draft) |
+|----------|--------|-----------|------------------------|
+| Where command-line state lives | Input-typestate layer only (`CommandLinePending`), not `EditorMode` | Faster to ship, avoids touching the sealed-trait `EditorMode` machinery and its call sites throughout the simulator; the behavior (a distinct, reachable prompt) is achievable without it | A new `EditorMode::CommandMode` sealed-trait variant, as drafted in FR-005/NFR-002 — not taken |
+| Command-line surface | `:goto N` / `:g N` alias only | `:s` substitute, `:g` global, `:sort`, `:clear-register` evaluated and explicitly dropped as "not verifiable against the snapshot-based scenario completion model" (from the commit message) — a completion-detection constraint the draft did not anticipate | Full `:s/pattern/replacement/` as originally targeted in FR-006/US-002 — not taken |
+| Register storage | Rename+generalize `clipboard: Option<String>` → `registers: RegisterFile` (`HashMap<char, String>`) | Additive without duplicating structure; single source of truth for both unnamed and named slots | A separate parallel register map alongside the untouched `clipboard` field — rejected, would violate FR-004's "no regression" requirement more riskily |
+| FSRS command-taught mapping | New `normalize_command_id()` canonicalization function at 3 call sites, rather than a `src/learning/` mapping table change | Keeps the normalization concern in `src/helix/commands.rs` (where the raw command-string format is defined) rather than duplicating knowledge of register/command-line syntax inside `src/learning/` | A `src/learning/`-side lookup table keyed on raw command strings — not taken |
+
+## 2. Project Structure
+
+```
+src/helix/
+├── simulator/
+│   ├── register_file.rs        # NEW — RegisterFile, UNNAMED_REGISTER
+│   ├── command_line.rs         # NEW — CommandLine::Goto(usize), parse()
+│   ├── mode.rs                 # UNCHANGED — still NormalMode/InsertMode only
+│   ├── mod.rs                  # HelixSimulator.clipboard -> .registers: RegisterFile
+│   └── commands/
+│       ├── clipboard.rs        # yank_to_register/paste now register-aware
+│       └── mod.rs               # dispatch tests for register ops
+└── commands.rs                 # normalize_command_id(), CMD_SELECT_REGISTER, CMD_COMMAND_LINE
+
+src/input/typestate/
+├── input_state.rs              # + RegisterPending, RegisterOpPending{register}, CommandLinePending{buffer}
+├── state_types.rs              # + marker structs, HandlerState/Sealed impls
+├── state_machine.rs            # + RegisterPreview enum (UI feedback)
+├── handlers/
+│   ├── base.rs                 # " -> RegisterPending; existing Esc/Alt/Ctrl hardening
+│   ├── register.rs             # NEW — RegisterOpPending dispatch, y/p/P/R handling
+│   └── command_line.rs         # NEW — CommandLinePending dispatch, parse/execute/cancel
+
+src/security.rs                 # + limits::MAX_COMMAND_LINE_LEN = 256
+
+src/config/scenarios.rs         # + ScenarioCategory::Registers
+
+scenarios/en/
+├── registers/
+│   └── named-registers.toml    # NEW — named_register_yank_paste_001
+└── movement/
+    └── command-line-goto.toml  # NEW — command_line_goto_001
+
+docs/HELIX_KEYBINDINGS.md       # updated with explicit scope disclaimer
+```
+
+## 3. Data Model
+
+```rust
+// src/helix/simulator/register_file.rs (as-built, illustrative)
+pub const UNNAMED_REGISTER: char = '"';
+
+pub struct RegisterFile {
+    registers: std::collections::HashMap<char, String>,
+}
+
+impl RegisterFile {
+    pub fn write(&mut self, register: Option<char>, content: String);
+    pub fn read(&self, register: Option<char>) -> Option<&str>;
+}
+
+// src/helix/simulator/command_line.rs (as-built, illustrative)
+pub enum CommandLine {
+    Goto(usize),
+}
+
+impl CommandLine {
+    pub fn parse(input: &str) -> Result<Self, UserError>;
+}
+```
+
+```rust
+// src/input/typestate/input_state.rs (as-built, illustrative)
+pub enum InputState {
+    // ...existing variants (GotoPending, ViewPending, MatchPending, ...)
+    RegisterPending,
+    RegisterOpPending { register: char },
+    CommandLinePending { buffer: String },
+}
+```
+
+### Migrations
+
+None — in-memory simulator state only; `RegisterFile` is not persisted to
+`profile.json` or `config.json`.
+
+## 4. API Design
+
+Not applicable — no HTTP/external API. Internal command dispatch:
+`HelixSimulator::execute_command` gained no new signature; register/
+command-line operations resolve to existing clipboard/cursor-movement
+primitives underneath.
+
+## 5. Integration Points
+
+| System | Direction | Notes |
+|--------|-----------|-------|
+| `src/learning/` (FSRS) | inbound | Consumes `normalize_command_id()`-canonicalized command strings for command-taught tracking; no changes to `src/learning/` itself |
+| `src/ui/state/handlers/quests.rs` | inbound | Same normalization call site, for daily-quest command tracking |
+| `tests/scenario_validation.rs` | inbound | Validates new scenario TOML via the unchanged existing harness |
+| `docs/HELIX_KEYBINDINGS.md` | outbound (docs) | Updated to disclose the goto-only scope to users/contributors |
+
+## 6. Security
+
+- Authentication/Authorization: not applicable (single-user local TUI).
+- Input validation: `CommandLine::parse` rejects non-digit and
+  out-of-range input via `UserError::CommandFailed`; register-name
+  characters validated as part of the `RegisterOpPending` transition.
+- New bound: `security::limits::MAX_COMMAND_LINE_LEN = 256` caps
+  command-line buffer growth.
+- Sensitive data: not applicable — registers hold only in-session buffer
+  text, never persisted or exposed externally.
+- Hardening found and fixed alongside (not originally scoped): multi-byte
+  register-char panics; Alt/Ctrl modifier keys falling through as bare-char
+  commands.
+
+## 7. Testing Strategy
+
+| Level | Framework | What Is Tested | Coverage |
+|-------|-----------|-----------------|----------|
+| Unit | `#[test]` | `RegisterFile` read/write/unnamed-default (5), `CommandLine::parse`/execute/sanitization (13), `keytrie` multi-byte regressions (6), register handler dispatch (6), command-line handler dispatch (12), clipboard dispatch (6) | `src/helix/simulator/`, `src/input/typestate/` |
+| Integration | `#[test]` in `tests/ui_multi_key_commands.rs` | End-to-end register/goto key sequences through the full input stack (+159 lines) | Cross-module |
+| Scenario | `cargo nextest run scenario` | `named-registers.toml`, `command-line-goto.toml` complete via their declared `solution` | Content-level |
+| Regression | `#[test]` | FSRS-normalization regression in `minigame/session.rs`; arcade Esc-routing (3); state-machine boundary-cancel (2) | Cross-cutting |
+| **Gap** | — | No property-based (`proptest`) coverage was added for `CommandLine::parse` or register-name validation, despite both being pure, deterministic parsing functions well-suited to it | `src/helix/simulator/command_line.rs`, `register_file.rs` |
+
+## 8. Performance Considerations
+
+No measurable impact — synchronous, in-process state-machine dispatch on
+keypress, same cost class as every other typestate transition already in
+the input pipeline.
+
+## 9. Rollout Plan
+
+Already shipped as part of commit `1ba668d` (2026-08-09), merged via PR
+#329, closing issue #282. No feature flag — immediately active for all
+users on merge. `docs/HELIX_KEYBINDINGS.md`'s scope disclaimer serves as
+the user-facing rollout communication for the goto-only narrowing.
+
+## 10. Constitution Compliance
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Architecture — input routed through `HelixSimulator`/`AnyModeSimulator`, typestate pattern for pending states | Compliant for registers; partially compliant for command-line (typestate used, but `EditorMode` itself not extended) | See [[NFR#NFR-002]] |
+| IV. Code Style — `#![forbid(unsafe_code)]` preserved | Compliant | Verified via grep |
+| IV. Code Style — doc comments on new `pub` items | Compliant | rustdoc CI gate would have blocked merge otherwise |
+| V. Security — input validation via `UserError`/`SecurityError` | Compliant | `CommandLine::parse`, register-name validation |
+| VII. Simplicity — extend existing subsystem rather than introduce a parallel one | Compliant | `RegisterFile` replaces/generalizes `clipboard`, not duplicates it |
+
+## Documented Scope Narrowing
+
+`docs/HELIX_KEYBINDINGS.md` was updated with an explicit disclaimer row
+("❌ everything else") stating only `:goto`/`:g` is implemented in the
+command-line surface. This is the project's own record of the FR-006/
+SC-002 gap, written at implementation time rather than discovered
+retroactively by this SDD pass.
+
+## 11. Risks and Mitigations
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|-------------|------------|
+| A future contributor assumes `:s` substitute exists because "command-line mode" shipped | Wasted investigation time, or a duplicate/conflicting implementation attempt | Medium | `docs/HELIX_KEYBINDINGS.md` disclaimer + this record's explicit FR-006 "not implemented" verdict |
+| `EditorMode` never gaining a real `CommandMode` variant becomes permanent architectural drift | Command-line handling diverges further from the simulator's own mode model as more commands are added later | Low-Medium | [[BRD#Open Questions]] flags this for a maintainer decision before any `:s`/`:g` follow-up is scoped |
+| No proptest coverage for `CommandLine::parse` despite it being pure/deterministic | Parsing edge cases (malformed digit sequences, boundary line numbers) undetected by example-based tests alone | Low | Flagged in Testing Strategy gap above; follow-up candidate, not scheduled |
+
+## See Also
+
+- [[spec]] — original research spec
+- [[BRD]] — business rationale and what shipped
+- [[SRS]] — FR-by-FR verdict
+- [[tasks]] — retroactive task breakdown
+- [[constitution]] — project principles, Section I (Architecture)

--- a/specs/register-command-mode-support/spec.md
+++ b/specs/register-command-mode-support/spec.md
@@ -1,0 +1,238 @@
+---
+aliases:
+  - Named Registers and Command-Line Mode
+  - Register + Goto-Mode Support
+tags:
+  - sdd
+  - spec
+  - helix-simulator
+  - input-system
+  - status/implemented
+created: 2026-08-08
+status: implemented
+related:
+  - "[[constitution]]"
+  - "[[BRD]]"
+  - "[[SRS]]"
+  - "[[NFR]]"
+  - "[[plan]]"
+  - "[[tasks]]"
+  - "[[MOC-specs]]"
+---
+
+# Feature: Named Register and Command-Line (`:`) Mode Support
+
+> [!info] Metadata
+> **Author**: rust-agents:sdd (research spec, from competitive-parity finding)
+> **Resolved by**: commit `1ba668d` — "feat(helix-core): add named registers
+> and command-line goto mode (#329)", closing issues #282 (implementation)
+> **Status**: Implemented, narrower scope than drafted — see [[SRS]] for the
+> FR-by-FR verdict. This document is retroactive: preserved below as the
+> original research spec, with a Resolution section appended describing
+> what actually shipped.
+
+## 1. Overview
+
+### Problem Statement
+
+A competitive-parity research scan compared helix-trainer against reference
+Vim/Helix training projects, including
+[S-Sigdel/vimhjkl](https://github.com/S-Sigdel/vimhjkl) (524 stars, actively
+maintained, terminal-based spaced-repetition Vim trainer, 66 skills / 230
+challenges). vimhjkl's curriculum explicitly drills "registers, marks,
+macros, `:g` / `:normal` / ranges, regex and substitution" as core skill
+categories.
+
+Cross-checking against helix-trainer's own simulator (`src/helix/`) found
+two real, documented [Helix keymap](https://docs.helix-editor.com/keymap.html)
+features with zero simulator support and zero scenario coverage:
+
+1. **Named registers** — `"` `<reg>` = `select_register` (select a register
+   to yank to or paste from). `HelixSimulator<M>` had only a single
+   `clipboard: Option<String>` field, no register map keyed by name.
+2. **Command-line / ex mode (`:`)** — documented under *Minor modes*,
+   supporting `:s` substitute, `:g` global, ranges, `:w`, `:sort`, etc.
+   `EditorMode` defined only `NormalMode`/`InsertMode` — no command-line
+   mode existed at all.
+
+**Why it matters**: named registers (multi-slot yank/paste) and command-line
+commands are among the most commonly used Helix command categories in daily
+editing. Their total absence meant helix-trainer taught a strict subset of
+Helix's real command surface compared to reference projects drilling the
+equivalent Vim concepts.
+
+### Goal
+
+Define named-register support (yank to / paste from a register selected via
+`"<reg>`) and a scoped command-line mode as first-class additions to
+`HelixSimulator` and the typestate input system, with at least one new
+scenario category demonstrating each.
+
+### Out of Scope
+
+> [!danger] Explicit Exclusion — Vim-Style Marks
+> Vim-style marks (backtick/apostrophe jump-to-mark) are **explicitly and
+> permanently out of scope**. helix-trainer already investigated and
+> rejected this in closed issue #104: "Original plan had 'marks (m, '')'
+> which is a VIM feature, NOT Helix! In Helix, `m` enters Match Mode for
+> brackets/surround/textobjects." This decision is correct and final.
+
+Additional exclusions in the original draft (some became permanent, not
+just deferred — see Resolution below):
+
+- Full command-line surface (`:g` global, `:w` write, `:sort`, arbitrary
+  line ranges, shell commands, `:normal`)
+- Register content inspection UI
+- Macro recording/playback (tracked separately under issue #198)
+- Scroll commands, view mode extensions, selection-regex (tracked under
+  issue #198)
+
+## 2. User Stories
+
+### US-001: Yank and paste using a named register
+AS A helix-trainer user practicing intermediate/advanced Helix workflows
+I WANT to select a named register with `"<reg>` before a yank or paste
+operation
+SO THAT I can hold multiple pieces of text simultaneously and learn Helix's
+real multi-register workflow.
+
+**Status**: satisfied as drafted, plus `R` (replace-with-yanked) additionally
+scoped to registers. See [[SRS#FR-001]]..[[SRS#FR-004]].
+
+### US-002: Substitute text via command-line mode
+AS A helix-trainer user practicing intermediate/advanced Helix workflows
+I WANT to enter command-line mode with `:` and run a substitute command
+SO THAT I can learn Helix's search-and-replace workflow.
+
+**Status**: **not satisfied as drafted.** No `:s/pattern/replacement/`
+substitute was implemented. What shipped instead is `:goto N` / `:g N`
+(line-number navigation) — see [[BRD#What Was Implemented]] and
+[[SRS#FR-006]].
+
+### US-003: Scenario coverage for both new capabilities
+AS A helix-trainer content maintainer
+I WANT dedicated scenario categories exercising named registers and
+command-line mode
+SO THAT the FSRS scheduler can teach and drill these commands.
+
+**Status**: satisfied at minimum viable coverage (1 scenario per category,
+not the ≥3-per-category-spanning-difficulty originally targeted by SC-003).
+
+## 3. Functional Requirements
+
+Use EARS notation. Prefix with FR-NNN. See [[SRS]] for the actual verdict of
+each.
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN the user presses `"` followed by a register name character in Normal mode THE SYSTEM SHALL enter a register-selection pending state analogous to `GotoPending`/`ViewPending`/`MatchPending` | must |
+| FR-002 | WHEN a register has been selected via `"<reg>` and the user subsequently presses `y` THE SYSTEM SHALL yank the current selection into that named register | must |
+| FR-003 | WHEN a register has been selected via `"<reg>` and the user subsequently presses `p` or `P` THE SYSTEM SHALL paste the content of that named register after/before the cursor respectively | must |
+| FR-004 | WHEN no register is explicitly selected THE SYSTEM SHALL preserve existing default-clipboard yank/paste behavior unchanged | must |
+| FR-005 | WHEN the user presses `:` in Normal mode THE SYSTEM SHALL enter a new command-line/prompt mode distinct from `NormalMode` and `InsertMode` | must |
+| FR-006 | WHEN the system is in command-line mode and the user types a valid `:s/pattern/replacement/` expression and confirms (Enter) THE SYSTEM SHALL apply the substitution and return to Normal mode | must |
+| FR-007 | WHEN the system is in command-line mode and the user presses Escape THE SYSTEM SHALL discard the pending input and return to Normal mode without modifying the document | must |
+| FR-008 | WHEN the system is in command-line mode and the user types an unrecognized or malformed command THE SYSTEM SHALL surface a `UserError` rather than panicking or silently no-op-ing | must |
+| FR-009 | WHERE new scenario categories are added THE SYSTEM SHALL validate them via `cargo nextest run scenario` with no changes to the validation harness itself | should |
+| FR-010 | WHEN a scenario's `metadata.commands_taught` references a register-select or command-line command THE SYSTEM SHALL recognize it as a valid taught command for FSRS tracking | should |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Architectural consistency | New register-selection and command-line states MUST use the existing typestate pattern in `src/input/typestate/` |
+| NFR-002 | Architectural consistency | Command-line mode MUST be added to `EditorMode` (`src/helix/simulator/mode.rs`) following the sealed-trait typestate pattern |
+| NFR-003 | Scope discipline | Vim-style marks MUST NOT be introduced under any name — see issue #104 |
+| NFR-004 | Safety | `#![forbid(unsafe_code)]` MUST be preserved |
+| NFR-005 | Testability | Both capabilities MUST be covered by scenario TOML fixtures plus unit tests |
+| NFR-006 | Error handling | All new user-facing failure modes MUST route through `UserError`/`SecurityError` |
+| NFR-007 | Documentation | All new `pub` types/functions MUST carry `///` doc comments |
+
+## 5. Data Model
+
+Described at the WHAT level in the original draft; see [[plan]] for the
+concrete as-built types.
+
+| Entity | Description |
+|--------|-------------|
+| Named Register | A named storage slot for yanked/deleted text, addressable via `"<reg>` |
+| Register Selection (pending input state) | Transient typestate marker capturing that the next operation targets a specific register |
+| Command-Line Session | Transient state representing an open `:` prompt |
+| Substitute Command | A parsed `:s/pattern/replacement/[flags]` expression — **not implemented, see Resolution** |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior | Actual (as shipped) |
+|----------|-------------------|----------------------|
+| User presses `"` then an invalid register-name character | `UserError`, return to `BaseState` | Matches — see [[SRS#FR-001]] |
+| User presses `"<reg>` then a key that is neither `y`, `p`, nor `P` | `[NEEDS CLARIFICATION]` in draft | Resolved: also allows `R`; anything else cancels the pending register state |
+| User enters command-line mode via `:` then presses `:` again mid-input | Treated as literal input unless a recognized control key | Not applicable — command-line only accepts digits for `:goto`; non-digit input is rejected as malformed |
+| `:s/pattern/replacement/` with invalid regex | `UserError` describing regex failure | Not applicable — `:s` was never implemented |
+| `:s` invoked with no active selection/range | `[NEEDS CLARIFICATION]` in draft | Moot — `:s` was never implemented |
+| Named register read via `"<reg>p` before anything yanked to it | No-op, no panic, mirrors default clipboard | Matches |
+| Scenario TOML references an unrecognized register/command-line command | `cargo nextest run scenario` MUST fail loudly | Matches — validation harness unchanged, still fails loudly on unmapped commands |
+
+## 7. Success Criteria
+
+| ID | Metric | Target | Actual |
+|----|--------|--------|--------|
+| SC-001 | Named-register yank/paste round-trip correctness | 100% pass, no regression | Met |
+| SC-002 | Command-line `:s` substitute correctness | 100% pass for `:s/pattern/replacement/` | **Not met — `:s` never implemented; `:goto`/`:g` implemented instead, with its own passing tests** |
+| SC-003 | ≥1 scenario category per capability, ≥3 scenarios/category spanning difficulty | ≥3 per category | **Partially met — 1 category + 1 scenario per capability, single difficulty level** |
+| SC-004 | No architectural drift — new states follow the typestate pattern | Code review confirms | Met for register states; **not met for command-line, which lives in input-typestate only, not `EditorMode`** — see [[SRS#FR-005]] |
+| SC-005 | No scope creep into vim marks | Code review confirms | Met |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Run `cargo nextest run --workspace --all-features --lib --bins` and
+  `cargo nextest run scenario` after any implementation change here
+- Follow the existing typestate pattern in `src/input/typestate/`
+- Add doc comments (`///`) to all new `pub` items
+
+### Ask First
+- Implementing `:s` substitute or any command-line command beyond
+  `:goto`/`:g` (see [[BRD#What Was Implemented]] — this is now a genuinely
+  new, unscoped follow-up, not part of what shipped)
+- Any change to the existing default/unnamed clipboard behavior
+
+### Never
+- Introduce vim-style marks under any name — permanently rejected per issue #104
+- Silently swallow malformed command-line input or invalid register names
+
+## 9. Open Questions
+
+All five `[NEEDS CLARIFICATION]` items from the original draft were
+implicitly resolved by the implementation — see [[SRS#5.1 Traceability Matrix]]
+for how. One new question is introduced by the resolution:
+
+- [NEEDS CLARIFICATION: should `:s` substitute (and `:g` global-with-subcommand,
+  as distinct from the `:g N` goto alias that shipped) be scoped as its own
+  follow-up feature, given the original US-002/FR-006 were not satisfied?
+  `docs/HELIX_KEYBINDINGS.md` already documents this narrowing explicitly to
+  users — see [[plan#Documented Scope Narrowing]].]
+
+## 10. Resolution (Retroactive)
+
+Implemented by commit `1ba668d` (2026-08-09), closing issue #282. Named
+registers shipped essentially as drafted (FR-001..004), plus `R` support.
+Command-line mode shipped **narrower than drafted**: only `:goto N` (line
+navigation, alias `:g N`) exists — no `:s` substitute, no `:g` global
+command, no ranges. This was an explicit, documented scoping decision (see
+`docs/HELIX_KEYBINDINGS.md`'s scope disclaimer), not an oversight. Full
+verdict in [[SRS]].
+
+## 11. See Also
+
+- [[constitution]] — project principles
+- [[BRD]] — business rationale and what actually shipped
+- [[SRS]] — FR-by-FR verdict
+- [[NFR]] — non-functional requirement verdicts
+- [[plan]] — as-built architecture
+- [[tasks]] — retroactive task breakdown
+- [[MOC-specs]] — all specifications
+- [Helix Keymap Reference](https://docs.helix-editor.com/keymap.html)
+- [Helix Command-Line Reference](https://docs.helix-editor.com/command-line.html)
+- [S-Sigdel/vimhjkl](https://github.com/S-Sigdel/vimhjkl) — reference project
+- Issue #198 — Helix command content-coverage gap (macros, scroll, view mode, selection-regex — distinct, unaddressed)
+- Issue #104 — vim-style marks explicitly rejected (authoritative prior art)

--- a/specs/register-command-mode-support/tasks.md
+++ b/specs/register-command-mode-support/tasks.md
@@ -1,0 +1,257 @@
+---
+aliases:
+  - Register and Command-Line Mode Tasks
+tags:
+  - sdd
+  - tasks
+  - helix-simulator
+  - input-system
+  - status/implemented
+created: 2026-08-09
+status: implemented
+related:
+  - "[[spec]]"
+  - "[[plan]]"
+---
+
+# Implementation Tasks: Named Register and Command-Line Mode Support (Retroactive)
+
+> [!info] References
+> **Spec**: [[spec]]
+> **Plan**: [[plan]]
+> **Total tasks**: 7 completed (commit `1ba668d`), 2 recommended follow-ups
+> (not scheduled)
+>
+> Retroactive breakdown reconstructed from the diff for traceability.
+
+## Progress
+
+- [x] T001: Add `RegisterFile` and generalize simulator clipboard state
+- [x] T002: Add register-selection typestate (`RegisterPending`, `RegisterOpPending`)
+- [x] T003: Wire register-aware yank/paste/replace commands
+- [x] T004: Add `CommandLine::Goto` and `CommandLinePending` typestate
+- [x] T005: Harden input dispatch (multi-byte register chars, Alt/Ctrl fallthrough, arcade Esc)
+- [x] T006: Add `normalize_command_id` for FSRS/quest tracking
+- [x] T007: Add scenario coverage and update `docs/HELIX_KEYBINDINGS.md`
+- [ ] T008 (follow-up, not scheduled): Implement `:s` substitute
+- [ ] T009 (follow-up, not scheduled): Extend `EditorMode` with a real `CommandMode` variant
+
+---
+
+## Dependency Graph
+
+```mermaid
+graph TD
+    T001[T001: RegisterFile] --> T002[T002: register typestate]
+    T002 --> T003[T003: register-aware commands]
+    T004[T004: CommandLine::Goto + typestate] --> T003
+    T003 --> T005[T005: input hardening]
+    T004 --> T005
+    T003 --> T006[T006: normalize_command_id]
+    T004 --> T006
+    T006 --> T007[T007: scenarios + docs]
+    T005 --> T007
+    T007 -.optional follow-up.-> T008[T008: :s substitute]
+    T004 -.optional follow-up.-> T009[T009: EditorMode::CommandMode]
+```
+
+---
+
+### T001: Add `RegisterFile` and Generalize Simulator Clipboard State
+
+**Context**: Foundation for named registers — replace the single
+`clipboard: Option<String>` field with a real named-storage map, without
+duplicating structure.
+**Spec reference**: [[spec#FR-004]]
+**Acceptance criteria**:
+- [x] `RegisterFile` (`HashMap<char, String>`, `UNNAMED_REGISTER = '"'`)
+      added to `src/helix/simulator/register_file.rs`
+- [x] `HelixSimulator.clipboard` renamed/replaced with
+      `registers: RegisterFile`
+- [x] Existing default-clipboard tests pass unmodified aside from the
+      field rename
+**Dependencies**: none
+**Files**: `src/helix/simulator/register_file.rs`, `src/helix/simulator/mod.rs`
+**Complexity**: low
+
+---
+
+### T002: Add Register-Selection Typestate
+
+**Context**: `"` and `"<reg>` need pending-input states consistent with
+the existing `GotoPending`/`ViewPending`/`MatchPending` pattern.
+**Spec reference**: [[spec#FR-001]]
+**Acceptance criteria**:
+- [x] `RegisterPending` (after `"`) and `RegisterOpPending { register:
+      char }` (after `"<reg>`) added to `InputState`/`state_types.rs`
+- [x] Invalid register-name characters route to `UserError` and return to
+      `BaseState`
+**Dependencies**: T001
+**Files**: `src/input/typestate/input_state.rs`, `state_types.rs`, `handlers/register.rs`
+**Complexity**: medium
+
+---
+
+### T003: Wire Register-Aware Yank/Paste/Replace Commands
+
+**Context**: Connect the register-selection typestate to real
+yank/paste/replace behavior against `RegisterFile`.
+**Spec reference**: [[spec#FR-002]], [[spec#FR-003]]
+**Acceptance criteria**:
+- [x] `"<reg>y` yanks into the named register
+- [x] `"<reg>p`/`"<reg>P` paste from the named register after/before cursor
+- [x] `"<reg>R` (extension beyond the draft) replaces with the named
+      register's content
+- [x] Any other key after `"<reg>` cancels the pending state
+**Dependencies**: T001, T002
+**Files**: `src/helix/simulator/commands/clipboard.rs`, `commands/mod.rs`
+**Complexity**: medium
+
+---
+
+### T004: Add `CommandLine::Goto` and `CommandLinePending` Typestate
+
+**Context**: Deliver a reachable command-line prompt, scoped to
+goto-line-N navigation after evaluating and dropping `:s`/`:g`-global/
+`:sort`/`:clear-register` as not verifiable against the snapshot-based
+scenario completion model.
+**Spec reference**: [[spec#FR-005]], [[spec#FR-007]], [[spec#FR-008]]
+**Acceptance criteria**:
+- [x] `:` enters `CommandLinePending { buffer }`
+- [x] `CommandLine::Goto(usize)` parses `:N`, `:goto N`, `:g N`
+- [x] Enter on valid input applies the goto and returns to Normal mode
+- [x] Escape discards input, no document mutation
+- [x] Malformed input converts to `Cancel` via intercepted `UserError`,
+      not a propagated panic-risking error
+- [x] `security::limits::MAX_COMMAND_LINE_LEN = 256` bounds buffer growth
+**Dependencies**: none (parallel to T001-T003)
+**Files**: `src/helix/simulator/command_line.rs`, `src/input/typestate/handlers/command_line.rs`, `src/security.rs`
+**Complexity**: medium
+**Note**: `EditorMode` was deliberately not extended — see [[plan#Key Design Decisions]]. `:s` substitute (FR-006) was **not** implemented — see T008.
+
+---
+
+### T005: Harden Input Dispatch
+
+**Context**: Building register/command-line handling surfaced adjacent
+input-robustness defects, fixed in the same commit rather than deferred.
+**Spec reference**: not drafted — discovered during implementation, see [[NFR#6. Unanticipated Finding]]
+**Acceptance criteria**:
+- [x] Multi-byte/non-ASCII register-name characters no longer panic
+      (`chars()` used instead of byte-length/`.nth()` indexing)
+- [x] Unmapped Alt/Ctrl key combinations no longer fall through as
+      bare-char commands
+- [x] Arcade-mode Esc cancels pending register/command-line/prefix state
+      instead of unconditionally pausing; input state resets between
+      arcade scenarios
+**Dependencies**: T002, T004
+**Files**: `src/input/typestate/handlers/base.rs`, `keytrie.rs`, `handlers.rs`
+**Complexity**: medium
+
+---
+
+### T006: Add `normalize_command_id` for FSRS/Quest Tracking
+
+**Context**: Register letters and command-line invocations need to
+collapse to stable, trackable FSRS/quest command IDs rather than one ID
+per raw string permutation.
+**Spec reference**: [[spec#FR-010]]
+**Acceptance criteria**:
+- [x] `normalize_command_id()` added to `src/helix/commands.rs`,
+      canonicalizing e.g. `"ay` → `"y`, `:g 3` → `:goto`
+- [x] Wired at 3 call sites: `scenario_completion.rs:163`,
+      `minigame/session.rs:848`, `ui/state/handlers/quests.rs:21`
+- [x] Regression test confirms consistent normalization
+**Dependencies**: T003, T004
+**Files**: `src/helix/commands.rs`, `src/minigame/session.rs`, `src/ui/state/handlers/quests.rs`
+**Complexity**: low
+
+---
+
+### T007: Add Scenario Coverage and Update Documentation
+
+**Context**: Ground both new capabilities in playable, FSRS-trackable
+content and disclose the goto-only command-line scope to users.
+**Spec reference**: [[spec#FR-009]], [[spec#US-003]]
+**Acceptance criteria**:
+- [x] `ScenarioCategory::Registers` added
+- [x] `scenarios/en/registers/named-registers.toml` (1 scenario) added
+- [x] `scenarios/en/movement/command-line-goto.toml` (1 scenario) added
+- [x] Both pass `cargo nextest run scenario`
+- [x] `docs/HELIX_KEYBINDINGS.md` updated with explicit "❌ everything
+      else" disclaimer for the command-line surface
+**Dependencies**: T005, T006
+**Files**: `src/config/scenarios.rs`, `scenarios/en/registers/`, `scenarios/en/movement/`, `docs/HELIX_KEYBINDINGS.md`
+**Complexity**: low
+
+---
+
+### T008 (Follow-up, Not Scheduled): Implement `:s` Substitute
+
+**Context**: The original US-002/FR-006 goal — search-and-replace via
+`:s/pattern/replacement/` — remains fully unimplemented. Only goto
+navigation shipped.
+**Spec reference**: [[spec#FR-006]], [[BRD#Open Questions]]
+**Acceptance criteria**:
+- [ ] `CommandLine` gains a `Substitute { pattern, replacement, scope }`
+      variant (or equivalent)
+- [ ] Scope semantics (current line/selection/whole document) resolved
+      against real Helix behavior before implementation, not assumed
+- [ ] Compatible with the snapshot-based scenario completion model, or an
+      explicit design note on how it becomes verifiable (the reason this
+      was dropped from the original scope)
+- [ ] Malformed regex surfaces `UserError`, does not modify the document
+**Dependencies**: T004 (extends the existing `CommandLine` type)
+**Files**: `src/helix/simulator/command_line.rs`, `src/input/typestate/handlers/command_line.rs`
+**Complexity**: high
+
+---
+
+### T009 (Follow-up, Not Scheduled): Extend `EditorMode` with a Real `CommandMode` Variant
+
+**Context**: Close the NFR-002 architectural gap — command-line state
+currently lives only in the input-typestate layer, not in the simulator's
+own sealed-trait mode type.
+**Spec reference**: [[spec#FR-005]], [[NFR#NFR-002]]
+**Acceptance criteria**:
+- [ ] `EditorMode` gains a `CommandMode` variant following the existing
+      sealed-trait pattern
+- [ ] `CommandLinePending` (input layer) and `EditorMode::CommandMode`
+      (simulator layer) are reconciled — either the input state drives the
+      simulator mode, or a maintainer decision is recorded that this is
+      unnecessary
+**Dependencies**: T004
+**Files**: `src/helix/simulator/mode.rs`
+**Complexity**: medium — mostly a modeling exercise, low runtime-behavior risk
+
+---
+
+## Implementation Notes
+
+### Order of execution
+T001 → T002 → T003 (registers) can proceed in parallel with T004
+(command-line, independent subsystem) before both converge at T005-T007.
+T008/T009 are independent follow-ups with no forced ordering between them.
+
+### Common patterns
+Follow the established typestate pattern (`state_types.rs` marker structs +
+`HandlerState`/`Sealed`); route all failure modes through `UserError`;
+prefer canonicalization functions over `src/learning/`-side lookup tables
+for command-ID mapping, per T006's precedent.
+
+### Gotchas
+- Do not assume `:` implies `EditorMode::CommandMode` exists — it does not
+  (see T004's note and [[NFR#NFR-002]]). Any code checking `EditorMode`
+  will not see command-line state.
+- Register-name character handling must use `chars()`, not byte length or
+  `.nth()` — multi-byte input caused real panics before T005.
+- If T008 is picked up, resolve the "not verifiable against snapshot-based
+  completion" constraint from T004 first — it is the reason `:s` was
+  dropped, not merely deferred for time.
+
+## See Also
+
+- [[spec]] — feature specification (retroactive)
+- [[plan]] — as-built architecture and residual work
+- [[BRD]] — business rationale
+- [[MOC-specs]] — all specifications


### PR DESCRIPTION
## Summary

- Moves three retroactively-authored Spec-Driven Development packages (FSRS proptest-coverage-gap, named-register/command-mode support, arcade-gamification-session-fixes) from the gitignored `.local/specs/` working area into the tracked `specs/` tree, alongside the existing `specs/arcade-game-mode-variety/` package.
- Adds `specs/constitution.md` (project-wide principles, synthesized from existing `.claude/CLAUDE.md` / `.claude/rules/*.md` conventions) and a consolidated `specs/MOC-specs.md` index.
- Fixes cross-references inside the moved packages that pointed at the old `.local/specs/` paths.

Each package documents functionality that is already implemented and merged (FSRS proptest coverage: #330; named registers/command-mode: #329; arcade session bookkeeping fixes: #322), so these are retroactive specs, not proposals for new work. Each package's README/spec notes where the shipped scope narrowed or partially covered the original draft.

## Test plan

- [x] Docs-only change — no source/test code touched, full check suite not required per repo convention
- [x] Verified no stale `.local/specs/` cross-references remain outside the intentional historical reference to the still-uncommitted `002-arcade-game-mode-variety` draft