### PR TITLE
chore: ignore unmaintained smartstring advisory (RUSTSEC-2026-0249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `cargo deny check` (CI's Security Audit job) failing on RUSTSEC-2026-0249: `smartstring` was marked unmaintained upstream; it is a transitive dependency pinned by `helix-core` (vendored at upstream tag 25.07.1) with no safe upgrade path, so it is now ignored in `deny.toml` following the same pattern as the existing `bincode` ignore.
+
 ## [0.6.0] - 2026-08-10
 
 ### Added

--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,10 @@ ignore = [
     # (bincode -> syntect -> helix-trainer); syntect is actively maintained
     # and will update when it moves off bincode
     "RUSTSEC-2025-0141",
+    # smartstring is unmaintained but it's a transitive dependency pinned by
+    # helix-core (smartstring -> helix-core -> helix-trainer); helix-core is
+    # vendored at upstream tag 25.07.1 and has no safe upgrade path off it
+    "RUSTSEC-2026-0249",
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary
- `cargo deny check` (Security Audit / CI Gate) started failing on `main` and on every open PR because of a new unmaintained advisory, RUSTSEC-2026-0249, for `smartstring`.
- `smartstring` is a transitive dependency pinned by `helix-core` (vendored at upstream tag 25.07.1); no safe upgrade path is available.
- Adds it to `deny.toml`'s advisory ignore list following the existing pattern used for the `bincode`/RUSTSEC-2025-0141 ignore, and records the fix in `CHANGELOG.md`.
- This unblocks unrelated PRs currently failing CI for the same reason, including dependabot's futures 0.3.34 bump (#404).

## Test plan
- [x] `cargo deny check` passes locally (advisories ok, bans ok, licenses ok, sources ok)
- [x] `cargo +nightly fmt --check` passes
- [ ] CI green on this PR