### PR TITLE
docs(specs): add proposed spec packages for training-content expansion

### DIFF
--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -32,6 +32,16 @@ superseded)
 | [[register-command-mode-support/README\|Named Register and Command-Line (`:`) Mode Support]] | review | implemented (command-line mode narrower than drafted — `:goto`/`:g` only, no `:s` substitute) |
 | [[arcade-gamification-session-fixes/spec\|Arcade Gamification Session Bookkeeping Fixes]] | specify (lightweight, per SDD scaling guidance) | implemented |
 
+## Proposed Specs
+
+Not yet built. Drafted for review/prioritization only.
+
+| Feature | Phase | Status |
+|---------|-------|--------|
+| [[language-aware-syntax-highlighting/spec\|Language-Aware Syntax Highlighting for Scenario Content]] | specify (lightweight, per SDD scaling guidance) | proposed — shared prerequisite for the two specs below |
+| [[writing-markup-scenario-track/spec\|Writing / Markup Scenario Track]] | specify (lightweight, per SDD scaling guidance) | proposed — evaluates GitHub issue #152, depends on [[language-aware-syntax-highlighting/spec\|Language-Aware Syntax Highlighting]] |
+| [[multi-language-scenario-content/spec\|Multi-Language Scenario Content]] | specify (lightweight, per SDD scaling guidance) | proposed — depends on [[language-aware-syntax-highlighting/spec\|Language-Aware Syntax Highlighting]] |
+
 ## Project Foundation
 
 - [[constitution]] — non-negotiable project principles. Created 2026-08-09,

