### PR TITLE
release: v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-10
+
 ### Added
 
 - `scripts/install.sh` and `scripts/install.ps1`: one-line installers that resolve the latest (or a pinned) GitHub release, download the archive matching the current OS/architecture, verify its SHA-256 checksum, and install the `helix-trainer` binary. `install.sh` covers Linux (glibc and static musl builds via `--static`) and macOS on x86_64/aarch64; `install.ps1` covers Windows on x86_64/aarch64. README's Installation section documents both as the recommended path alongside manual archive download and building from source, with one-liners that resolve and pin to the latest release tag before fetching the script from `raw.githubusercontent.com`, instead of fetching from the mutable `main` branch ref. `install.sh` extracts the downloaded archive with [exarch](https://github.com/bug-ops/exarch) when available or bootstrappable on the host, falling back to the system `tar` otherwise (see #392 below for how the exarch bootstrap itself is verified). CI runs `shellcheck` on `scripts/install.sh` when it changes.
@@ -68,6 +70,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `deny.toml`'s `[bans].skip` now explicitly documents and skips the `windows_x86_64_{gnu,gnullvm,msvc}` and `winnow` duplicate-version clusters: each fans out from two independent transitive chains (`rodio -> cpal -> jni` vs `helix-core`/`helix-loader -> etcetera` for the `windows_x86_64_*` crates; `toml` 0.8 vs `toml` 1.x for `winnow`) that are not collapsible from this workspace without an upstream major-version alignment; `cargo update` confirms no newer compatible version resolves either. Silences the corresponding `cargo deny check bans` warnings (already non-blocking, `multiple-versions = "warn"`) with a recorded rationale instead of leaving them unexplained (#356)
 - **BREAKING**: `StreakChange::Protected`'s vestigial `used_freeze` field (always `true` in practice — the `false` case was never constructed) is dropped; it is now a unit variant (#310)
 - Training-mode (`record_scenario_completion`) and Arcade-mode (`execute_minigame_command`'s completion block) scenario completion no longer reimplement the same post-completion bookkeeping independently: speed-achievement counting (`SPEED_DEMON_TIME_RATIO`/`FLASH_TIME_RATIO` threshold checks plus `difficulties_completed` tracking), achievement-check-and-notify, and `LevelUp` notification construction are now shared through new `ScenarioCompletionService::track_speed_and_difficulty`/`check_and_notify_achievements`/`level_up_notification` methods. Behavior is unchanged for both modes, including Training's inline `save_immediate`/`save_debounced` persistence and Arcade's no-mid-session-persist policy (#358)
+- **BREAKING**: `ScoringConfig.optimal_count` is now `NonZeroUsize` instead of `usize`; TOML layout is unchanged, but zero rejection now happens at parse time, so `optimal_count = 0` now surfaces as "Failed to load scenario file..." instead of "Operation failed..." (#277)
+- **BREAKING**: Removed the now-unreachable `SecurityError::InvalidScoringConfig` variant (#277)
+- Unified scenario and quest ID validation into `security::validators::validate_id_field` (#275)
+- Consolidated scenario/quest TOML parsing, count-limit enforcement, and per-item validation into a shared `config::loader::parse_and_validate` pipeline (#276)
+- Collapsed the duplicated `PlayableScenario` trait implementations for `GameSession<Active>` and `GameSession<Completed>` into a single `impl<S: SessionState> PlayableScenario for GameSession<S>` block; the per-state `elapsed()` behavior is now dispatched through a new `SessionState::session_elapsed` associated function (#280)
+- **BREAKING**: Removed `AppState::save_profile_debounced`, `AppState::save_profile_immediate`, and `ProgressState::save_blocking` — the serialized save-writer path introduced for #294 left them with no production caller; the application's exit-time save now goes through `AppState::prepare_final_save_request` instead (#294)
+- `ScenarioCompletionService::record_and_scale_xp` now returns a named `XPScalingResult` struct instead of an unlabeled `(u64, ScenarioMastery, f64, f64, f64)` tuple, removing the risk of a silent positional swap between its three `f64` fields (#281)
 
 ### Fixed
 
@@ -148,16 +157,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### CI
 
 - Added a `changes` job (`dorny/paths-filter`) to `ci.yml` that skips the 3-OS `test` matrix, `msrv`, the 3-OS `build` matrix, and `coverage` when a push/PR only touches docs/metadata (no `src/`, `scenarios/`, `locales/`, manifests, or workflow files changed); `fmt`/`clippy`/`security` remain always-on since they're cheap and also cover config files like `Cargo.toml`. Any change under `.github/workflows/**` still forces every job to run. The `gate` job's pass/fail check now accepts a `skipped` result for the gated jobs only when the path filter deliberately excluded them, so a real failure or an unexpected skip still fails the gate.
-
-### Changed
-
-- **BREAKING**: `ScoringConfig.optimal_count` is now `NonZeroUsize` instead of `usize`; TOML layout is unchanged, but zero rejection now happens at parse time, so `optimal_count = 0` now surfaces as "Failed to load scenario file..." instead of "Operation failed..." (#277)
-- **BREAKING**: Removed the now-unreachable `SecurityError::InvalidScoringConfig` variant (#277)
-- Unified scenario and quest ID validation into `security::validators::validate_id_field` (#275)
-- Consolidated scenario/quest TOML parsing, count-limit enforcement, and per-item validation into a shared `config::loader::parse_and_validate` pipeline (#276)
-- Collapsed the duplicated `PlayableScenario` trait implementations for `GameSession<Active>` and `GameSession<Completed>` into a single `impl<S: SessionState> PlayableScenario for GameSession<S>` block; the per-state `elapsed()` behavior is now dispatched through a new `SessionState::session_elapsed` associated function (#280)
-- **BREAKING**: Removed `AppState::save_profile_debounced`, `AppState::save_profile_immediate`, and `ProgressState::save_blocking` — the serialized save-writer path introduced for #294 left them with no production caller; the application's exit-time save now goes through `AppState::prepare_final_save_request` instead (#294)
-- `ScenarioCompletionService::record_and_scale_xp` now returns a named `XPScalingResult` struct instead of an unlabeled `(u64, ScenarioMastery, f64, f64, f64)` tuple, removing the risk of a silent positional swap between its three `f64` fields (#281)
 
 ## [0.5.12] - 2026-07-27
 
@@ -1461,7 +1460,8 @@ With this release, all Phase 1 components are fully implemented:
 
 ---
 
-[Unreleased]: https://github.com/bug-ops/helix-trainer/compare/v0.5.12...HEAD
+[Unreleased]: https://github.com/bug-ops/helix-trainer/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/bug-ops/helix-trainer/compare/v0.5.12...v0.6.0
 [0.5.12]: https://github.com/bug-ops/helix-trainer/compare/v0.5.11...v0.5.12
 [0.5.11]: https://github.com/bug-ops/helix-trainer/compare/v0.5.10...v0.5.11
 [0.5.10]: https://github.com/bug-ops/helix-trainer/compare/v0.5.9...v0.5.10

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "helix-trainer"
-version = "0.5.12"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helix-trainer"
-version = "0.5.12"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.91"
 authors = ["Andrei G <andrei.g@my.com>"]

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ All modes feature:
 - **Rich Metadata** — Every scenario tagged with category, difficulty, taught commands, and practice focus
 - **Syntax Highlighting** — Realistic Rust code snippets with proper highlighting
 - **Real Helix Accuracy** — Uses official `helix-core` library (v25.07.1)
-- **100 Commands** — Movement, editing, clipboard, undo/redo, repeat, surround, text objects, multi-cursor
-- **134 Training Scenarios** — From basics to intermediate workflows with difficulty indicators
+- **95+ Commands** — Movement, editing, clipboard, undo/redo, repeat, surround, text objects, multi-cursor, registers, macros
+- **160 Training Scenarios** — From basics to intermediate workflows with difficulty indicators
 - **70 Daily Quests** — Easy, medium, and hard challenges across all commands
 - **100% Offline** — No cloud, no tracking, all data stays local (`~/.config/helix-trainer/`)
 - **Arrow Key Navigation** — Optional `enable_arrow_keys_in_normal_mode` configuration for cursor movement
@@ -96,7 +96,7 @@ Both one-liners resolve and pin to the latest release tag before fetching the sc
 Pin a specific version or install directory:
 
 ```bash
-./scripts/install.sh --version 0.5.12 --dir /usr/local/bin
+./scripts/install.sh --version 0.6.0 --dir /usr/local/bin
 ./scripts/install.sh --static   # Linux: static musl build, no audio feature
 ```
 
@@ -170,7 +170,7 @@ Mode Selection
 │  │  ├─ ✅ Practice: Complete 3 scenarios
 │  │  ├─ ⏳ Learning: Try 2 new scenarios
 │  │  └─ 🔄 Review: 5 cards due
-│  ├─ Scenario List (134 available)
+│  ├─ Scenario List (160 available)
 │  │  ├─ Basic Movement (Mastered - 20% XP)
 │  │  ├─ Word Navigation (Proficient - 50% XP)
 │  │  └─ Delete Line (Learning - 100% XP)
@@ -190,8 +190,11 @@ Mode Selection
 | **Match Mode** | <kbd>mm</kbd> (brackets) <kbd>ms</kbd> (surround) <kbd>md</kbd> (delete surround) <kbd>mr</kbd> (replace surround) |
 | **Text Objects** | <kbd>ma</kbd>/<kbd>mi</kbd> + <kbd>w</kbd> <kbd>W</kbd> <kbd>(</kbd> <kbd>[</kbd> <kbd>{</kbd> <kbd><</kbd> <kbd>"</kbd> <kbd>'</kbd> <kbd>`</kbd> <kbd>p</kbd> |
 | **Selection** | <kbd>x</kbd> <kbd>X</kbd> <kbd>v</kbd> <kbd>;</kbd> <kbd>,</kbd> <kbd>Alt</kbd>+<kbd>,</kbd> <kbd>%</kbd> <kbd>s</kbd> <kbd>S</kbd> <kbd>Alt</kbd>+<kbd>s</kbd> <kbd>Alt</kbd>+<kbd>;</kbd> <kbd>&</kbd> <kbd>_</kbd> <kbd>Alt</kbd>+<kbd>-</kbd> <kbd>Alt</kbd>+<kbd>_</kbd> <kbd>C</kbd> <kbd>Alt</kbd>+<kbd>C</kbd> <kbd>K</kbd> <kbd>Alt</kbd>+<kbd>K</kbd> |
-| **Editing** | <kbd>i</kbd> <kbd>a</kbd> <kbd>I</kbd> <kbd>A</kbd> <kbd>o</kbd> <kbd>O</kbd> <kbd>r</kbd> <kbd>c</kbd> <kbd>Alt</kbd>+<kbd>c</kbd> <kbd>d</kbd> <kbd>J</kbd> <kbd>Alt</kbd>+<kbd>J</kbd> <kbd>></kbd> <kbd><</kbd> <kbd>~</kbd> <kbd>`</kbd> <kbd>Alt</kbd>+<kbd>`</kbd> <kbd>R</kbd> <kbd>Alt</kbd>+<kbd>x</kbd> <kbd>Ctrl</kbd>+<kbd>c</kbd> (toggle comment) |
+| **Editing** | <kbd>i</kbd> <kbd>a</kbd> <kbd>I</kbd> <kbd>A</kbd> <kbd>o</kbd> <kbd>O</kbd> <kbd>r</kbd> <kbd>c</kbd> <kbd>Alt</kbd>+<kbd>c</kbd> <kbd>d</kbd> <kbd>Alt</kbd>+<kbd>d</kbd> <kbd>J</kbd> <kbd>Alt</kbd>+<kbd>J</kbd> <kbd>></kbd> <kbd><</kbd> <kbd>~</kbd> <kbd>`</kbd> <kbd>Alt</kbd>+<kbd>`</kbd> <kbd>R</kbd> <kbd>Alt</kbd>+<kbd>x</kbd> <kbd>Ctrl</kbd>+<kbd>c</kbd> (toggle comment) |
 | **Clipboard** | <kbd>y</kbd> <kbd>p</kbd> <kbd>P</kbd> |
+| **Registers** | <kbd>"</kbd><kbd>a</kbd>-<kbd>z</kbd> prefix on <kbd>y</kbd>/<kbd>p</kbd>/<kbd>P</kbd>/<kbd>R</kbd>/<kbd>d</kbd>/<kbd>c</kbd> (named registers) <kbd>"</kbd><kbd>_</kbd> (blackhole, discards writes) |
+| **Macros** | <kbd>q</kbd> (record/stop) <kbd>Q</kbd> (replay) |
+| **Command-line** | <kbd>:</kbd> then <kbd>goto N</kbd> / <kbd>g N</kbd> (jump to line) |
 | **Search** | <kbd>/</kbd> <kbd>?</kbd> <kbd>n</kbd> <kbd>N</kbd> <kbd>*</kbd> <kbd>Alt</kbd>+<kbd>*</kbd> |
 | **View** | <kbd>z</kbd> <kbd>zz</kbd> <kbd>zt</kbd> <kbd>zb</kbd> <kbd>zm</kbd> <kbd>zj</kbd> <kbd>zk</kbd> |
 | **Undo/Redo** | <kbd>u</kbd> <kbd>U</kbd> <kbd>Ctrl</kbd>+<kbd>r</kbd> |

--- a/docs/HELIX_KEYBINDINGS.md
+++ b/docs/HELIX_KEYBINDINGS.md
@@ -1,7 +1,7 @@
 # Helix Editor — Complete Keybindings Reference
 
 > **Source:** [docs.helix-editor.com/keymap.html](https://docs.helix-editor.com/keymap.html)
-> **Updated:** 2026-01-15
+> **Updated:** 2026-08-10
 
 Comprehensive reference of all Helix editor keybindings for developing training scenarios.
 
@@ -584,11 +584,11 @@ Track which commands have been implemented in the simulator:
 | ✅ | <kbd><</kbd> | Unindent selection |
 | ❌ | <kbd>=</kbd> | Format selection (LSP) |
 | ✅ | <kbd>d</kbd> | Delete selection |
-| ❌ | <kbd>Alt</kbd>+<kbd>d</kbd> | Delete without yanking |
+| ✅ | <kbd>Alt</kbd>+<kbd>d</kbd> | Delete without yanking |
 | ✅ | <kbd>c</kbd> | Change selection (delete and enter insert mode) |
-| ❌ | <kbd>Alt</kbd>+<kbd>c</kbd> | Change without yanking |
+| ✅ | <kbd>Alt</kbd>+<kbd>c</kbd> | Change without yanking |
 | ❌ | <kbd>Ctrl</kbd>+<kbd>a</kbd>, <kbd>Ctrl</kbd>+<kbd>x</kbd> | Increment/decrement number |
-| ❌ | <kbd>Q</kbd>, <kbd>q</kbd> | Record/replay macro |
+| ✅ | <kbd>Q</kbd>, <kbd>q</kbd> | Record/replay macro |
 
 ### Selection & Line Operations
 
@@ -665,6 +665,13 @@ Track which commands have been implemented in the simulator:
 | ✅ | <kbd>ma</kbd> + object | Select around text object |
 | ✅ | <kbd>mi</kbd> + object | Select inside text object |
 
+### Macros
+
+| Status | Keys | Description |
+|:------:|------|-------------|
+| ✅ | <kbd>Q</kbd> | Start/stop recording macro to a named register |
+| ✅ | <kbd>q</kbd> | Replay recorded macro from a named register |
+
 ### Command Mode
 
 | Status | Keys | Description |
@@ -676,9 +683,9 @@ Track which commands have been implemented in the simulator:
 
 ## Implementation Summary
 
-**Phase 2.2 Complete: 90+ Commands Implemented**
+**Phase 2.2 Complete: 95+ Commands Implemented**
 
-**Implemented:** 90+ commands covering most essential Helix operations
+**Implemented:** 95+ commands covering most essential Helix operations
 
 ### By Category
 
@@ -687,11 +694,12 @@ Track which commands have been implemented in the simulator:
 | **Movement** | 23 | <kbd>h</kbd> <kbd>j</kbd> <kbd>k</kbd> <kbd>l</kbd> <kbd>w</kbd> <kbd>b</kbd> <kbd>e</kbd> <kbd>W</kbd> <kbd>B</kbd> <kbd>E</kbd> <kbd>0</kbd> <kbd>$</kbd> <kbd>^</kbd> <kbd>gg</kbd> <kbd>ge</kbd> <kbd>gh</kbd> <kbd>gl</kbd> <kbd>gs</kbd> <kbd>G</kbd> <kbd>f</kbd> <kbd>F</kbd> <kbd>t</kbd> <kbd>T</kbd> |
 | **Paragraph** | 2 | <kbd>[p</kbd> <kbd>]p</kbd> |
 | **Page** | 4 | <kbd>Ctrl+b</kbd> <kbd>Ctrl+f</kbd> <kbd>Ctrl+u</kbd> <kbd>Ctrl+d</kbd> |
-| **Editing** | 17 | <kbd>i</kbd> <kbd>a</kbd> <kbd>I</kbd> <kbd>A</kbd> <kbd>o</kbd> <kbd>O</kbd> <kbd>d</kbd> <kbd>c</kbd> <kbd>r</kbd> <kbd>R</kbd> <kbd>~</kbd> <kbd>`</kbd> <kbd>Alt+`</kbd> <kbd>.</kbd> <kbd>u</kbd> <kbd>U</kbd> |
+| **Editing** | 19 | <kbd>i</kbd> <kbd>a</kbd> <kbd>I</kbd> <kbd>A</kbd> <kbd>o</kbd> <kbd>O</kbd> <kbd>d</kbd> <kbd>c</kbd> <kbd>r</kbd> <kbd>R</kbd> <kbd>~</kbd> <kbd>`</kbd> <kbd>Alt+`</kbd> <kbd>Alt+d</kbd> <kbd>Alt+c</kbd> <kbd>.</kbd> <kbd>u</kbd> <kbd>U</kbd> |
 | **Selection** | 20 | <kbd>x</kbd> <kbd>X</kbd> <kbd>v</kbd> <kbd>;</kbd> <kbd>,</kbd> <kbd>%</kbd> <kbd>s</kbd> <kbd>S</kbd> <kbd>C</kbd> <kbd>K</kbd> <kbd>Alt+C</kbd> <kbd>Alt+K</kbd> <kbd>Alt+s</kbd> <kbd>Alt+x</kbd> <kbd>_</kbd> <kbd>&</kbd> <kbd>Alt+-</kbd> <kbd>Alt+_</kbd> <kbd>Alt+,</kbd> |
 | **Search** | 6 | <kbd>/</kbd> <kbd>?</kbd> <kbd>n</kbd> <kbd>N</kbd> <kbd>*</kbd> <kbd>Alt+*</kbd> |
 | **View** | 6 | <kbd>z</kbd> <kbd>zz</kbd> <kbd>zt</kbd> <kbd>zb</kbd> <kbd>zm</kbd> <kbd>zj</kbd> <kbd>zk</kbd> |
 | **Match Mode** | 6 | <kbd>mm</kbd> <kbd>ms</kbd> <kbd>md</kbd> <kbd>mr</kbd> <kbd>ma</kbd> <kbd>mi</kbd> |
+| **Macros** | 2 | <kbd>Q</kbd> <kbd>q</kbd> |
 | **Indentation** | 2 | <kbd>></kbd> <kbd><</kbd> |
 | **Line ops** | 3 | <kbd>J</kbd> <kbd>Alt+J</kbd> <kbd>Ctrl+c</kbd> |
 | **Clipboard** | 3 | <kbd>y</kbd> <kbd>p</kbd> <kbd>P</kbd> |
@@ -701,18 +709,17 @@ Track which commands have been implemented in the simulator:
 
 ### Training Scenarios Coverage
 
-- ✅ 136 scenarios covering 90+ implemented commands
-- ✅ All scenarios use realistic Rust code
+- ✅ 160 scenarios covering 95+ implemented commands
+- ✅ All scenarios use realistic code (Rust, Python, Markdown)
 - ✅ Syntax highlighting for code display
 - ✅ Multiple difficulty levels per command
 - ✅ Hints and alternative solutions provided
-- ✅ Organized in thematic directory structure
+- ✅ Organized in thematic directory structure (movement, editing, registers, writing, macros, and more)
 
 ### Not Yet Implemented (Future Phases)
 
 - Tree-sitter selections (<kbd>Alt+o</kbd>, <kbd>Alt+i</kbd>, etc.)
 - LSP integration commands
-- Macros (<kbd>Q</kbd>, <kbd>q</kbd>) — named registers (<kbd>"</kbd>) are implemented, scoped to y/p/P/R
 - Window mode (<kbd>Ctrl+w</kbd>)
 - Space mode (<kbd>Space</kbd>)
 - Jumplist (<kbd>Ctrl+i</kbd>, <kbd>Ctrl+o</kbd>)

--- a/docs/SCENARIOS_AND_QUESTS.md
+++ b/docs/SCENARIOS_AND_QUESTS.md
@@ -105,7 +105,7 @@ description = "Use 'l' five times (less efficient)"
 
 ```toml
 [scenarios.metadata]
-category = "movement"              # movement, editing, clipboard, search, selection, textobjects, advanced, registers
+category = "movement"              # movement, editing, clipboard, search, selection, textobjects, advanced, registers, writing
 difficulty = "beginner"            # beginner, intermediate, advanced
 tags = ["word", "motion"]          # Flexible filtering tags
 commands_taught = ["w"]            # Commands this scenario teaches

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -14,8 +14,9 @@ status: moc
 > [!abstract]
 > Map of Content for all helix-trainer project specifications. Each entry
 > links to a feature spec with its current phase and status. This index
-> was last reconciled 2026-08-09 against actual merged implementation
-> state — see each package's README.md for the retroactive-documentation
+> was reconciled 2026-08-09 and again 2026-08-10 (v0.6.0 release prep)
+> against actual merged implementation state — see each package's
+> README.md (where present) for the retroactive-documentation
 > methodology.
 
 ## Active Specs
@@ -29,11 +30,14 @@ superseded)
 |---------|-------|--------|
 | [[fsrs-proptest-coverage-gap/README\|FSRS Scheduler Property-Based Test Coverage Gap]] | review | implemented (partial scope — see [[fsrs-proptest-coverage-gap/BRD#Residual Gap\|Residual Gap]]) |
 | [[arcade-game-mode-variety/README\|Arcade Game Mode Variety]] | rejected | NO-GO — full decision-record package, not built |
-| [[register-command-mode-support/README\|Named Register and Command-Line (`:`) Mode Support]] | review | implemented (command-line mode narrower than drafted — `:goto`/`:g` only, no `:s` substitute) |
-| [[arcade-gamification-session-fixes/spec\|Arcade Gamification Session Bookkeeping Fixes]] | specify (lightweight, per SDD scaling guidance) | implemented |
+| [[register-command-mode-support/README\|Named Register and Command-Line (`:`) Mode Support]] | review | implemented (command-line mode narrower than drafted — `:goto`/`:g` only, no `:s` substitute); extended in v0.6.0 with blackhole register and register-scoped delete/change — see [[register-command-mode-support/spec#11. Post-Release Extensions (v0.6.0)\|Post-Release Extensions]] |
+| [[arcade-gamification-session-fixes/spec\|Gamification Live-Trigger Wiring, Notifications, and Bookkeeping Fixes]] | specify (lightweight, per SDD scaling guidance) | implemented — broadened in v0.6.0 from one commit (`623e0a8`) to the full seven-commit bug-fix thread |
 | [[language-aware-syntax-highlighting/spec\|Language-Aware Syntax Highlighting for Scenario Content]] | specify (lightweight, per SDD scaling guidance) | implemented — shared prerequisite for the two specs below |
 | [[writing-markup-scenario-track/spec\|Writing / Markup Scenario Track]] | specify (lightweight, per SDD scaling guidance) | implemented — evaluates GitHub issue #152 (#361) |
 | [[multi-language-scenario-content/spec\|Multi-Language Scenario Content]] | specify (lightweight, per SDD scaling guidance) | implemented — pilot shipped as scoped (#362) |
+| [[regex-selection-and-macro-commands/spec\|Regex Selection (`s`/`S`) and Macro Record/Replay (`q`/`Q`)]] | specify (lightweight, per SDD scaling guidance) | implemented — closes issue #198's remaining scope (macros, selection-regex) |
+| [[custom-helix-keymap-support/spec\|Custom Helix Keymap Remapping (`use_helix_keymap`)]] | specify (lightweight, per SDD scaling guidance) | implemented — closes issue #163 |
+| [[end-game-summary-screen/spec\|End-Game Summary Screen on Curriculum Completion]] | specify (lightweight, per SDD scaling guidance) | implemented — closes issue #145 |
 
 ## Proposed Specs
 
@@ -86,6 +90,55 @@ changed and why:
   guidance for small, independent bug fixes (3 single-guard-clause
   changes, 6 files, no new architecture) — a full BRD/SRS/NFR/plan/tasks
   package would be disproportionate.
+
+## Reconciliation Notes (2026-08-10, v0.6.0 release prep)
+
+Reviewed every commit merged since the `v0.5.12` tag (61 commits) and
+updated this tree so it stays in sync with what actually shipped. Summary:
+
+- **arcade-gamification-session-fixes** (broadened) — was scoped to a
+  single commit (`623e0a8`, 3 bugs). Six more commits in the same release
+  turned out to be the same continuous bug-fix thread on
+  streaks/freezes/achievements/quests/level-ups/Daily Challenge
+  (`573fab8`, `1b1a8bb`, `04f0e8b`, `71ed504`, `a2b0185`, `e637c30`), each
+  triggered by adversarial review of the one before it, none previously
+  documented anywhere. Expanded the existing package in place (title
+  broadened, old title kept as an alias) rather than creating six new
+  micro-packages, per this project's guidance against excessive package
+  proliferation for small related fixes.
+- **register-command-mode-support** (extended) — its original research
+  spec deferred macros and selection-regex to "issue #198, separate,
+  still open." Issue #198 is now closed: `d66278d` added scroll/
+  select-all/`R` scenario coverage and explicitly deferred macros/regex;
+  `a4efc2e` then implemented exactly that deferral. A trio of further
+  commits (`fb2e0c5`, `dd39300`, `efeac9d`) extended register-scoped
+  behavior itself (blackhole register `"_`, register-scoped delete/change,
+  `Alt-c`/`Alt-d` noyank variants, a command-repeat register-drop fix).
+  Added as a new "Post-Release Extensions" section rather than a new
+  package, since these are direct extensions of FR-002/FR-003 in the
+  existing spec; stale "#198 still open" references corrected throughout
+  (spec.md and README.md).
+- **regex-selection-and-macro-commands** (new) — `a4efc2e` implemented
+  `s`/`S` (regex select/split) and `q`/`Q` (macro record/replay), a
+  substantial standalone feature (new `helix-stdx` dependency, new
+  `MacroRecorder`) with no prior spec coverage beyond a deferred bullet in
+  register-command-mode-support.
+- **custom-helix-keymap-support** (new) — `999e63e` (issue #163) plus
+  follow-up fixes `463d363` and `d7003ca` had no spec anywhere in the
+  repository despite being a substantial multi-file addition
+  (`src/input/keymap/`, `src/config/keymap/`).
+- **end-game-summary-screen** (new) — `0dbfcbe` (issue #145) had no spec
+  anywhere in the repository.
+- **No change needed** — the majority of the 61 commits are pure bug
+  fixes, internal refactors, or chores with no existing spec-level
+  behavior description to go stale: e.g. the `Clock` abstraction
+  (`ba8e0d3`), the `ScenarioFilter`/`DifficultyController` RNG-seam
+  refactor (`8100ebc`), the `MiniGameStats` field-to-accessor restructuring
+  (`e119429`), the `get_`-prefix getter renames (`34208d0`, `90eccbe`),
+  and the MSRV 1.89→1.91 bump (`fc95b07`) are all internal/architectural —
+  none were described by name in any existing spec, so nothing there is
+  now stale. The MSRV bump in particular is already correctly reflected in
+  [[constitution]] (Section II), written after that change landed.
 
 ## See Also
 

--- a/specs/arcade-gamification-session-fixes/spec.md
+++ b/specs/arcade-gamification-session-fixes/spec.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - Arcade Gamification Session Fixes
+  - Gamification Live-Trigger Wiring and Notification Fixes
   - Double XP / Streak Freeze / Review Level-Up Fixes
 tags:
   - sdd
@@ -13,71 +14,127 @@ created: 2026-08-09
 status: implemented
 related:
   - "[[constitution]]"
+  - "[[../end-game-summary-screen/spec]]"
   - "[[MOC-specs]]"
 ---
 
-# Feature: Arcade Gamification Session Bookkeeping Fixes
+# Feature: Gamification Live-Trigger Wiring, Notifications, and Bookkeeping Fixes
 
 > [!info] Metadata
-> **Resolved by**: commit `623e0a8` — "fix(gamification): stop double XP on
-> arcade replay, guard zero-streak freeze, notify review level-ups (#322)",
-> closing issues #317, #319, #318
+> **Resolved by**: an iterative bug-fix thread across seven commits —
+> `573fab8`, `1b1a8bb`, `04f0e8b`, `623e0a8`, `71ed504`, `a2b0185`,
+> `e637c30` — each triggered by adversarial/impl-critic review of the
+> previous PR, closing issues #256, #257, #267, #292, #309, #310, #317,
+> #318, #319, #325, #345, #346, #376.
 > **Status**: Implemented
-> **Depth**: Lightweight spec only, per this project's SDD scaling
-> guidance ("small bug fix → 3-5 sentences + acceptance criteria") — three
-> independent single-guard-clause fixes, 6 files, 179/-9 lines, no new
-> types or architecture. A full BRD/SRS/NFR/plan/tasks package would be
-> disproportionate. This document exists to fill a genuine documentation
-> gap: this work was previously undocumented in any spec, BRD, or decision
-> record anywhere in the repository.
+> **Depth**: Lightweight spec, per this project's SDD scaling guidance.
+> Each individual fix is small (a guard clause, a missing wiring call, a
+> notification), but they form one continuous thread on the same
+> subsystem (streaks/freezes/achievements/quests/level-ups/Daily
+> Challenge), so they are grouped in one evolving document rather than
+> one micro-package per commit. Originally scoped to `623e0a8` alone;
+> broadened during the v0.6.0 spec sync (2026-08-10) to cover the full
+> thread, which otherwise had no spec coverage anywhere in the
+> repository.
 
-> [!note] Not the Same Feature as `002-arcade-game-mode-variety`
+> [!note] Not the Same Feature as `arcade-game-mode-variety`
 > This is unrelated to GitHub issue #264 ("Arcade Game Mode Variety" — a
 > proposed reflex-drill minigame mechanic, rejected NO-GO; see
-> `specs/arcade-game-mode-variety/`). This spec covers three narrow
-> gamification bookkeeping bugs in the *existing* `Arcade`/review-session
-> code paths, not a new game mode.
+> `specs/arcade-game-mode-variety/`). This spec covers a family of
+> gamification bookkeeping/notification bugs in the *existing*
+> Training/Arcade/review-session code paths, not a new game mode.
 
 ## 1. Overview
 
 ### Problem Statement
 
-Three independent gamification bookkeeping defects existed in the arcade
-minigame and FSRS review-session paths:
+Streaks, streak freezes, achievements, quests, and Daily Challenge were
+each fully implemented and unit-tested in isolation, but the wiring that
+invokes them from live gameplay — and the player-facing notifications
+confirming they fired — shipped incrementally and buggily across seven
+commits, each surfaced by review of the one before it:
 
-1. **Double XP on arcade replay** (#317) — `handle_minigame_back_to_menu`
-   (`src/ui/state/handlers/minigame.rs`) unconditionally re-ran
-   `handle_minigame_game_over` whenever a `minigame_session` existed, with
-   no check for whether game-over bookkeeping had already run. Since
-   `handle_minigame_timeout` already runs it once when lives are depleted
-   (without clearing `minigame_session`), pressing the back-to-menu key at
-   the game-over screen re-awarded XP, re-incremented
-   `minigame_games_played`, and re-recorded an FSRS failure a second time
-   on the same session.
-2. **Zero-streak freeze guard** (#319) — `StreakManager::update_streak`
-   (`src/gamification/streak.rs`) consumed an available streak freeze and
-   emitted a `StreakFreezeUsed` notification on any missed day, without
-   checking whether `current_streak` was actually nonzero — silently
-   burning a freeze "protecting" a streak that was never active.
-3. **Missing review-session level-up notification** (#318) —
-   `handle_next_review_command` (`src/ui/state/handlers/review.rs`) called
-   `profile.add_xp(xp)` and discarded the returned `leveled_up` boolean, so
-   a level crossed purely by FSRS review-session XP produced no
-   `NotificationType::LevelUp`, inconsistent with the training-mode and
-   arcade-mode XP paths, which do notify.
+1. **`573fab8`** — `completed_quests_today`, streak-freeze eligibility, and
+   achievement unlocks were never invoked from the live scenario-completion
+   path: streaks could never increment, freezes could never be earned,
+   achievements never unlocked for real players. Fixed by wiring
+   `UserProfile::complete_quest` into quest completion, correcting freeze
+   eligibility to "every quest generated today" (the quest generator caps
+   at 4/day, so the previous fixed threshold of 5 was unreachable), and
+   running `AchievementEngine::check_achievements` on scenario completion
+   and profile load.
+2. **`1b1a8bb`** — adversarial review of (1) found three more gaps: quest
+   completion could double-award XP (a stale `previously_completed_quests`
+   re-detection tracker ran alongside `award_quest_completion_xp`; removed,
+   `QuestXpAward`'s return is now the single source of truth for both the
+   applied XP and the results-screen breakdown); `StreakManager::update_streak`
+   silently consumed a freeze with no player-facing notification (added
+   `NotificationType::StreakFreezeUsed`); achievements unlocked correctly
+   but had no persistent UI beyond a transient toast (added a scrollable
+   `Achievements` screen, `TypedScreen::Achievements`, reachable via the
+   `a` key, following the existing Statistics-screen pattern).
+3. **`04f0e8b`** — arcade mode discarded the `leveled_up` result from all
+   three of its `add_xp` calls (quest XP, scenario-completion XP,
+   end-of-game XP), so level-ups during arcade play never notified, unlike
+   training mode; all three now push `NotificationType::LevelUp`.
+   `StreakChange::Broken` went through the same match site as `Protected`
+   but was only logged at debug level; it now pushes a `StreakBroken`
+   notification, gated on `was_streak > 0` to avoid notifying on a streak
+   that was already at zero. `Protected`'s vestigial `used_freeze` field
+   (always `true` in practice) was dropped.
+4. **`623e0a8`** — three more bugs from review of (3): double XP on arcade
+   replay (`handle_minigame_back_to_menu` re-ran game-over bookkeeping on a
+   session already past `GameOver`); a zero-streak freeze guard gap
+   symmetric to (3)'s `StreakBroken` fix but for `StreakFreezeUsed`
+   (`StreakManager::update_streak` could consume a freeze and notify while
+   `current_streak` was already 0); a missing `LevelUp` notification on the
+   FSRS review-session completion path (`handle_next_review_command`
+   discarded `add_xp`'s `leveled_up` result, unlike training/arcade).
+5. **`71ed504`** — a single streak freeze protected a streak regardless of
+   how long the absence was, treating a 2-day gap and a 60-day gap
+   identically. A freeze now only covers a gap of up to
+   `STREAK_FREEZE_MAX_GAP_DAYS` (3 days, a Friday-to-Monday weekend
+   absence); beyond that the streak breaks normally and the freeze is left
+   unconsumed. Lower-bounded at 2 days so a negative gap from a backwards
+   clock or NTP correction can't silently consume the freeze.
+6. **`a2b0185`** — `use_freeze` (the explicit/manual freeze-use path) had
+   no gap-length check at all, diverging from (5)'s cap-aware policy on
+   `update_streak`. Both now share a `try_consume_freeze` helper;
+   `use_freeze` returns a distinct error instead of silently no-oping when
+   the gap or streak state can't be covered. `StreakChange::Broken` and the
+   `StreakBroken` notification gained a `freeze_could_not_cover_gap` flag
+   so a break caused by an out-of-cap gap reads distinctly from a plain
+   unprotected break.
+7. **`e637c30`** — `ChallengeProgress::can_attempt`/`start_attempt`/
+   `record_result` (Daily Challenge mode) were fully implemented and
+   unit-tested but had no production call site: Daily Challenge could be
+   launched unlimited times per day and best-score tracking never
+   persisted. `handle_launch_minigame_mode` now checks `can_attempt` before
+   creating a session and only consumes an attempt once the launch is
+   actually going to succeed (after the empty-scenario-pool guard);
+   `handle_minigame_game_over` records the result for Challenge-mode
+   sessions across every exit path; the mode-selection submenu shows
+   attempts remaining as `(N/3)`.
 
 ### Goal
 
-Each of the three bugs is fixed with a single additional guard condition,
-verified by a dedicated regression test, with no change to public API
-surface or data model.
+Every gamification subsystem that ships implemented-and-tested code
+(streaks, freezes, achievements, quests, level-ups, Daily Challenge)
+actually fires during live gameplay, with a player-facing notification for
+every state change, and no double-counting across the
+Training/Arcade/review-session paths.
 
 ### Out of Scope
 
 - Any change to XP formula, streak-freeze earning rules, or level
-  thresholds — only the bookkeeping/guard logic around existing rules
-- Arcade game-mode variety (`002-arcade-game-mode-variety`, unrelated,
+  thresholds — only the bookkeeping/guard/notification logic around
+  existing rules
+- Arcade game-mode variety (`arcade-game-mode-variety`, unrelated,
   separately researched and rejected)
+- Daily Challenge's scenario-selection logic itself — only the
+  attempt-cap/persistence wiring around it (item 7 above)
+- The Achievements screen's layout/rendering beyond following the
+  existing Statistics-screen pattern — not a distinct rendering spec
 
 ## 2. Acceptance Criteria (as shipped)
 
@@ -112,6 +169,53 @@ Tests: `test_review_session_completion_notifies_on_level_up`,
 `test_review_session_completion_no_level_up_notification_without_level_up`
 (`src/ui/state/tests/review_tests.rs`).
 
+```
+GIVEN a quest is completed
+WHEN  award_quest_completion_xp records XP
+THEN  the previously-completed-quests re-detection tracker is not
+      consulted — QuestXpAward is the single source of both the applied
+      XP and the results-screen breakdown, so no quest can award XP twice
+```
+
+```
+GIVEN a streak freeze is consumed to protect a streak
+WHEN  StreakManager::update_streak (or use_freeze) protects it
+THEN  a NotificationType::StreakFreezeUsed notification is shown, and
+      unlocked achievements are reachable afterward via the scrollable
+      TypedScreen::Achievements screen (key 'a')
+```
+
+```
+GIVEN an arcade quest/scenario/end-of-game XP award crosses a level
+  threshold
+WHEN  that award applies
+THEN  a NotificationType::LevelUp notification is shown, at parity with
+      the training-mode path
+```
+
+```
+GIVEN current_streak was nonzero and a missed day breaks it
+WHEN  the break is recorded
+THEN  a NotificationType::StreakBroken notification is shown, gated on
+      was_streak > 0
+```
+
+```
+GIVEN a streak-freeze-eligible gap exceeds STREAK_FREEZE_MAX_GAP_DAYS
+  (3 days)
+WHEN  update_streak or use_freeze evaluates the gap
+THEN  the freeze is left unconsumed, the streak breaks, and the resulting
+      StreakBroken notification's freeze_could_not_cover_gap flag is true
+```
+
+```
+GIVEN a Daily Challenge session has already been attempted 3 times today
+WHEN  the player tries to launch another Daily Challenge session
+THEN  handle_launch_minigame_mode refuses the launch before creating a
+      session, and the mode-selection submenu shows "(3/3)" attempts
+      remaining, read live from the profile
+```
+
 ## 3. Functional Requirements
 
 | ID | Requirement | Priority |
@@ -119,15 +223,30 @@ Tests: `test_review_session_completion_notifies_on_level_up`,
 | FR-001 | WHEN the player returns to the menu from the arcade game-over screen AND the minigame session has already reached the `GameOver` state THE SYSTEM SHALL NOT re-run game-over XP, games-played, or FSRS-failure bookkeeping for that session | must |
 | FR-002 | WHEN a streak-freeze check occurs on a missed day AND the user's `current_streak` is already 0 THE SYSTEM SHALL NOT consume the available streak freeze and SHALL NOT emit a `StreakFreezeUsed` notification | must |
 | FR-003 | WHEN a review session's completion XP award causes the profile to cross a level threshold THE SYSTEM SHALL emit a `LevelUp` notification reporting the new level, consistent with the training-mode and arcade-mode XP paths | must |
+| FR-004 | WHEN quest-completion XP is awarded THE SYSTEM SHALL treat `QuestXpAward`'s return as the single source of truth for both the profile XP applied and the results-screen breakdown — no separate re-detection tracker may award it a second time | must |
+| FR-005 | WHEN a streak freeze protects a streak THE SYSTEM SHALL emit a `NotificationType::StreakFreezeUsed` notification (previously silent), and WHEN an achievement unlocks THE SYSTEM SHALL make it reachable afterward via a scrollable `TypedScreen::Achievements` screen bound to the `a` key | must |
+| FR-006 | WHEN an arcade quest, scenario-completion, or end-of-game XP award crosses a level threshold THE SYSTEM SHALL emit a `LevelUp` notification, and WHEN a nonzero streak breaks on a missed day THE SYSTEM SHALL emit a `StreakBroken` notification | must |
+| FR-007 | WHEN a streak-freeze-eligible gap exceeds `STREAK_FREEZE_MAX_GAP_DAYS` (3 days, lower-bounded at 2) THE SYSTEM SHALL leave the freeze unconsumed and break the streak normally, via a policy shared identically between `update_streak` and `use_freeze` (`try_consume_freeze`); the resulting `StreakBroken` notification SHALL set `freeze_could_not_cover_gap` to distinguish it from a plain unprotected break | must |
+| FR-008 | WHEN a Daily Challenge launch is attempted THE SYSTEM SHALL check `ChallengeProgress::can_attempt` before creating a session, consume an attempt only once the launch is actually going to succeed, record the result across every exit path, and display attempts remaining as `(N/3)` in the mode-selection submenu | must |
 
-All three implemented as-is, no deviation, no residual gap — confirmed by
-the six regression tests listed above.
+All eight requirements implemented as-is, confirmed by the regression
+tests in each resolving commit.
 
 ## 4. Data Model
 
-No new persistent entities. No changes to `Profile`, `CardState`, or
-`MiniGameStats` schema — only guard conditions on existing fields
-(`is_game_over()`, `current_streak`, `leveled_up` return value).
+No new persistent entities beyond what the underlying subsystems already
+declared. Changes are to bookkeeping guards, notification emission, and UI
+surface:
+
+| Entity | Description |
+|--------|-------------|
+| `TypedScreen::Achievements` / `AchievementsData` | New scrollable screen, key `a`, mirrors the Statistics-screen pattern |
+| `NotificationType::{StreakFreezeUsed, StreakBroken, LevelUp}` | Player-facing notifications wired into every XP/streak path that previously fired silently or not at all |
+| `StreakChange::Broken.freeze_could_not_cover_gap: bool` | Distinguishes an out-of-cap break from a plain unprotected one |
+| `STREAK_FREEZE_MAX_GAP_DAYS` | Constant (3 days), shared cap enforced by both `update_streak` and `use_freeze` via `try_consume_freeze` |
+| `ChallengeProgress` (`can_attempt`/`start_attempt`/`record_result`) | Pre-existing type, now actually invoked from `handle_launch_minigame_mode`/`handle_minigame_game_over` |
+
+No changes to `Profile`, `CardState`, or `MiniGameStats` schema.
 
 ## 5. Edge Cases and Error Handling
 
@@ -135,35 +254,51 @@ No new persistent entities. No changes to `Profile`, `CardState`, or
 |----------|-------------------|
 | Player quits mid-game (before `GameOver` state) via back-to-menu | `handle_minigame_game_over` still runs exactly once — the guard only suppresses the *second* run, not the first |
 | User has never had an active streak but has a freeze from some other earned source | Freeze is preserved (not silently consumed), per FR-002 |
-| Review session XP does not cross a level boundary | No `LevelUp` notification shown — the existing no-op path, verified by `test_review_session_completion_no_level_up_notification_without_level_up` |
+| Review session XP does not cross a level boundary | No `LevelUp` notification shown — existing no-op path |
+| A missed-day gap is exactly `STREAK_FREEZE_MAX_GAP_DAYS` | Covered by the freeze (inclusive upper bound) |
+| A missed-day gap is negative (backwards clock / NTP correction) | Lower-bounded at 2 days — cannot silently consume the freeze |
+| Daily Challenge launch fails after the attempt was already consumed (e.g. empty scenario pool discovered late) | Attempt is only consumed once the launch is confirmed to succeed — a failed launch never burns an attempt |
 
 ## 6. Success Criteria
 
 | ID | Metric | Target | Actual |
 |----|--------|--------|--------|
-| SC-001 | Regression tests pass for all 3 fixes | 6/6 new tests pass | Met |
-| SC-002 | No regression in `cargo nextest run --workspace --all-features --lib --bins` | 100% pass | Met (per CHANGELOG entry) |
-| SC-003 | CHANGELOG.md documents all three fixes under their issue numbers | 3/3 entries present | Met — #317, #318, #319 all present under `[Unreleased]` |
+| SC-001 | Regression tests pass for all fixes in this thread | All new tests across the 7 resolving commits pass | Met |
+| SC-002 | No regression in `cargo nextest run --workspace --all-features --lib --bins` | 100% pass | Met |
+| SC-003 | CHANGELOG.md documents every fix under its issue number | 12/12 issue references present under their respective `[Unreleased]`/release entries | Met |
+| SC-004 | No remaining silent gamification state change (streak/freeze/level-up) without a player-facing notification | Verified by code review across all XP/streak call sites | Met |
 
 ## 7. Agent Boundaries
 
 ### Always (without asking)
 - Run the full check suite after any change touching
-  `src/gamification/streak.rs`, `src/ui/state/handlers/minigame.rs`, or
+  `src/gamification/streak.rs`, `src/gamification/quests.rs`,
+  `src/gamification/achievements.rs`, `src/minigame/challenge.rs`,
+  `src/ui/state/handlers/minigame.rs`, or
   `src/ui/state/handlers/review.rs`
-- Preserve the guard conditions added here when refactoring these handlers
+- Preserve every guard condition documented in section 3 (FR-001..008)
+  when refactoring these handlers
+- Route a new gamification state change through a `NotificationType`
+  rather than leaving it silent
 
 ### Never
 - Remove the `is_game_over()` guard in `handle_minigame_back_to_menu`
-  without an equivalent replacement — doing so reintroduces double-XP
-- Remove the `was_streak > 0` guard in `StreakManager::update_streak`
-  without an equivalent replacement — doing so reintroduces the zero-streak
-  freeze bug
+  without an equivalent replacement — reintroduces double-XP (FR-001)
+- Remove the `was_streak > 0` guard on `StreakFreezeUsed`/`StreakBroken`
+  without an equivalent replacement — reintroduces zero-streak
+  notifications (FR-002, FR-006)
+- Let `update_streak` and `use_freeze` diverge on freeze-cap policy again
+  — both MUST route through `try_consume_freeze` (FR-007)
+- Consume a Daily Challenge attempt before a launch is confirmed to
+  succeed (FR-008)
 
 ## 8. See Also
 
 - [[constitution]] — project principles
+- [[../end-game-summary-screen/spec|End-Game Summary Screen]] — sibling
+  progress/gamification UI work from the same release cycle
 - [[MOC-specs]] — all specifications
-- CHANGELOG.md — `[Unreleased]` section, entries for #317, #318, #319
-- `specs/arcade-game-mode-variety/` — unrelated feature, do not confuse (see note above)
-- `.local/specs/002-arcade-game-mode-variety/spec.md` — the actually-related-by-name-only draft, superseded, also unrelated to this fix
+- CHANGELOG.md — entries for #256, #257, #267, #292, #309, #310, #317,
+  #318, #319, #325, #345, #346, #376
+- `specs/arcade-game-mode-variety/` — unrelated feature, do not confuse
+  (see note above)

--- a/specs/custom-helix-keymap-support/spec.md
+++ b/specs/custom-helix-keymap-support/spec.md
@@ -1,0 +1,211 @@
+---
+aliases:
+  - Custom Helix Keymap Support
+  - use_helix_keymap
+tags:
+  - sdd
+  - spec
+  - input-system
+  - config
+  - status/implemented
+created: 2026-08-10
+status: implemented
+related:
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+---
+
+# Feature: Custom Helix Keymap Remapping (`use_helix_keymap`)
+
+> [!info] Metadata
+> **Resolved by**: commit `999e63e` — "feat(input): support custom Helix
+> keymap remapping (#350)", closing issue #163. Follow-up fixes: `463d363`
+> (applied-count/fingerprint tracking correctness, #347/#348), `d7003ca`
+> (docs: workaround for physically-unreachable bindings on some
+> terminals).
+> **Status**: Implemented
+> **Depth**: Lightweight spec, per this project's SDD scaling guidance —
+> retroactively documented because this shipped with no spec anywhere in
+> the repository, despite being a substantial, multi-file addition
+> (`src/input/keymap/` — `context.rs`, `keys.rs`, `overlay.rs`, `mod.rs`).
+
+## 1. Overview
+
+### Problem Statement
+
+helix-trainer only ever taught the stock Helix keymap. Users who run Helix
+with a customized keymap (non-default keyboard layouts, remapped movement
+keys) had no way to train against the bindings they actually use day to
+day — the trainer's drilled muscle memory would not transfer to their real
+editor configuration.
+
+A prerequisite surfaced during investigation: `CommandMetadata.name`
+(`src/helix/commands.rs`) held ~35-40 values that did not match real Helix
+25.07.1 command identifiers, with no production consumer to catch the
+drift. This had to be corrected first (mechanical, behavior-preserving) so
+that `CommandMetadata.name` could become the authoritative key a user's
+`config.toml` command name resolves against.
+
+### Goal
+
+A user can opt in to training against their own Helix `config.toml`
+`[keys.normal]` remaps (including nested `g`/`m`/`z`/`[`/`]` minor-mode
+tables) instead of the stock keymap, scoped to gameplay input only, with
+review history (FSRS card ids) unaffected by whether the remap is active.
+
+### Out of Scope
+
+- Menu, results, filter screens, and scenario hint prose — these always
+  use the stock `j`/`k`/`gg`/`G` navigation, documented in the README,
+  since remapping trainer UI chrome would break the canonical command
+  identity FSRS review history depends on
+- Insert-mode or select-mode remap tables — only `[keys.normal]` (and its
+  nested minor-mode tables) is parsed
+- Relocating a command across prefixes (e.g. moving a `g`-prefixed command
+  to a `z`-prefix) — reported as `UnsupportedRelocation`, not applied
+- Key-sequence, `@`-macro, or `:`-typable binding values — reported as
+  `UnsupportedBindingForm`, not applied
+
+## 2. User Stories
+
+### US-001: Train against my real keymap
+AS A Helix user with a customized keymap
+I WANT to opt in to training against the bindings I actually use
+SO THAT the muscle memory I build in the trainer transfers directly to my
+real editor, instead of teaching me keys I've remapped away from
+
+**Acceptance criteria:**
+```
+GIVEN AppConfig.use_helix_keymap = true and a valid
+  ~/.config/helix/config.toml with a [keys.normal] remap
+WHEN  the trainer starts and the player is on the gameplay input path
+THEN  physical keys resolve through the parsed remap to canonical Helix
+      command keys before reaching command dispatch
+```
+
+### US-002: Unsupported bindings never block startup
+AS A helix-trainer user with an unusual or partially-unsupported custom
+keymap
+I WANT the trainer to start normally and tell me what it couldn't apply
+SO THAT a malformed or advanced config never locks me out of the app
+
+**Acceptance criteria:**
+```
+GIVEN a config.toml with some bindings this trainer cannot model
+  (unknown command name, key-sequence value, minor-mode relocation, etc.)
+WHEN  the trainer starts
+THEN  it starts normally, applies every binding it can, and surfaces the
+      rest via a quantitative startup notification plus full tracing detail
+```
+
+### US-003: Review history survives toggling the keymap
+AS A helix-trainer user who enables or disables the custom keymap over time
+I WANT my FSRS review history to remain valid either way
+SO THAT switching keymaps doesn't reset my learning progress
+
+**Acceptance criteria:**
+```
+GIVEN a scenario was solved under one keymap mapping
+WHEN  the keymap is toggled on/off or changed to a different mapping
+THEN  FSRS card ids, quest matching, and scenario solutions (all keyed on
+      canonical command strings) are unaffected — only the physical-key
+      translation layer changes
+```
+
+## 3. Functional Requirements
+
+Use EARS notation. Prefix with FR-NNN.
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHERE `AppConfig.use_helix_keymap` is `true` (default `false`) THE SYSTEM SHALL load and parse the user's `~/.config/helix/config.toml` `[keys.normal]` section, including nested `g`/`m`/`z`/`[`/`]` minor-mode tables | must |
+| FR-002 | WHEN a physical `KeyEvent` arrives at the gameplay input boundary (`handle_gameplay_input`) THE SYSTEM SHALL translate it to canonical Helix key(s) once, via a normalized `PhysicalKey` newtype as the sole lookup key | must |
+| FR-003 | WHEN a remap resolves one physical key to a multi-token canonical-key expansion (e.g. a remapped `G` → `"ge"`) THE SYSTEM SHALL apply it atomically (clone-and-commit-or-discard) and only from the `Base` input state — a multi-token expansion looked up from a pending state (count or register prefix) SHALL fall through to the stock key instead of executing | must |
+| FR-004 | WHEN loading the config THE SYSTEM SHALL validate one-key-to-many-canonical-key expansions at load time, not at first use | must |
+| FR-005 | WHEN a binding cannot be modeled (unknown command name, unparsable key, non-command-name value form, unsupported minor-mode table, or cross-prefix relocation) THE SYSTEM SHALL report it via `KeymapWarningReason` and a startup notification, and SHALL NOT block startup or silently drop it | must |
+| FR-006 | WHEN two distinct TOML keys normalize to the same `(context, physical key)` pair THE SYSTEM SHALL detect the collision at insert time (via a `HashMap`-backed `Resolution`) and report it as `KeymapWarningReason::Shadowed`, rather than silently letting one binding shadow the other while still counting both as applied | must |
+| FR-007 | WHEN gameplay input is dispatched downstream of the physical-key translation (registry dispatch, FSRS card ids, quest matching, scenario solutions) THE SYSTEM SHALL key everything on canonical command strings, unaffected by whether a custom keymap is active | must |
+| FR-008 | WHEN the active keymap mapping changes (enabled, disabled, or a different custom mapping loaded) THE SYSTEM SHALL update `UserProfile.keymap_fingerprint` so a mismatch across a review history is detectable, regardless of whether the *current* keymap is the stock one | must |
+| FR-009 | WHERE menu, results, filter screens, or scenario hint prose are rendered THE SYSTEM SHALL always use the stock `j`/`k`/`gg`/`G` navigation, never the custom keymap | must |
+| FR-010 | WHEN `AppConfig`/`ConfigData` gains a new field THE SYSTEM SHALL default it via `#[serde(default)]` so an existing `config.json` is merged with defaults rather than discarded wholesale | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Architectural consistency | New pending-input handling for remap expansion MUST follow the existing typestate pattern in `src/input/typestate/`; no parallel ad-hoc state tracking |
+| NFR-002 | Safety | `#![forbid(unsafe_code)]` MUST be preserved; a malformed, missing, or oversized `config.toml` MUST fall back to the stock keymap without blocking startup |
+| NFR-003 | Performance | Physical-key lookup on the gameplay hot path MUST NOT allocate for the common single-token case with no active remap (see `CanonicalKeys::is_single_token()`, added in the follow-up perf fix `8e0b6ef`) |
+| NFR-004 | Testability | Load-time validation, atomic apply, and every `KeymapWarningReason` variant MUST have dedicated unit coverage |
+| NFR-005 | Backward compatibility | Adding `use_helix_keymap` (or any future `AppConfig`/`ConfigData` field) MUST NOT discard an existing `config.json`'s other fields (FR-010) |
+
+## 5. Data Model
+
+| Entity | Description |
+|--------|-------------|
+| `AppConfig.use_helix_keymap: bool` | Opt-in flag, default `false` |
+| `PhysicalKey` (`src/input/keymap/keys.rs`) | Normalized newtype identifying a physical keystroke; sole lookup key for remap resolution |
+| `KeymapOverlay` (`src/input/keymap/overlay.rs`) | `HashMap`-backed `(context, PhysicalKey) -> canonical key(s)` resolution built from parsed config entries |
+| `KeymapWarningReason` (`src/config/keymap/parse.rs`) | `UnknownCommand`, `UnparsableKey`, `UnsupportedBindingForm`, `UnsupportedMinorMode`, `UnsupportedRelocation`, `Shadowed`, plus a resolve-time replay-mismatch variant — every unsupported binding is one of these, never silently dropped |
+| `UserProfile.keymap_fingerprint: Option<u64>` | Detects when review history spans more than one binding mapping, including transitions to/from the stock keymap |
+
+No changes to `Scenario`/`Setup`/`TargetState` — this feature only affects
+the physical-key-to-canonical-key translation layer, not scenario content.
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| `config.toml` missing or unreadable | Falls back to stock keymap, no startup failure |
+| `config.toml` larger than the path-validator size limit | Rejected via the same `validate_file_size` guard used for scenario TOML and profile/config files; falls back to stock |
+| Two TOML keys normalize to the same physical key | Detected at insert time, reported `Shadowed`, first-wins is not silently assumed |
+| A multi-token expansion is looked up from a pending state (count/register prefix) | Falls through to the stock key rather than executing partway |
+| Custom keymap disabled after being active | `keymap_fingerprint` tracking still runs (stock keymap is fingerprinted like any other mapping, per `463d363`), so re-enabling later against a stretch under stock is still detected as a genuine transition |
+| A command name in the config doesn't match any `CommandMetadata.name` this trainer implements | Reported as `UnknownCommand`, not applied, does not block other valid bindings |
+| Alt-`s` (`split_selection_on_newline`) physically unreachable on a terminal without kitty keyboard protocol support (e.g. macOS Terminal.app, since real Option+s composition was removed for layout-collision reasons — see `cd8751c`) | Documented workaround (`d7003ca`): remap a reachable key to `split_selection_on_newline` via this feature |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | `CommandMetadata.name` matches real Helix 25.07.1 identifiers | Verified by a build-breaking test asserting the name-to-key reverse index is total and injective |
+| SC-002 | Regression tests pass for load-time validation, atomic apply, and every warning reason | `src/input/keymap/`, `src/config/keymap/` unit tests green |
+| SC-003 | No regression in `cargo nextest run --workspace --all-features --lib --bins` | 100% pass |
+| SC-004 | Existing `config.json` files load unchanged after this field is added | Verified by a regression test simulating a pre-`use_helix_keymap` config.json |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Run `cargo nextest run --workspace --all-features --lib --bins` after any
+  change touching `src/input/keymap/`, `src/config/keymap/`, or
+  `handle_gameplay_input`
+- Report every unsupported binding via `KeymapWarningReason` — never drop
+  one silently
+
+### Ask First
+- Extending remap support to insert-mode or select-mode key tables
+- Extending remap support to menu/results/filter screens or hint prose
+  (violates the gameplay-only scope, FR-009)
+
+### Never
+- Key FSRS card ids, quest matching, or scenario solutions on physical
+  keys instead of canonical command strings — this is the invariant that
+  lets review history survive keymap changes (FR-007)
+- Apply a multi-token expansion from a pending input state (FR-003)
+- Discard existing `config.json` fields when adding a new `AppConfig` field
+
+## 9. Open Questions
+
+None outstanding — follow-up work items #347, #348 (fixed by `463d363`)
+and #349 (perf, fixed by `8e0b6ef`) are resolved. #386 (Alt-s
+reachability) has a documented workaround (`d7003ca`); #389 (Alt-c) is
+resolved by a separate, unrelated fix — see
+[[../register-command-mode-support/spec#11. Post-Release Extensions (v0.6.0)|register-command-mode-support's Post-Release Extensions]].
+
+## 10. See Also
+
+- [[constitution]] — project principles, Section I (typestate pattern)
+- [[MOC-specs]] — all specifications
+- README.md — "Custom Helix keymap (optional)" user-facing section
+- `docs/HELIX_KEYBINDINGS.md` — implemented-command reference
+- Issue #163 — original feature request

--- a/specs/end-game-summary-screen/spec.md
+++ b/specs/end-game-summary-screen/spec.md
@@ -1,0 +1,143 @@
+---
+aliases:
+  - End-Game Summary Screen
+  - Curriculum Completion Screen
+tags:
+  - sdd
+  - spec
+  - ui
+  - gamification
+  - status/implemented
+created: 2026-08-10
+status: implemented
+related:
+  - "[[constitution]]"
+  - "[[MOC-specs]]"
+---
+
+# Feature: End-Game Summary Screen on Curriculum Completion
+
+> [!info] Metadata
+> **Resolved by**: commit `0dbfcbe` — "feat(ui): add end-game summary
+> screen on curriculum completion (#342)", closing issue #145.
+> **Status**: Implemented
+> **Depth**: Lightweight spec, per this project's SDD scaling guidance —
+> single self-contained UI feature (one new screen, one new
+> `ScenarioCollection` query surface), retroactively documented because it
+> shipped with no spec anywhere in the repository.
+
+## 1. Overview
+
+### Problem Statement
+
+Before this feature, completing the last available scenario left the
+Results screen's `(n)` "next" key with nowhere to go — reaching the end of
+the curriculum was a dead end rather than a milestone.
+
+### Goal
+
+Completing the curriculum transitions to a dedicated `EndGameSummary`
+screen presenting a full progress recap and concrete next steps, computed
+from the actual unfiltered scenario/history data rather than
+replay-inclusive lifetime counters.
+
+### Out of Scope
+
+- Any change to scoring, XP, or FSRS mechanics
+- A "New Game+" or reset-and-replay-all mode
+- Persisting a distinct "curriculum completed" flag — completion is
+  always recomputed live from `ScenarioCollection` + `ScenarioHistory`
+
+## 2. User Stories
+
+### US-001: See a milestone summary on finishing the curriculum
+AS A learner who has completed every available scenario
+I WANT a dedicated summary screen showing my overall progress
+SO THAT reaching the end of the curriculum feels like a real milestone
+with clear next steps, not a dead end
+
+**Acceptance criteria:**
+```
+GIVEN the player has completed every scenario in the (unfiltered) library
+  at least once, per ScenarioCollection::is_curriculum_complete
+WHEN  they press (n) on the Results screen
+THEN  the system transitions to TypedScreen::EndGameSummary, showing:
+      total scenarios, perfected count, lifetime completions, level, XP,
+      command success rate, commands mastered, a per-category mastery
+      breakdown, and next-step suggestions (due FSRS reviews, open
+      quests, imperfect scenarios, Arcade mode)
+```
+```
+GIVEN the player has not yet completed the curriculum
+WHEN  they view the Results screen
+THEN  no discoverability hint for the EndGameSummary transition is shown —
+      the hint is computed live, exactly when (n) would lead there
+```
+
+## 3. Functional Requirements
+
+Use EARS notation. Prefix with FR-NNN.
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN `ScenarioCollection::is_curriculum_complete(profile)` is `true` THE SYSTEM SHALL make the Results screen's `(n)` key transition to `TypedScreen::EndGameSummary` instead of the previous no-op | must |
+| FR-002 | WHEN rendering the `EndGameSummary` screen THE SYSTEM SHALL display total scenarios, perfected count, lifetime completions, level, XP, command success rate, commands mastered, and a per-category mastery breakdown | must |
+| FR-003 | WHEN rendering the `EndGameSummary` screen THE SYSTEM SHALL surface next-step suggestions: due FSRS reviews, open quests, imperfect (non-mastered) scenarios, and Arcade mode | must |
+| FR-004 | WHEN the Results screen is rendered THE SYSTEM SHALL compute, live, whether `(n)` would lead to `EndGameSummary` and show a discoverability hint exactly then | should |
+| FR-005 | WHEN computing curriculum-completion state THE SYSTEM SHALL use `ScenarioCollection::curriculum_stats`/`completed_count`/`is_curriculum_complete` — joining the unfiltered scenario set against `scenario_history` — instead of the replay-inclusive `profile.scenarios_completed`/`perfect_scenarios` counters, which double-count replays of an already-mastered scenario | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Correctness | `is_curriculum_complete` on an empty scenario collection (`ScenarioCollection::new(vec![])`) MUST return `false`, never vacuously `true` |
+| NFR-002 | Performance | `completed_count` is a fast, per-frame-safe query (used for the live Results-screen hint); `curriculum_stats` is a single-pass aggregate that allocates a `per_category` breakdown, called only when actually rendering the summary screen |
+| NFR-003 | Consistency | Rendering (`src/ui/render/end_game.rs`) MUST remain pure — no side effects, computed entirely from `AppState`, per the constitution's rendering principle |
+
+## 5. Data Model
+
+| Entity | Description |
+|--------|-------------|
+| `ScenarioCollection::curriculum_stats()` | Single-pass aggregate over the unfiltered scenario set joined against `scenario_history`: totals, per-category completion breakdown |
+| `ScenarioCollection::completed_count(&profile)` | Fast, allocation-free count derived from the same join, safe to call every frame for the Results-screen hint |
+| `ScenarioCollection::is_curriculum_complete(&profile)` | `true` iff every scenario in the collection has at least one completion in history, and the collection is non-empty |
+| `TypedScreen::EndGameSummary` | New screen variant carrying the computed summary snapshot |
+
+No new persistent entities — the summary is always recomputed live from
+existing `ScenarioCollection` and `UserProfile`/`ScenarioHistory` data.
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Scenario library is empty | `is_curriculum_complete` returns `false` — no summary is reachable (NFR-001) |
+| Player replays an already-mastered scenario after reaching the summary once | Replay does not re-trigger the transition; only pressing `(n)` from the Results screen does, and only while `is_curriculum_complete` still holds |
+| A new scenario is added to the library after the player had completed everything | `is_curriculum_complete` becomes `false` again on next evaluation (recomputed live, not cached) — the discoverability hint disappears until the new scenario is also completed |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | `is_curriculum_complete` correctness | Verified by doc-tests and unit tests, including the empty-collection edge case |
+| SC-002 | No regression in existing Results-screen `(n)` behavior for an incomplete curriculum | `cargo nextest run --workspace --all-features --lib --bins` green |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Keep `curriculum_stats`/`completed_count`/`is_curriculum_complete` as the
+  single source of truth for curriculum-completion state over the
+  replay-inclusive profile counters
+
+### Never
+- Reintroduce a dead-end for `(n)` once the curriculum is complete
+- Cache curriculum-completion state across frames in a way that could go
+  stale relative to `ScenarioHistory`
+
+## 9. See Also
+
+- [[constitution]] — project principles, rendering purity
+- [[../arcade-gamification-session-fixes/spec|Gamification Live-Trigger
+  Wiring, Notifications, and Bookkeeping Fixes]] — sibling
+  progress/notification work from the same release cycle
+- [[MOC-specs]] — all specifications
+- Issue #145 — original feature request

--- a/specs/regex-selection-and-macro-commands/spec.md
+++ b/specs/regex-selection-and-macro-commands/spec.md
@@ -1,0 +1,211 @@
+---
+aliases:
+  - Regex Selection and Macro Commands
+  - select_regex / split_selection / Macro Record-Replay
+tags:
+  - sdd
+  - spec
+  - helix-simulator
+  - input-system
+  - status/implemented
+created: 2026-08-10
+status: implemented
+related:
+  - "[[constitution]]"
+  - "[[../register-command-mode-support/spec]]"
+  - "[[MOC-specs]]"
+---
+
+# Feature: Regex Selection (`s`/`S`) and Macro Record/Replay (`q`/`Q`)
+
+> [!info] Metadata
+> **Resolved by**: commit `a4efc2e` — "feat: implement regex selection and
+> macro record/replay commands (#351)", closing issues #337, #338.
+> **Status**: Implemented
+> **Depth**: Lightweight spec, per this project's SDD scaling guidance —
+> retroactively documented because this shipped with no spec anywhere in
+> the repository. Both capabilities were previously tracked only as a
+> deferred bullet inside [[../register-command-mode-support/spec|Named
+> Register and Command-Line Mode Support]]'s "Out of Scope" (referencing
+> issue #198), which this feature resolves.
+
+## 1. Overview
+
+### Problem Statement
+
+Issue #198's Normal Mode command-coverage audit found two documented Helix
+commands registered in the command metadata but with no working handler:
+
+1. `s` / `S` (`select_regex` / `split_selection`) — narrow or split the
+   current selection by regex match — were stubbed as commented-out
+   no-op placeholders.
+2. `q` / `Q` (macro record/replay) had no key binding and no
+   record/replay machinery at all in `HelixSimulator`.
+
+`d66278d` (the commit that closed #198's scenario-coverage gap for
+scroll/select-all/replace commands) explicitly deferred both of these as
+"from-scratch feature work, not scenario content." This feature is that
+follow-up work.
+
+### Goal
+
+`s`/`S` narrow or split the current selection by a user-supplied regex
+pattern; `q`/`Q` record and replay a sequence of successfully-executed
+commands, both reachable from Normal mode and usable inside scenario
+solutions.
+
+### Out of Scope
+
+- Named macro registers (`"<reg>q`) — `RegisterFile` stores a single
+  `String` per register, not a `Vec<String>`; deferred, tracked as a
+  follow-up in `src/helix/macro_recorder.rs`'s module doc
+- Unifying the macro recorder with the existing `.`-repeat recorder — the
+  two capture fundamentally different shapes (raw `KeyEvent`s vs. resolved
+  command strings) for real reasons; deferred, not attempted here
+- `Alt-K` / `K` (keep/remove selections matching regex) — not part of this
+  change (tracked separately, see `docs/HELIX_KEYBINDINGS.md`)
+- Any change to the command-line `:goto`/`:g` scope already resolved by
+  [[../register-command-mode-support/spec|register-command-mode-support]]
+
+## 2. User Stories
+
+### US-001: Narrow or split a selection by regex
+AS A helix-trainer user practicing advanced selection workflows
+I WANT to press `s` or `S` and type a regex pattern to narrow or split the
+current selection
+SO THAT I can learn Helix's real regex-based selection workflow instead of
+manual character-by-character selection
+
+**Acceptance criteria:**
+```
+GIVEN a selection spanning multiple regex-matchable substrings
+WHEN  the user presses `s`, types a pattern, and confirms
+THEN  the selection narrows to all non-overlapping matches inside the prior
+      selection (select_on_matches)
+```
+```
+GIVEN a selection spanning multiple regex-matchable substrings
+WHEN  the user presses `S`, types a pattern, and confirms
+THEN  the selection splits into the segments between matches (split_on_matches)
+```
+
+### US-002: Record and replay a macro
+AS A helix-trainer user
+I WANT to press `q` to start/stop recording a sequence of commands and `Q`
+to replay it
+SO THAT I can learn Helix's macro workflow for repetitive multi-step edits
+
+**Acceptance criteria:**
+```
+GIVEN the simulator is idle (not recording, not replaying)
+WHEN  the user presses `q`, executes N commands, then presses `q` again
+THEN  those N commands are stored as the current macro, replacing any
+      previously stored macro
+```
+```
+GIVEN a macro has been recorded
+WHEN  the user presses `Q`
+THEN  every stored command replays through the same dispatch path
+      (execute_command_any_mode) used for live input
+```
+
+## 3. Functional Requirements
+
+Use EARS notation. Prefix with FR-NNN.
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-001 | WHEN the user presses `s` in Normal mode with an active selection THE SYSTEM SHALL enter the existing command-line prompt-input pattern to collect a regex pattern | must |
+| FR-002 | WHEN a valid regex pattern is confirmed after `s` THE SYSTEM SHALL narrow the current selection to all non-overlapping matches via `helix-core`'s `select_on_matches` | must |
+| FR-003 | WHEN a valid regex pattern is confirmed after `S` THE SYSTEM SHALL split the current selection at match boundaries via `helix-core`'s `split_on_matches` | must |
+| FR-004 | WHEN a regex pattern exceeds a maximum length or a match count exceeds `MAX_REGEX_SELECTION_MATCHES` (10,000) THE SYSTEM SHALL truncate/reject rather than panic or hang | must |
+| FR-005 | WHEN the user presses `q` while idle THE SYSTEM SHALL begin recording successfully-executed command strings into a single unnamed macro slot | must |
+| FR-006 | WHEN the user presses `q` while recording THE SYSTEM SHALL stop recording and overwrite the stored macro with what was just captured (unconditionally, even if empty) | must |
+| FR-007 | WHEN the user presses `Q` and a macro is stored THE SYSTEM SHALL replay every stored command through `execute_command_any_mode`, the same dispatch path used for live input, bounded by `MAX_MACRO_LENGTH` (100 commands recorded) and `MAX_MACRO_DEPTH` (10, replay recursion) | must |
+| FR-008 | WHEN a command executes while a macro replay (`Q`) is in progress THE SYSTEM SHALL NOT feed it back into the recording tap, even if recording is simultaneously active | must |
+| FR-009 | WHEN `s`/`S` scenario completions are recorded THE SYSTEM SHALL normalize the command id so scenario completions mint one FSRS card per skill (`select_regex`/`split_selection`) rather than one card per literal regex pattern typed | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Dependency hygiene | The `select_on_matches`/`split_on_matches` implementations come from a new `helix-stdx` dependency, pinned to the same git tag (`25.07.1`) as the existing `helix-core` dependency — no independent version drift |
+| NFR-002 | Safety | `#![forbid(unsafe_code)]` MUST be preserved; regex compilation/matching MUST be guarded against pathological patterns via the length cap and match-count truncation (FR-004) |
+| NFR-003 | Architectural consistency | The regex prompt reuses the existing command-line typestate prompt-input pattern rather than introducing a parallel one |
+| NFR-004 | Correctness | Macro replay MUST NOT resurface a latent bug in repeat-state restore — `a4efc2e` fixed exactly this class of bug as part of this change |
+
+## 5. Data Model
+
+| Entity | Description |
+|--------|-------------|
+| `MacroRecorder` (`src/helix/macro_recorder.rs`) | Owns `recording: Option<Vec<String>>`, `stored: Vec<String>`, `is_replaying: bool`, `replay_depth: usize` — records/replays a single unnamed `q`/`Q` macro on the simulator |
+| Regex prompt input | Transient typestate state collecting a pattern string, shared shape with the existing command-line prompt |
+
+No persistent (serialized) entities — macro state lives on `HelixSimulator`
+for the duration of a session only; it does not survive a screen
+transition that resets simulator state (see Edge Cases).
+
+## 6. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| `s`/`S` pattern is invalid regex syntax | `UserError` describing the failure; selection unchanged |
+| Pattern matches nothing inside the current selection | Selection unchanged (no-op), no error |
+| Match count would exceed `MAX_REGEX_SELECTION_MATCHES` | Truncated to the cap rather than hanging or panicking |
+| `q` pressed a second time immediately after the first (nothing captured) | Stored macro is overwritten with an empty macro, discarding any prior one — deliberate, matches real Helix's `q`/`Q` parity (no separate "cancel without saving" gesture) |
+| `Q` pressed with nothing stored, already replaying, or at `MAX_MACRO_DEPTH` | `begin_replay` returns `false` and changes nothing |
+| `.`-repeat executed while recording | Captured as the *expansion* of `.` (each resulting command individually), not the literal `.` character — deterministic regardless of repeat-buffer state at replay time |
+| `Q` triggered while already recording | Deliberate no-op for the replay call itself: `execute_command_any_mode` checks `is_recording_macro()` before calling `execute_macro_replay()`, so a nested replay's effects would otherwise apply to the document without being captured |
+| Session paused or ended mid-recording (Task/MiniGame screens consume bare `q` for `QuitApp`/`MiniGameBackToMenu` in some states) | In-progress recording is silently dropped along with the rest of simulator state — known limitation, not addressed by this change |
+| `"<reg>d`/`"<reg>c` register-scoped commands executed inside a macro | Handled as part of a later fix, see [[../register-command-mode-support/spec#11. Post-Release Extensions (v0.6.0)\|register-command-mode-support's extensions]] (`efeac9d`) |
+
+## 7. Success Criteria
+
+| ID | Metric | Target |
+|----|--------|--------|
+| SC-001 | `s`/`S` regression tests pass | `select_regex`/`split_selection` covered in `src/helix/simulator/commands/selection.rs` and dispatch tests in `src/helix/simulator/commands/mod.rs` |
+| SC-002 | Macro record/replay regression tests pass | `src/helix/simulator/tests/macro_tests.rs` (new, 161 lines) |
+| SC-003 | No regression in `cargo nextest run --workspace --all-features --lib --bins` | 100% pass |
+| SC-004 | Issue #198's deferred scope (macros, selection-regex) fully closed | Both capabilities implemented; no remaining reference to #198 as "still open" anywhere in `specs/` |
+
+## 8. Agent Boundaries
+
+### Always (without asking)
+- Run `cargo nextest run --workspace --all-features --lib --bins` after any
+  change touching `src/helix/macro_recorder.rs` or
+  `src/helix/simulator/commands/selection.rs`
+- Keep macro replay dispatching through `execute_command_any_mode` — never
+  introduce a parallel replay path that bypasses the registry
+
+### Ask First
+- Introducing named macro registers (`"<reg>q`) — requires a `RegisterFile`
+  data-model change (single `String` per register → `Vec<String>`)
+- Raising `MAX_MACRO_LENGTH`/`MAX_MACRO_DEPTH`/`MAX_REGEX_SELECTION_MATCHES`
+
+### Never
+- Let macro replay call back into itself unboundedly — always respect
+  `MAX_MACRO_DEPTH`
+- Feed replayed commands back into the recording tap while a macro is
+  simultaneously being recorded (FR-008)
+
+## 9. Open Questions
+
+- [NEEDS CLARIFICATION: should named macro registers (`"<reg>q`) be
+  prioritized as a follow-up, given named registers already exist for
+  yank/paste via [[../register-command-mode-support/spec|register-command-mode-support]]?]
+
+## 10. See Also
+
+- [[constitution]] — project principles
+- [[../register-command-mode-support/spec]] — sibling feature; this spec
+  resolves the "Macro recording/playback" and "selection-regex" bullets
+  that spec's Out of Scope section deferred to issue #198
+- [[MOC-specs]] — all specifications
+- [Helix Keymap Reference](https://docs.helix-editor.com/keymap.html)
+- `docs/HELIX_KEYBINDINGS.md` — user-facing implemented/not-implemented
+  matrix (note: this project's `q`=record-toggle/`Q`=replay assignment is
+  a deliberate deviation from real Helix's register-scoped `Q`=record/
+  `q`=replay, since only a single unnamed macro slot is implemented, not
+  named macro registers)
+- Issue #198 — Normal Mode command-coverage gap (closed; this spec plus
+  `d66278d` closes it)

--- a/specs/register-command-mode-support/README.md
+++ b/specs/register-command-mode-support/README.md
@@ -78,4 +78,10 @@ variant as the draft's FR-005/NFR-002 requested.
 - [[constitution]] — project principles, Section I (Architecture)
 - `docs/HELIX_KEYBINDINGS.md` — user-facing scope disclaimer
 - Issue #104 — vim-style marks explicitly rejected (unaffected by this work)
-- Issue #198 — separate, still-open content-coverage gap (macros, scroll, view mode, selection-regex)
+- Issue #198 — Helix command content-coverage gap (macros, scroll, view
+  mode, selection-regex) — **closed** as of v0.6.0: scroll/select-all/`R`
+  scenario coverage landed in `d66278d`, and macros/selection-regex landed
+  in `a4efc2e`, documented in
+  `specs/regex-selection-and-macro-commands/spec.md` (see
+  `spec.md#11. Post-Release Extensions (v0.6.0)` in this package for the
+  full breakdown)

--- a/specs/register-command-mode-support/spec.md
+++ b/specs/register-command-mode-support/spec.md
@@ -83,9 +83,14 @@ just deferred — see Resolution below):
 - Full command-line surface (`:g` global, `:w` write, `:sort`, arbitrary
   line ranges, shell commands, `:normal`)
 - Register content inspection UI
-- Macro recording/playback (tracked separately under issue #198)
-- Scroll commands, view mode extensions, selection-regex (tracked under
-  issue #198)
+- Macro recording/playback — was tracked separately under issue #198;
+  **now implemented**, see [[../regex-selection-and-macro-commands/spec|Regex
+  Selection and Macro Commands]] and section 11 below
+- Scroll commands, view mode extensions, selection-regex — was tracked
+  under issue #198; **scroll commands and select-all/replace now have
+  scenario coverage** (`d66278d`), **selection-regex now implemented**,
+  see [[../regex-selection-and-macro-commands/spec|Regex Selection and
+  Macro Commands]] and section 11 below
 
 ## 2. User Stories
 
@@ -222,7 +227,50 @@ command, no ranges. This was an explicit, documented scoping decision (see
 `docs/HELIX_KEYBINDINGS.md`'s scope disclaimer), not an oversight. Full
 verdict in [[SRS]].
 
-## 11. See Also
+## 11. Post-Release Extensions (v0.6.0)
+
+Three follow-up commits, still within the register/command-mode feature
+area, shipped after the retroactive documentation above was written:
+
+- **`d66278d`** (closes issue #198) — added scenario coverage for `Ctrl-b`/
+  `Ctrl-f`/`Ctrl-u`/`Ctrl-d` (half-page/page scroll), `%` (select-all), and
+  `R` (replace-selection-with-yanked), plus a bug fix recognizing
+  Ctrl-modified keys that previously fell through to their unmodified
+  bare-key command. Explicitly deferred `q`/`Q` (macros — no
+  record/replay logic existed) and `s`/`S` (selection-regex — no-op
+  stubs) as "from-scratch feature work, not scenario content."
+- **`a4efc2e`** — implemented exactly what `d66278d` deferred: `s`/`S`
+  (regex select/split) and `q`/`Q` (macro record/replay). Fully documented
+  in its own package, [[../regex-selection-and-macro-commands/spec|Regex
+  Selection and Macro Commands]]. This closes issue #198's remaining
+  scope; the "still-open content-coverage gap" language in this package's
+  original research spec (section 2, US-003 note; section 10 References)
+  is now stale and superseded by that package.
+- **`fb2e0c5`**, **`dd39300`**, **`efeac9d`** — a trio of register-scoped
+  Helix-simulator correctness fixes discovered via kitty-keyboard-protocol
+  reachability testing of `Alt-c`/`Alt-d`:
+  - `fb2e0c5` registered `change_selection_noyank` for `Alt-c`, initially
+    reusing the plain `change_selection` handler (at that point the
+    simulator never wrote registers on change/delete, so yank vs. noyank
+    were behaviorally identical).
+  - `dd39300` split the two apart: `change_selection` (`c`, `d`) now
+    deletes the full active selection and writes the deleted text to the
+    default register via `yank_to_register` (folding over all selection
+    ranges, not just the primary one); `change_selection_noyank` (`Alt-c`)
+    keeps the deletion but does not populate the register.
+  - `efeac9d` added **blackhole register** (`"_`) support — register-scoped
+    delete/change operations targeting `"_` discard text instead of
+    overwriting a register, matching real Helix — plus the missing `Alt-d`
+    (`delete_selection_noyank`) binding mirroring `Alt-c`, and a fix for
+    command-repeat (`.`) silently dropping `"<reg>d`/`"<reg>c`
+    register-scoped operations (a gap only reachable once `d`/`c` became
+    routable through the register-selection input layer).
+
+These extend FR-002/FR-003 (register-scoped yank on `y`, paste on `p`/`P`)
+to also cover register-scoped delete/change (`d`/`c`), and add the
+blackhole register as a new addressable register alongside named ones.
+
+## 12. See Also
 
 - [[constitution]] — project principles
 - [[BRD]] — business rationale and what actually shipped
@@ -230,9 +278,13 @@ verdict in [[SRS]].
 - [[NFR]] — non-functional requirement verdicts
 - [[plan]] — as-built architecture
 - [[tasks]] — retroactive task breakdown
+- [[../regex-selection-and-macro-commands/spec|Regex Selection and Macro
+  Commands]] — resolves this package's deferred macro/selection-regex
+  scope (section 11)
 - [[MOC-specs]] — all specifications
 - [Helix Keymap Reference](https://docs.helix-editor.com/keymap.html)
 - [Helix Command-Line Reference](https://docs.helix-editor.com/command-line.html)
 - [S-Sigdel/vimhjkl](https://github.com/S-Sigdel/vimhjkl) — reference project
-- Issue #198 — Helix command content-coverage gap (macros, scroll, view mode, selection-regex — distinct, unaddressed)
+- Issue #198 — Helix command content-coverage gap — **closed**, see
+  section 11 (macros, scroll, selection-regex all landed)
 - Issue #104 — vim-style marks explicitly rejected (authoritative prior art)


### PR DESCRIPTION
## Summary

- Bump version from 0.5.12 to 0.6.0
- Finalize CHANGELOG.md with the v0.6.0 release section (consolidated duplicate `### Changed` headers)
- Refresh README.md: command/scenario counts (95+ commands, 160 scenarios), pinned-version install example, new commands table entries (Registers, Macros, Command-line, Alt+d)
- Update docs/HELIX_KEYBINDINGS.md and docs/SCENARIOS_AND_QUESTS.md to reflect newly-implemented commands and scenario categories
- Reconcile specs/ against all 61 commits merged since v0.5.12: new packages for regex-selection-and-macro-commands, custom-helix-keymap-support, and end-game-summary-screen; broadened arcade-gamification-session-fixes and register-command-mode-support

## Checklist

- [x] Version updated in Cargo.toml (Cargo.lock refreshed)
- [x] CHANGELOG.md has release section with date
- [x] README reflects new version and current feature set
- [x] specs/ reconciled against merged commits since last release
- [x] All checks pass locally (fmt, clippy, nextest, release build)
- [ ] Ready for tagging after merge