--- a/specs/language-aware-syntax-highlighting/spec.md
+++ b/specs/language-aware-syntax-highlighting/spec.md
@@ -1,0 +1,173 @@
+---
+aliases:
+  - Language-Aware Syntax Highlighting
+  - Scenario Filetype Field
+tags:
+  - sdd
+  - spec
+  - ui
+  - scenarios
+  - config
+  - architecture
+  - status/proposed
+created: 2026-08-09
+status: proposed
+related:
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+---
+
+# Feature: Language-Aware Syntax Highlighting for Scenario Content
+
+> [!info] Metadata
+> **Depth**: Lightweight spec only, per this project's SDD scaling guidance
+> ("small bug / single function → 3-5 sentences + acceptance criteria") —
+> this is a scoped fix touching one struct field and one function body, no
+> new module or architecture. A full BRD/SRS/NFR/plan/tasks package would be
+> disproportionate.
+> **Status**: Proposed — not yet implemented.
+
+## 1. Overview
+
+### Problem Statement
+
+`highlight_code_with_multi_cursor` in `src/ui/render/highlight.rs:65` calls
+`SYNTAX_SET.find_syntax_by_extension("rs")` unconditionally to highlight
+every scenario's `file_content`, regardless of what that content actually
+is. The `Scenario`/`Setup` struct in `src/config/scenarios.rs` has no
+`language`/`filetype` field at all, so there is no way for a scenario TOML
+to declare its content type — and `Scenario` derives
+`#[serde(deny_unknown_fields)]`, so a TOML author cannot even add an ad-hoc
+field without a schema change.
+
+This has been invisible so far because all 149 currently-shipped scenarios
+across the 9 categories under `scenarios/en/` contain exclusively
+Rust-flavored content (`fn`, `let`, `struct`, `use`, `println` — verified
+via `grep -h "file_content" -A1 scenarios/en/*/*.toml`). But the hardcoding
+silently blocks two independently-useful directions that are both currently
+being drafted:
+
+1. A markdown/prose-editing scenario track (GitHub issue #152) — markdown
+   highlighted as Rust renders headings, links, and emphasis with wrong
+   token boundaries.
+2. Diversifying existing code-editing categories across multiple
+   programming languages (Python, JS/TS, Go, C) so that different
+   bracket/quote/indentation/comment-token conventions exercise Helix
+   motions differently — any such content would render with incorrect
+   (Rust) syntax coloring today.
+
+### Goal
+
+A scenario TOML can optionally declare its content's language/filetype; the
+highlighter resolves the syntect syntax definition from that declaration
+instead of a hardcoded `"rs"` literal, with existing scenarios continuing
+to render identically (defaulting to Rust) without any TOML changes.
+
+### Out of Scope
+
+- Actually authoring any non-Rust scenario content (markdown track,
+  multi-language code track) — that is the job of the two dependent specs
+  listed in [[#9. See Also|See Also]]
+- Adding new syntect syntax definitions beyond what `SyntaxSet::load_defaults_newlines`
+  already bundles (covers common languages including Markdown, Python,
+  JavaScript, TypeScript, Go, C — sufficient for both dependent tracks)
+- Per-line or embedded/mixed-language highlighting within a single scenario
+  (e.g. Markdown with fenced code blocks) — one language per scenario only
+- Changing the highlighting theme (`base16-eighties.dark` stays as-is)
+
+## 2. Functional Requirements
+
+Use EARS notation. Prefix with FR-NNN.
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | THE SYSTEM SHALL support an optional `language` field on `Setup` (`src/config/scenarios.rs`), deserialized as `Option<String>` with `#[serde(default)]`, so existing scenario TOML files that omit it continue to parse without modification | must |
+| FR-002 | WHEN a scenario's `Setup.language` is `None` THE SYSTEM SHALL treat it as `"rs"` (current hardcoded behavior), preserving identical rendering for all 149 existing scenarios | must |
+| FR-003 | WHEN `highlight_code_with_multi_cursor` is invoked THE SYSTEM SHALL resolve the syntect syntax via `find_syntax_by_extension` (or `find_syntax_by_token`, whichever syntect provides for the declared value) using the scenario's effective language string instead of the literal `"rs"` | must |
+| FR-004 | WHEN the declared `language` value does not match any syntax definition known to `SYNTAX_SET` THE SYSTEM SHALL fall back to `SYNTAX_SET.find_syntax_plain_text()` (plain, unhighlighted text) rather than panicking or silently reusing Rust highlighting | must |
+| FR-005 | THE SYSTEM SHALL accept `language` values as file-extension-style tokens (e.g. `"rs"`, `"md"`, `"py"`, `"js"`, `"go"`, `"c"`) consistent with the tokens syntect's bundled `SyntaxSet` resolves via `find_syntax_by_extension`, so scenario authors don't need to know syntect-internal syntax names | should |
+| FR-006 | THE SYSTEM SHALL validate `language` (if present) the same way other scenario string fields are validated/sanitized (see `src/security::sanitizer`/`validators`), rejecting scenario files with malformed or oversized values consistent with existing `MAX_*` limits conventions | should |
+
+## 3. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Backward Compatibility | All 149 existing scenario TOML files under `scenarios/en/**/*.toml` MUST continue to load and render with zero visual diff — no `language` field needs to be added to any of them; `cargo nextest run scenario` MUST pass unchanged |
+| NFR-002 | Robustness | An unsupported/misspelled `language` value MUST NOT cause a panic, `unwrap()` failure, or crash on load or render — it degrades to plain text (FR-004), never to a hard error at scenario-load time |
+| NFR-003 | Performance | Syntax resolution is a `HashMap`-backed lookup in a `LazyLock`-cached `SyntaxSet` already paid for today; adding a language parameter must not introduce measurable per-frame overhead beyond the existing lookup cost |
+| NFR-004 | Maintainability | The change is confined to `Setup`/`highlight_code_with_multi_cursor` and their direct call sites — no new module, no new public API surface beyond the one struct field |
+
+## 4. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| `Setup` (`src/config/scenarios.rs`) | Initial editor state for a scenario, currently `file_content: String` + flattened `CursorSpec` | + `language: Option<String>` (new, optional, defaults to `None` → treated as `"rs"`) |
+
+No new entities. `TargetState` is not touched — target content is compared
+structurally against the document, never syntax-highlighted, so it does not
+need a `language` field.
+
+## 5. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Existing scenario TOML with no `language` field | Parses as `None`, highlighter uses `"rs"` — identical to current behavior (FR-002) |
+| `language = "md"` and syntect's bundled defaults include Markdown | Highlighted using the Markdown syntax definition |
+| `language = "cobol"` (or any extension not in the bundled `SyntaxSet`) | Falls back to `find_syntax_plain_text()` — content renders unstyled but readable, no crash (FR-004) |
+| `language = ""` (empty string, explicitly set) | Treated as an unsupported value per FR-004 — falls back to plain text, not silently coerced to `"rs"` |
+| Two scenarios in the same TOML file with different `language` values | Each resolves independently per its own `Setup.language` — no cross-scenario leakage, since `HighlightLines` is constructed fresh per call inside `highlight_code_with_multi_cursor` |
+
+## 6. Success Criteria
+
+Measurable metrics that prove the feature works:
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Existing scenario test suite | `cargo nextest run --workspace --all-features --lib --bins` and `cargo nextest run scenario` pass unchanged, 0 regressions |
+| SC-002 | Backward-compat rendering | All 149 existing scenarios render with the same highlighted output as before the change (no `language` field added to any of them) |
+| SC-003 | Unsupported-language handling | A regression test asserting that an unknown `language` value resolves to `find_syntax_plain_text()` and does not panic |
+| SC-004 | Unlocks dependent specs | `specs/writing-markup-scenario-track/` and `specs/multi-language-scenario-content/` can declare `language = "md"` / `language = "py"` (etc.) without further changes to `src/ui/render/highlight.rs` or `src/config/scenarios.rs` |
+
+## 7. Agent Boundaries
+
+### Always (without asking)
+- Run `cargo nextest run --workspace --all-features --lib --bins` and
+  `cargo nextest run scenario` after touching `src/config/scenarios.rs` or
+  `src/ui/render/highlight.rs`
+- Keep `Scenario`'s `#[serde(deny_unknown_fields)]` intact — add the new
+  field explicitly to `Setup` rather than loosening field validation
+
+### Ask First
+- Adding a new dependency to expand syntect's bundled language coverage
+  beyond `SyntaxSet::load_defaults_newlines` (e.g. a custom `.sublime-syntax`
+  bundle) — the default set is expected to be sufficient for both
+  dependent tracks; confirm before pulling in extra assets
+
+### Never
+- Add `language` to `TargetState` — target content is never rendered
+  through the syntax highlighter
+- Change the fallback behavior for unresolved languages to reuse Rust
+  highlighting — that reintroduces a silent-wrong-coloring failure mode,
+  the same class of bug this spec exists to fix
+
+## 8. Open Questions
+
+- [NEEDS CLARIFICATION: Should `language` also gate any non-rendering
+  behavior (e.g. future language-aware scoring/diffing), or is its scope
+  strictly limited to `highlight.rs` for now? Assumed strictly rendering-only
+  for this spec; dependent specs should re-raise if that assumption breaks.]
+- [NEEDS CLARIFICATION: Exact validation rule for FR-006 (max length,
+  allowed character set) — deferred to implementation, follow the pattern
+  of the nearest existing string field validator in `src/security/validators.rs`.]
+
+## 9. See Also
+
+- [[constitution]] — project principles
+- [[MOC-specs]] — all specifications
+- `specs/writing-markup-scenario-track/` — proposed markdown/prose scenario
+  track (issue #152); depends on this spec for correct Markdown rendering
+- `specs/multi-language-scenario-content/` — proposed diversification of
+  code-editing categories across Python/JS/TS/Go/C; depends on this spec
+  for correct per-language rendering
+- `src/ui/render/highlight.rs` — implementation target
+- `src/config/scenarios.rs` — `Setup` struct, implementation target

--- a/specs/multi-language-scenario-content/spec.md
+++ b/specs/multi-language-scenario-content/spec.md
@@ -1,0 +1,211 @@
+---
+aliases:
+  - Multi-Language Scenario Content
+  - Non-Rust Scenario Syntax Variety
+tags:
+  - sdd
+  - spec
+  - scenarios
+  - i18n
+  - content
+  - status/proposed
+created: 2026-08-09
+status: proposed
+related:
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+---
+
+# Feature: Multi-Language Scenario Content
+
+> [!info] Metadata
+> **Origin**: `rust-researcher` continuous-improvement cycle, 2026-08-09 —
+> content-expansion research alongside the writing/markup track proposal.
+> **Priority**: P3
+> **Depth**: Lightweight spec only, per this project's SDD scaling
+> guidance ("feature (1-3 files)" tier) — this is content diversification
+> within existing categories, not a new content type or architecture
+> change. No BRD/SRS/NFR/plan/tasks package.
+
+## 1. Overview
+
+### Problem Statement
+
+All 149 existing scenarios, across all 9 categories (`basic`, `clipboard`,
+`editing`, `macros`, `movement`, `registers`, `repeat`, `search`,
+`selection`), use exclusively Rust-flavored syntax in their
+`setup.file_content` and `target.file_content` fields — confirmed via
+`grep -h "file_content" -A1 scenarios/en/*/*.toml`, which shows only `fn`,
+`let`, `struct`, `use`, `println!` style content and zero occurrences of
+Python (`def`, indentation-significant blocks), JS/TS, Go, or C-style
+content.
+
+This matters because different languages exercise Helix's motions and
+text-objects differently:
+
+- **Bracket density** — Rust/C/JS lean heavily on `{}`/`()`/`[]`, which
+  drives `mi(`, `ms`, `md` surround-command drills. Python code is
+  comparatively bracket-sparse.
+- **String quoting style** — single vs. double quotes, Python triple/
+  f-strings vs. Rust's plain `"..."` — affects `mi"` / `ma"` text-object
+  drills.
+- **Indentation semantics** — Python is indentation-significant, unlike
+  Rust's brace-delimited blocks. This meaningfully changes how `>`/`<`
+  (indent/outdent) and `=` (reindent) commands behave and are trained.
+- **Comment tokens** — `//` (Rust/JS/Go) vs. `#` (Python) vs. `/* */`
+  block comments — relevant to any future comment-toggle scenarios.
+
+Training exclusively on Rust syntax means a user who writes Python, Go, or
+JS/TS day-to-day has drilled Helix motions only against Rust's syntax
+shape, not the shape of code they will actually edit. Motion muscle memory
+transfers, but the specific keystroke sequence for, e.g., deleting a
+Python triple-quoted string or reindenting a Python block after an `if`
+insertion is untested by the current library.
+
+> [!note] Competitive Parity
+> Researched vim-be-good, vimtutor, OpenVim, Vim Adventures, and VimHero —
+> none of them vary the programming language of their code-editing drills
+> either. This is a potential differentiator, not catch-up.
+
+### Goal
+
+A pilot set of scenarios in 1-2 categories (recommended: `movement` and
+`editing`) has a parallel Python variant validating that non-Rust syntax
+content is viable, sets a content-authoring pattern other languages
+(Go, JS/TS) can follow later, and does not require any `ScenarioCategory`
+enum changes.
+
+### Out of Scope
+
+- Adding new `ScenarioCategory` variants — a Python/Go/JS scenario fits
+  existing categories unchanged; this is pure content diversification
+- Implementing language-aware syntax highlighting itself — that is the
+  prerequisite tracked in [[language-aware-syntax-highlighting/spec|Language-Aware Syntax Highlighting]]
+  (being authored separately; this feature is blocked on it landing)
+- Full rollout across all 9 categories and all target languages in one
+  pass — start with the 1-2 category pilot described here
+- Non-programming-language content tracks (markdown/writing prose) — see
+  the sibling proposal [[writing-markup-scenario-track/spec|Writing/Markup Scenario Track]]
+- Localizing scenario *descriptions/hints* into other spoken languages —
+  unrelated to `metadata.locale`; this spec is about the programming
+  language of the sample code, not the UI/prose language
+
+## 2. User Stories
+
+### US-001: Python developer drills Python-shaped code
+
+AS A helix-trainer user whose daily work is in Python
+I WANT movement and editing drills that operate on Python syntax
+(indentation-significant blocks, `def`/`class`, single/double-quoted
+strings, `#` comments)
+SO THAT the motions I practice map directly onto the code shapes I edit
+every day, including indent/outdent behavior that Rust's brace-delimited
+syntax never exercises
+
+**Acceptance criteria:**
+```
+GIVEN the scenario library includes a Python variant of a movement or
+  editing scenario
+WHEN  the user selects that scenario from the scenario browser
+THEN  the scenario loads with Python source content, a correct target
+      state expressed in Python syntax, and a solution key sequence that
+      achieves that target using the same Helix commands taught by the
+      Rust original
+```
+
+### US-002: Content author adds a new-language variant without touching the enum
+
+AS A content author extending the scenario library to a new language
+I WANT to author a scenario TOML file using existing `ScenarioCategory`
+values
+SO THAT I do not need a code change to `src/config/scenarios.rs` to add
+language variety — only new TOML content and (once the prerequisite
+lands) a `language` field on `Setup`
+
+**Acceptance criteria:**
+```
+GIVEN a new scenario TOML file with Python file_content is placed under
+  scenarios/en/movement/ using an existing category value (e.g. "movement")
+WHEN  the scenario loader parses the file
+THEN  it loads successfully with no changes required to ScenarioCategory
+      or any other enum in src/config/scenarios.rs
+```
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | THE SYSTEM SHALL support scenario content in languages other than Rust using the existing `ScenarioCategory` enum unchanged — no new variants added for this feature | must |
+| FR-002 | WHEN [[language-aware-syntax-highlighting/spec\|the language-aware syntax highlighting prerequisite]] lands (a `language` field on `Setup`/`TargetState` and per-language syntax lookup replacing the hardcoded `find_syntax_by_extension("rs")` in `src/ui/render/highlight.rs`) THE SYSTEM SHALL allow non-Rust scenario TOML files to declare their language and render with correct syntax highlighting | must |
+| FR-003 | THE SYSTEM SHALL author a pilot set of Python-variant scenarios covering 1-2 existing categories (recommended: `movement`, `editing`), each a parallel of an existing Rust scenario testing the same command(s) against Python-shaped content | must |
+| FR-004 | THE SYSTEM SHALL prioritize Python pilot scenarios that specifically exercise indentation-significant behavior (`>`, `<`, `=` commands against `if`/`for`/`def` blocks) since this is the syntax dimension with no Rust equivalent | should |
+| FR-005 | WHEN no `language` field is present on a scenario's `Setup` THE SYSTEM SHALL default to Rust syntax highlighting, preserving current behavior for all 149 existing scenarios | must |
+| FR-006 | THE SYSTEM SHALL NOT modify or renumber any existing Rust scenario's `id` when adding parallel-language variants — new scenarios get new, distinct IDs | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Compatibility | All 149 existing Rust-only scenarios remain the default and are byte-for-byte unchanged by this feature — no `language` field means Rust, exactly as today |
+| NFR-002 | Testability | New Python-variant scenario TOML files must pass `cargo nextest run scenario` (structural/schema validation) with no changes to the validator required beyond what the prerequisite spec already introduces |
+| NFR-003 | Dependency | This feature cannot ship visually-correct syntax highlighting until [[language-aware-syntax-highlighting/spec\|language-aware-syntax-highlighting]] lands; scenario TOML content may be authored ahead of that landing but should not be exposed to users (e.g. behind a feature flag or unmerged branch) until highlighting is correct, to avoid a regression where Python code is mis-highlighted as Rust |
+| NFR-004 | Scope discipline | The pilot (FR-003) is capped at 1-2 categories and does not block on or require full 9-category, multi-language coverage before being considered a successful validation |
+
+## 5. Data Model
+
+No new persistent entities. Reuses the existing `Scenario` /
+`ScenarioMetadata` / `Setup` / `TargetState` structures in
+`src/config/scenarios.rs`. The only structural addition this feature
+depends on — a `language` field on `Setup`/`TargetState` — is owned by
+the prerequisite spec, not this one.
+
+| Entity | Description | Relevant Fields (existing, unchanged) |
+|--------|-------------|----------------|
+| `Scenario` | A single trainable drill | `id`, `setup`, `target`, `solution`, `metadata` |
+| `ScenarioMetadata` | Filtering/quest metadata | `category` (existing `ScenarioCategory` enum, unchanged), `locale` (spoken-language of prose, unrelated to code language) |
+| `Setup` / `TargetState` | Initial/goal editor content | `file_content` (will hold Python source for pilot scenarios) |
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| A Python-variant scenario is authored before the highlighting prerequisite lands | Content is valid TOML and passes `cargo nextest run scenario`, but is not surfaced to end users until highlighting support ships (per NFR-003) |
+| A scenario's Python solution requires a Helix command with no direct Rust-scenario equivalent (e.g. reindent after `def`) | Author it as a new scenario testing that command explicitly rather than forcing a 1:1 mirror of an existing Rust scenario |
+| Difficulty/category filters are applied by the user in the scenario browser | Python-variant scenarios appear identically alongside Rust scenarios in the same category/difficulty buckets — no separate "language" filter is introduced by this feature |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | Pilot Python scenarios pass validation | `cargo nextest run scenario` green for all new scenario files |
+| SC-002 | Existing scenario suite unaffected | `cargo nextest run --workspace --all-features --lib --bins` shows zero regressions in existing 149 scenarios |
+| SC-003 | Pilot scope | At least one Python scenario each in `movement` and `editing` categories, with at least one specifically exercising indent/outdent (`>`/`<`/`=`) semantics |
+| SC-004 | No enum drift | `ScenarioCategory` in `src/config/scenarios.rs` has zero new variants after this feature ships |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Run `cargo nextest run scenario` after adding or modifying any scenario TOML file
+- Reuse existing `ScenarioCategory` values; never introduce a new category for language variety alone
+
+### Ask First
+- Merging/exposing Python-variant scenario content to users before confirming [[language-aware-syntax-highlighting/spec|language-aware-syntax-highlighting]] has landed and been verified against non-Rust content
+- Adding a `language` field to `Setup`/`TargetState` outside the prerequisite spec's implementation (avoid duplicating that work here)
+
+### Never
+- Modify the `id` or content of an existing Rust scenario to "convert" it — always add a new, separate scenario file for the language variant
+- Add a new `ScenarioCategory` variant to accommodate a new language — categories are motion/action-based, not language-based
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: Which languages beyond Python are in scope for a second wave — Go and JS/TS were named as candidates but not prioritized against each other]
+- [NEEDS CLARIFICATION: Should the scenario browser eventually gain a language filter/badge, or should language variety stay invisible to the category/difficulty UI as proposed here]
+
+## 10. See Also
+
+- [[constitution]] — project principles
+- [[MOC-specs]] — all specifications
+- [[language-aware-syntax-highlighting/spec|Language-Aware Syntax Highlighting]] — **prerequisite**: this feature's syntax-correct rendering is blocked on that spec landing (`language` field on `Setup`, replacing the hardcoded `find_syntax_by_extension("rs")` in `src/ui/render/highlight.rs`). Being authored in parallel by the same research cycle; link target may not exist yet at time of writing.
+- [[writing-markup-scenario-track/spec|Writing/Markup Scenario Track]] — sibling content-expansion proposal from the same research cycle, sharing the same highlighting prerequisite but targeting prose/markdown content rather than additional programming languages
+- `src/config/scenarios.rs` — `ScenarioCategory`, `Scenario`, `Setup` definitions referenced throughout this spec
+- `scenarios/en/` — existing 149 Rust-only scenario TOML files across 9 categories

--- a/specs/writing-markup-scenario-track/spec.md
+++ b/specs/writing-markup-scenario-track/spec.md
@@ -1,0 +1,278 @@
+---
+aliases:
+  - Writing / Markup Scenario Track
+  - Markdown & Typst Prose Editing Scenarios
+tags:
+  - sdd
+  - spec
+  - scenarios
+  - ui
+  - config
+  - status/proposed
+created: 2026-08-09
+status: proposed
+related:
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+---
+
+# Feature: Writing / Markup Scenario Track
+
+> [!info] Metadata
+> **Source**: GitHub issue #152 ("markdown/typst related scenarios"),
+> filed by @fabiosirna, labeled `enhancement`, `P4`, `scenarios`
+> (repo-assigned priority). This spec's own triage priority is **P3** —
+> see rationale below.
+> **Status**: Proposed — research/evaluation complete, not yet built.
+> **Depth**: Lightweight spec only, per this project's SDD scaling
+> guidance. No dedicated new engine capability is required (see FR-001
+> rationale) — this is primarily new scenario content plus one closed-enum
+> extension, so a full BRD/SRS/NFR/plan/tasks package would be
+> disproportionate at this stage. Revisit depth if scope grows once
+> `[NEEDS CLARIFICATION]` items below are resolved.
+
+## 1. Overview
+
+### Problem Statement
+
+helix-trainer's scenario library (`scenarios/en/{basic,clipboard,editing,
+macros,movement,registers,repeat,search,selection}/`) is built almost
+entirely around code-editing motions and commands. Issue #152 observes that
+users who write prose or technical documentation in Helix (Markdown, Typst)
+exercise a distinct pattern set that today's scenarios don't drill:
+surround-based emphasis (bold/italic), link construction, list
+indent/outdent, heading-level changes, blockquote prefixing, and code-fence
+wrapping. None of the current categories target this workflow, so a writer
+learning Helix has no dedicated on-ramp — they'd have to infer prose-editing
+technique from code-focused drills.
+
+Investigation confirmed this is cheaper to deliver than the issue title
+("new module") suggests:
+
+1. The core mechanic issue #152 leans on hardest — `ms`/`md`/`mr`
+   (add/delete/replace surround) — is **already fully implemented**:
+   `CMD_SURROUND_ADD_PREFIX` in `src/helix/commands.rs`, the `ms` chord
+   resolution in `src/helix/registry/keytrie.rs`, `surround_selection` /
+   `delete_surround` / `replace_surround` in
+   `src/helix/simulator/commands/editing.rs`, and full typestate coverage
+   in `src/input/typestate/`. However,
+   `scenarios/en/editing/surround.toml` carries a **stale** header comment
+   ("Note: ms (add surround) is not yet implemented") — the file currently
+   contains only `md`/`mr` scenarios; no `ms` scenarios exist yet, but
+   nothing blocks authoring them today. See FR-006.
+2. `HelixSimulator` has no tree-sitter or filetype-aware textobject logic
+   (confirmed: no `tree_sitter` / `Syntax::` / `Loader::` usage anywhere
+   under `src/`). It purely replays real Helix keystrokes against a
+   `helix-core` buffer. A "markdown scenario" is therefore not a new
+   simulator capability — it is ordinary `setup`/`target`/`solution` TOML
+   content, same as any other scenario, provided the syntax-highlighting
+   rendering issue below is addressed first.
+3. `ScenarioCategory` (`src/config/scenarios.rs`) is a closed Rust enum —
+   `Movement | Editing | Clipboard | Search | Selection | TextObjects |
+   Advanced | Registers | Multi | Other` — not a free-form string sourced
+   from TOML. Introducing a "Writing" category is a source-code change (new
+   variant + updating every exhaustive `match` over it across
+   filtering/UI/quest-generation code), not just adding a new
+   `scenarios/en/writing/` directory.
+4. **Prerequisite**: `src/ui/render/highlight.rs` hardcodes
+   `find_syntax_by_extension("rs")` and `Setup` has no `language` field —
+   all scenario content renders with Rust syntax highlighting regardless of
+   actual content. Markdown/Typst scenario text would render with
+   incorrect coloring until this is fixed. Tracked separately in
+   [[../language-aware-syntax-highlighting/spec|Language-Aware Syntax
+   Highlighting]] (parallel/companion spec). This feature depends on that
+   one landing first — see FR-007.
+5. **Competitive landscape**: vim-be-good, vimtutor, OpenVim, Vim
+   Adventures, and VimHero were checked — none ship a dedicated
+   markdown/prose-editing drill track. This would be a genuine
+   differentiator for helix-trainer, not parity catch-up, which supports
+   prioritizing it above a typical "someday" (P4) request despite its
+   modest scope.
+
+### Goal
+
+A learner can select a "Writing" category filter and complete a coherent
+set of scenarios that drill the concrete prose-editing use cases from issue
+#152 — surround-based emphasis, link construction, list indent/outdent,
+heading-level change, blockquote prefixing, and code-fence wrapping —
+rendered with correct Markdown (and, if in scope, Typst) syntax
+highlighting.
+
+### Out of Scope
+
+- Any new `HelixSimulator` capability, tree-sitter integration, or
+  filetype-aware textobjects — this feature is scenario content plus a
+  category enum addition, not an engine change
+- "Structural paragraph/list movement" (issue #152's Obsidian
+  Alt+Up/Alt+Down analogy) — Helix has no single built-in keybinding
+  equivalent to move a paragraph/list-item as a unit; see
+  `[NEEDS CLARIFICATION]` FR-003 below on whether to scope this out
+  entirely or approximate it with select+delete+paste
+- Converting an unordered list to a numbered list (mentioned in issue
+  #152's "List management" bullet) — no direct Helix command performs this
+  transformation; likely out of scope, see FR-004
+- The [[../language-aware-syntax-highlighting/spec|syntax-highlighting
+  prerequisite]] itself — that is a separate spec and separate PR
+- Any change to `ScenarioCategory`'s existing variants or the surround
+  command implementation
+
+## 2. User Stories
+
+### US-001: Practicing text emphasis in prose
+
+AS A technical writer using Helix for Markdown documentation
+I WANT dedicated drills for wrapping a word or selection in `**bold**` or
+`_italic_` using `ms`
+SO THAT I build the same muscle memory for emphasis that I already have for
+code-editing motions
+
+**Acceptance criteria:**
+```
+GIVEN a scenario in the Writing category with setup text containing an
+  unformatted word and a target with that word wrapped in ** **
+WHEN the learner selects the word and executes ms*
+THEN the scorer reports success against the target buffer state
+```
+
+### US-002: Constructing a Markdown link
+
+AS A documentation author
+I WANT a scenario that drills select-word → wrap in `[ ]` → move to end →
+append `(url)`
+SO THAT I can build links fluently without looking up the keystroke sequence
+
+**Acceptance criteria:**
+```
+GIVEN a scenario with setup text containing a bare word and a target with
+  that word rendered as a Markdown link to a fixed placeholder URL
+WHEN the learner performs the documented solution keystrokes
+THEN the resulting buffer matches the target exactly
+```
+
+### US-003: Adjusting list and heading structure
+
+AS A writer restructuring a Markdown outline
+I WANT drills for indenting/outdenting list items and bumping a heading
+between `##` and `###`
+SO THAT these become fast, deliberate edits rather than manual retyping
+
+**Acceptance criteria:**
+```
+GIVEN a scenario with a list item or heading line at one level
+WHEN the learner applies the documented indent/outdent or heading-edit
+  solution
+THEN the resulting line matches the target level exactly
+```
+
+### US-004: Quoting and fencing a block
+
+AS A writer citing a source or including a code sample in a Markdown/Typst
+document
+I WANT drills for prefixing a paragraph with `> ` (blockquote) and wrapping
+a block with triple backticks (code fence)
+SO THAT these structural edits become as fluent as `ms`-based surround
+edits already are for inline emphasis
+
+**Acceptance criteria:**
+```
+GIVEN a scenario with a plain paragraph and a target with `> ` prefixed to
+  each line (blockquote) or the block wrapped in fenced code delimiters
+WHEN the learner applies the documented solution
+THEN the resulting buffer matches the target exactly
+```
+
+## 3. Functional Requirements
+
+Use EARS notation. Prefix with FR-NNN.
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN this feature is implemented THE SYSTEM SHALL NOT require any new `HelixSimulator`, tree-sitter, or filetype-aware textobject capability — all scenarios SHALL be expressible with existing `setup`/`target`/`solution` TOML fields and existing simulator commands | must |
+| FR-002 | WHEN a scenario is authored under the Writing track THE SYSTEM SHALL classify it via a new `ScenarioCategory::Writing` enum variant, and every existing exhaustive `match` over `ScenarioCategory` (filtering UI, quest generation, and any other call site) SHALL be updated to handle it | must |
+| FR-003 | WHEN authoring scenarios for issue #152's "Structural movement" use case (move a paragraph/list item, analogous to Obsidian's Alt+Up/Down) THE SYSTEM SHALL either omit this use case from the initial scope or implement it via an approximation using existing select/delete/paste commands — `[NEEDS CLARIFICATION: Helix has no single built-in "move block" keybinding; confirm whether to (a) scope this out entirely, (b) approximate via select-line(s) + delete + move + paste, or (c) treat as a candidate for a future dedicated command outside this spec's scope]` | must |
+| FR-004 | WHEN authoring scenarios for issue #152's "convert a list to a numbered list" use case THE SYSTEM SHALL treat it as out of scope, since no direct Helix command performs this transformation — `[NEEDS CLARIFICATION: confirm this exclusion is acceptable, or identify a keystroke sequence that approximates it (e.g., manual per-line find/replace) worth drilling anyway]` | should |
+| FR-005 | WHEN authoring Writing-track scenarios THE SYSTEM SHALL cover, at minimum, the following concrete use cases from issue #152: (a) bold/italic emphasis via `ms`, (b) Markdown link construction (select word, wrap `[ ]`, append `(url)`), (c) list item indent/outdent (`>`/`<`), (d) heading level change (e.g., `##` ↔ `###`), (e) blockquote prefixing (`> `), (f) code-fence wrapping (triple backtick) | must |
+| FR-006 | WHEN this feature is implemented THE SYSTEM SHALL correct the stale header comment in `scenarios/en/editing/surround.toml` ("Note: ms (add surround) is not yet implemented") as a drive-by fix, since `ms` has been fully implemented since the surround feature landed | must |
+| FR-007 | WHEN Writing-track scenarios are authored with Markdown or Typst content THE SYSTEM SHALL render them with correct language-specific syntax highlighting, which depends on [[../language-aware-syntax-highlighting/spec|Language-Aware Syntax Highlighting]] landing first — `[NEEDS CLARIFICATION: is Markdown-only sufficient for v1, with Typst deferred until the highlighting prerequisite confirms Typst support, or must both ship together?]` | must |
+| FR-008 | WHEN a Writing-track scenario TOML file is added to the repository THE SYSTEM SHALL pass `cargo nextest run scenario` schema validation, identical to every other scenario category | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Compatibility | Adding `ScenarioCategory::Writing` SHALL NOT change the serialized representation or behavior of any existing category value (backward-compatible enum extension, `#[serde(rename_all = "lowercase")]` convention preserved) |
+| NFR-002 | Testability | All new scenario TOML files SHALL pass `cargo nextest run scenario` (schema/solution validation) as a hard gate before merge |
+| NFR-003 | Consistency | New scenarios SHALL follow the existing TOML schema and file organization convention (`scenarios/en/<category>/*.toml`) used by all other categories, with no new fields introduced without updating the shared scenario schema/parser |
+| NFR-004 | Maintainability | Filtering UI and quest-generation code touched to handle the new enum variant SHALL be updated exhaustively (no `_ => ...` catch-all introduced solely to sidestep the compiler's exhaustiveness check) |
+
+## 5. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|-----------------|
+| `ScenarioCategory::Writing` | New enum variant identifying prose/markup-editing scenarios | Serialized as `writing` per existing `rename_all = "lowercase"` convention |
+| Writing-track `Scenario` (TOML) | Ordinary `Scenario` entity (no new fields), content targeting Markdown/Typst prose-editing patterns | `setup` (initial buffer + cursor, Markdown/Typst content), `target` (goal buffer state), `solution` (canonical keystrokes), `metadata.category = Writing`, `metadata.commands_taught`, `metadata.tags` |
+
+No new persistent entities, no changes to `Profile`, FSRS card state, or
+any other data model outside the `ScenarioCategory` enum itself.
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Learner selects "Writing" category filter before any Writing scenarios exist | Category is a valid, empty result set — same behavior as any other category with zero matching scenarios today; no special-case handling required |
+| A Writing scenario's `setup` content contains Typst-specific syntax before Typst highlighting support lands | Scenario SHOULD be gated behind confirming Typst support in the prerequisite spec, or restricted to Markdown-only content for v1 (see FR-007 clarification) |
+| Existing code that exhaustively matches `ScenarioCategory` is missed during the enum addition | `cargo build` fails to compile (Rust's exhaustiveness checking on non-`_` matches) — this is a compile-time safety net, not a runtime edge case, but should be called out during implementation review |
+| A Writing scenario's `target` requires the "move paragraph" use case that has no direct Helix equivalent (FR-003) | Scenario SHOULD NOT be authored until FR-003's `[NEEDS CLARIFICATION]` is resolved — do not ship a scenario whose "solution" is an artificial workaround presented as canonical technique without flagging it as such in `metadata.tags` |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | `ScenarioCategory::Writing` compiles and every existing exhaustive match site handles it | 100% (verified by `cargo build` + `cargo clippy --all-targets --all-features --workspace -- -D warnings`) |
+| SC-002 | New Writing-track scenario TOML files pass schema validation | 100% via `cargo nextest run scenario` |
+| SC-003 | Concrete use cases from issue #152 covered by at least one scenario each (excluding items explicitly scoped out per FR-003/FR-004) | 6/6 in-scope use cases (FR-005 a–f) |
+| SC-004 | Stale `surround.toml` comment corrected | Done (FR-006) |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Run `cargo nextest run scenario` after adding or modifying any Writing
+  scenario TOML file
+- Run the full check suite (`cargo +nightly fmt --check`, `cargo clippy
+  --all-targets --all-features --workspace -- -D warnings`, `cargo nextest
+  run --workspace --all-features --lib --bins`) after adding the
+  `ScenarioCategory::Writing` enum variant
+- Correct the stale `scenarios/en/editing/surround.toml` header comment as
+  part of this work (FR-006)
+
+### Ask First
+- Authoring any scenario that approximates the "move paragraph/list item"
+  use case (FR-003) before its `[NEEDS CLARIFICATION]` is resolved
+- Adding Typst-specific scenario content before confirming Typst support in
+  [[../language-aware-syntax-highlighting/spec|the highlighting
+  prerequisite]] (FR-007)
+
+### Never
+- Add a new `HelixSimulator` capability, tree-sitter dependency, or
+  filetype-aware textobject logic to satisfy this feature — if a use case
+  appears to require one, flag it and scope it out rather than expanding
+  the simulator (violates FR-001 / Out of Scope)
+- Introduce a `_ => ...` catch-all in an exhaustive `ScenarioCategory`
+  match purely to avoid updating call sites for the new variant
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: FR-003 — should "structural paragraph/list movement" be scoped out entirely, approximated with select+delete+paste, or deferred as a future dedicated-command request?]
+- [NEEDS CLARIFICATION: FR-004 — is excluding "convert list to numbered list" acceptable, or is there a worthwhile approximate drill?]
+- [NEEDS CLARIFICATION: FR-007 — does v1 require both Markdown and Typst highlighting support, or can Typst scenarios be deferred until the prerequisite spec confirms Typst support specifically?]
+- Should Writing-track scenarios support a language other than English content-wise (this repo's existing scenarios live under `scenarios/en/`), or is English-only prose content acceptable for v1 given the trainer's existing i18n scope is UI strings, not scenario content?
+
+## 10. See Also
+
+- [[constitution]] — project principles
+- [[MOC-specs]] — all specifications
+- [[../language-aware-syntax-highlighting/spec|Language-Aware Syntax Highlighting]] — prerequisite spec; Writing-track scenarios depend on this landing first for correct Markdown/Typst rendering
+- GitHub issue [#152](https://github.com/bug-ops/helix-trainer/issues/152) — "markdown/typst related scenarios" (original feature request this spec evaluates)
+- `scenarios/en/editing/surround.toml` — contains the stale `ms`-not-implemented comment corrected by FR-006
+- `src/config/scenarios.rs` — `ScenarioCategory` enum definition (FR-002 target)
+- `src/ui/render/highlight.rs` — hardcoded Rust syntax highlighting, addressed by the prerequisite spec


### PR DESCRIPTION
## Summary
- Adds three lightweight, not-yet-implemented spec packages produced by the CI research cycle (cycle 005) answering issue #152's follow-up question: should helix-trainer expand beyond generic code-editing scenarios into distinct content tracks?
- `specs/language-aware-syntax-highlighting/spec.md` — shared prerequisite fix (`Setup` has no `language` field; highlighting is hardcoded to Rust). Relates to #360.
- `specs/writing-markup-scenario-track/spec.md` — evaluates a Markdown/Typst "Writing" scenario category per #152 (does not close #152). Relates to #361.
- `specs/multi-language-scenario-content/spec.md` — evaluates diversifying scenario content across programming languages. Relates to #362.
- `specs/MOC-specs.md` gains a new "Proposed Specs" section indexing all three as `status: proposed` pending review/prioritization.

## Test plan
- [x] Docs-only change — no code, no build/test impact
- [ ] Maintainer review/prioritization of the three proposed specs