### PR TITLE
chore: raise MSRV to 1.98 and adopt Path::is_empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump MSRV to Rust 1.98 to use the newly-stabilized `Path::is_empty()` in `ProfileStorage` path handling.
+
 ### Fixed
 
 - `cargo deny check` (CI's Security Audit job) failing on RUSTSEC-2026-0249: `smartstring` was marked unmaintained upstream; it is a transitive dependency pinned by `helix-core` (vendored at upstream tag 25.07.1) with no safe upgrade path, so it is now ignored in `deny.toml` following the same pattern as the existing `bincode` ignore.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump MSRV to Rust 1.98 to use the newly-stabilized `Path::is_empty()` in `ProfileStorage` path handling.
+- Migrate `assert!(matches!(...))` to `assert_matches!` across the test suite, now that MSRV covers its Rust 1.96 stabilization.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "helix-trainer"
 version = "0.6.0"
 edition = "2024"
-rust-version = "1.91"
+rust-version = "1.98"
 authors = ["Andrei G <andrei.g@my.com>"]
 description = "Interactive trainer for learning Helix editor keybindings"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI Status](https://img.shields.io/github/actions/workflow/status/bug-ops/helix-trainer/ci.yml?branch=main)](https://github.com/bug-ops/helix-trainer/actions)
 [![codecov](https://codecov.io/github/bug-ops/helix-trainer/graph/badge.svg?token=GMTOLA56LW)](https://codecov.io/github/bug-ops/helix-trainer)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Rust](https://img.shields.io/badge/rust-1.91+-orange.svg)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/rust-1.98+-orange.svg)](https://www.rust-lang.org)
 [![Release](https://img.shields.io/github/v/release/bug-ops/helix-trainer)](https://github.com/bug-ops/helix-trainer/releases/latest)
 [![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 
@@ -135,7 +135,7 @@ cd helix-trainer-*/
 ### Build from source
 
 > [!WARNING]
-> **Requires Rust 1.91+** (2024 edition). Install via [rustup.rs](https://rustup.rs/)
+> **Requires Rust 1.98+** (2024 edition). Install via [rustup.rs](https://rustup.rs/)
 
 ```bash
 git clone https://github.com/bug-ops/helix-trainer.git

--- a/specs/constitution.md
+++ b/specs/constitution.md
@@ -48,7 +48,7 @@ status: permanent
 
 ## II. Technology Stack
 
-- Language: Rust, MSRV per `Cargo.toml` `rust-version` (1.91 at time of
+- Language: Rust, MSRV per `Cargo.toml` `rust-version` (1.98 at time of
   writing).
 - TUI: `ratatui` + `crossterm`.
 - Async runtime: `tokio` (2 worker threads).

--- a/src/config/keymap/parse.rs
+++ b/src/config/keymap/parse.rs
@@ -370,6 +370,7 @@ fn resolves_cleanly_from_base(canonical: &CanonicalKeys) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
 
     /// M1: `resolves_cleanly_from_base`'s "final token may transition"
     /// exception is scoped to `tokens.len() == 1` because *today*, by
@@ -397,8 +398,9 @@ mod tests {
                 });
                 result = Some(machine.process_key(key_event));
             }
-            assert!(
-                matches!(result, Some(HandlerResult::Execute(_))),
+            assert_matches!(
+                result,
+                Some(HandlerResult::Execute(_)),
                 "registry key {:?} (name {:?}) is multi-token but its final token doesn't execute: {:?}",
                 meta.key,
                 meta.name,
@@ -483,10 +485,10 @@ mod tests {
         assert!(overlay.is_empty());
         assert_eq!(report.applied, 0);
         assert_eq!(report.ignored.len(), 1);
-        assert!(matches!(
+        assert_matches!(
             report.ignored[0].reason,
             KeymapWarningReason::UnknownCommand(_)
-        ));
+        );
     }
 
     #[test]
@@ -584,10 +586,10 @@ mod tests {
         )
         .unwrap();
         assert!(overlay.is_empty());
-        assert!(matches!(
+        assert_matches!(
             report.ignored[0].reason,
             KeymapWarningReason::UnparsableKey(_)
-        ));
+        );
     }
 
     #[test]
@@ -672,12 +674,12 @@ mod tests {
             toml.push_str(&format!("k{i} = \"move_char_left\"\n"));
         }
         let err = resolve_str(&toml).unwrap_err();
-        assert!(matches!(err, SecurityError::TooManyKeymapBindings { .. }));
+        assert_matches!(err, SecurityError::TooManyKeymapBindings { .. });
     }
 
     #[test]
     fn missing_file_is_not_found_not_a_hard_error() {
         let err = load_keymap_file(Path::new("/nonexistent/helix/config.toml")).unwrap_err();
-        assert!(matches!(err, KeymapLoadError::NotFound));
+        assert_matches!(err, KeymapLoadError::NotFound);
     }
 }

--- a/src/config/quests/tests.rs
+++ b/src/config/quests/tests.rs
@@ -1,6 +1,7 @@
 //! Tests for quest template loading
 
 use super::*;
+use std::assert_matches;
 use std::path::PathBuf;
 
 #[test]
@@ -73,7 +74,7 @@ command = "x"
 target = 3
 "#;
     let result: QuestSpec = toml::from_str(valid).unwrap();
-    assert!(matches!(result, QuestSpec::CommandPractice { .. }));
+    assert_matches!(result, QuestSpec::CommandPractice { .. });
 
     let valid = r#"
 type = "speed_run"
@@ -82,7 +83,7 @@ scenario_id = "delete_line_001"
 time_limit_seconds = 5
 "#;
     let result: QuestSpec = toml::from_str(valid).unwrap();
-    assert!(matches!(result, QuestSpec::SpeedRun { .. }));
+    assert_matches!(result, QuestSpec::SpeedRun { .. });
 }
 
 #[test]

--- a/src/game/command_context.rs
+++ b/src/game/command_context.rs
@@ -121,10 +121,11 @@ impl ParsedCommand {
 ///
 /// ```ignore
 /// use helix_trainer::game::command_context::{parse_command_buffer, ParsedCommand};
+/// use std::assert_matches;
 ///
-/// assert!(matches!(parse_command_buffer("gg"), ParsedCommand::Complete(_)));
-/// assert!(matches!(parse_command_buffer("g"), ParsedCommand::Partial));
-/// assert!(matches!(parse_command_buffer("xyz"), ParsedCommand::Invalid));
+/// assert_matches!(parse_command_buffer("gg"), ParsedCommand::Complete(_));
+/// assert_matches!(parse_command_buffer("g"), ParsedCommand::Partial);
+/// assert_matches!(parse_command_buffer("xyz"), ParsedCommand::Invalid);
 /// ```
 pub fn parse_command_buffer(buffer: &str) -> ParsedCommand {
     use crate::helix::registry::{KeyMatch, normal_registry};
@@ -306,102 +307,55 @@ pub fn process_command_input<B: CommandBuffer>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
 
     #[test]
     fn test_parse_command_buffer_single_key() {
-        assert!(matches!(
-            parse_command_buffer("j"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("k"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("d"),
-            ParsedCommand::Complete(_)
-        ));
+        assert_matches!(parse_command_buffer("j"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("k"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("d"), ParsedCommand::Complete(_));
 
         assert_eq!(parse_command_buffer("j").command(), Some("j"));
     }
 
     #[test]
     fn test_parse_command_buffer_goto_commands() {
-        assert!(matches!(
-            parse_command_buffer("gg"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("gh"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("gl"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("gs"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("ge"),
-            ParsedCommand::Complete(_)
-        ));
+        assert_matches!(parse_command_buffer("gg"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("gh"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("gl"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("gs"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("ge"), ParsedCommand::Complete(_));
 
         assert_eq!(parse_command_buffer("gg").command(), Some("gg"));
     }
 
     #[test]
     fn test_parse_command_buffer_partial() {
-        assert!(matches!(parse_command_buffer("g"), ParsedCommand::Partial));
-        assert!(matches!(parse_command_buffer("r"), ParsedCommand::Partial));
-        assert!(matches!(parse_command_buffer("f"), ParsedCommand::Partial));
+        assert_matches!(parse_command_buffer("g"), ParsedCommand::Partial);
+        assert_matches!(parse_command_buffer("r"), ParsedCommand::Partial);
+        assert_matches!(parse_command_buffer("f"), ParsedCommand::Partial);
     }
 
     #[test]
     fn test_parse_command_buffer_replace() {
-        assert!(matches!(
-            parse_command_buffer("ra"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("rx"),
-            ParsedCommand::Complete(_)
-        ));
+        assert_matches!(parse_command_buffer("ra"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("rx"), ParsedCommand::Complete(_));
 
         assert_eq!(parse_command_buffer("ra").command(), Some("ra"));
     }
 
     #[test]
     fn test_parse_command_buffer_find() {
-        assert!(matches!(
-            parse_command_buffer("fa"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("Fx"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("te"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("TY"),
-            ParsedCommand::Complete(_)
-        ));
+        assert_matches!(parse_command_buffer("fa"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("Fx"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("te"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("TY"), ParsedCommand::Complete(_));
     }
 
     #[test]
     fn test_parse_command_buffer_invalid() {
-        assert!(matches!(
-            parse_command_buffer("xyz"),
-            ParsedCommand::Invalid
-        ));
-        assert!(matches!(
-            parse_command_buffer("ggg"),
-            ParsedCommand::Invalid
-        ));
+        assert_matches!(parse_command_buffer("xyz"), ParsedCommand::Invalid);
+        assert_matches!(parse_command_buffer("ggg"), ParsedCommand::Invalid);
     }
 
     #[test]
@@ -430,285 +384,156 @@ mod tests {
         let result = parse_command_buffer("");
         // Single-key logic treats len==1 as complete, but empty is len==0
         // Falls through to Invalid
-        assert!(matches!(result, ParsedCommand::Invalid));
+        assert_matches!(result, ParsedCommand::Invalid);
     }
 
     #[test]
     fn test_parse_command_buffer_replace_special_chars() {
         // Replace with space
-        assert!(matches!(
-            parse_command_buffer("r "),
-            ParsedCommand::Complete(_)
-        ));
+        assert_matches!(parse_command_buffer("r "), ParsedCommand::Complete(_));
         assert_eq!(parse_command_buffer("r ").command(), Some("r "));
 
         // Replace with newline
-        assert!(matches!(
-            parse_command_buffer("r\n"),
-            ParsedCommand::Complete(_)
-        ));
+        assert_matches!(parse_command_buffer("r\n"), ParsedCommand::Complete(_));
 
         // Replace with tab
-        assert!(matches!(
-            parse_command_buffer("r\t"),
-            ParsedCommand::Complete(_)
-        ));
+        assert_matches!(parse_command_buffer("r\t"), ParsedCommand::Complete(_));
     }
 
     #[test]
     fn test_parse_command_buffer_find_special_chars() {
         // Find space
-        assert!(matches!(
-            parse_command_buffer("f "),
-            ParsedCommand::Complete(_)
-        ));
+        assert_matches!(parse_command_buffer("f "), ParsedCommand::Complete(_));
 
         // Find uppercase reverse with space
-        assert!(matches!(
-            parse_command_buffer("F "),
-            ParsedCommand::Complete(_)
-        ));
+        assert_matches!(parse_command_buffer("F "), ParsedCommand::Complete(_));
 
         // Till newline
-        assert!(matches!(
-            parse_command_buffer("t\n"),
-            ParsedCommand::Complete(_)
-        ));
+        assert_matches!(parse_command_buffer("t\n"), ParsedCommand::Complete(_));
 
         // Till reverse with tab
-        assert!(matches!(
-            parse_command_buffer("T\t"),
-            ParsedCommand::Complete(_)
-        ));
+        assert_matches!(parse_command_buffer("T\t"), ParsedCommand::Complete(_));
     }
 
     #[test]
     fn test_parse_command_buffer_all_movement_commands() {
         // Basic movement
-        assert!(matches!(
-            parse_command_buffer("h"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("l"),
-            ParsedCommand::Complete(_)
-        ));
+        assert_matches!(parse_command_buffer("h"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("l"), ParsedCommand::Complete(_));
 
         // Word movement
-        assert!(matches!(
-            parse_command_buffer("w"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("b"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("e"),
-            ParsedCommand::Complete(_)
-        ));
+        assert_matches!(parse_command_buffer("w"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("b"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("e"), ParsedCommand::Complete(_));
 
         // WORD movement (uppercase)
-        assert!(matches!(
-            parse_command_buffer("W"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("B"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("E"),
-            ParsedCommand::Complete(_)
-        ));
+        assert_matches!(parse_command_buffer("W"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("B"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("E"), ParsedCommand::Complete(_));
 
         // Line bounds
         // Note: "0" is NOT a command in Helix - use "gh" for goto line start
         // Note: "$" is NOT a line end command in Helix - use "gl" for goto line end
-        assert!(matches!(parse_command_buffer("0"), ParsedCommand::Invalid));
-        assert!(matches!(parse_command_buffer("$"), ParsedCommand::Invalid));
+        assert_matches!(parse_command_buffer("0"), ParsedCommand::Invalid);
+        assert_matches!(parse_command_buffer("$"), ParsedCommand::Invalid);
     }
 
     #[test]
     fn test_parse_command_buffer_all_editing_commands() {
         // Insert modes
-        assert!(matches!(
-            parse_command_buffer("i"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("a"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("I"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("A"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("o"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("O"),
-            ParsedCommand::Complete(_)
-        ));
+        assert_matches!(parse_command_buffer("i"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("a"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("I"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("A"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("o"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("O"), ParsedCommand::Complete(_));
 
         // Change/delete
-        assert!(matches!(
-            parse_command_buffer("c"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("d"),
-            ParsedCommand::Complete(_)
-        ));
+        assert_matches!(parse_command_buffer("c"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("d"), ParsedCommand::Complete(_));
 
         // Other editing
-        assert!(matches!(
-            parse_command_buffer("J"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer(">"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("<"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("~"),
-            ParsedCommand::Complete(_)
-        ));
+        assert_matches!(parse_command_buffer("J"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer(">"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("<"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("~"), ParsedCommand::Complete(_));
     }
 
     #[test]
     fn test_parse_command_buffer_selection_commands() {
-        assert!(matches!(
-            parse_command_buffer("x"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("X"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("%"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer(";"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("v"),
-            ParsedCommand::Complete(_)
-        ));
+        assert_matches!(parse_command_buffer("x"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("X"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("%"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer(";"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("v"), ParsedCommand::Complete(_));
     }
 
     #[test]
     fn test_parse_command_buffer_clipboard_commands() {
-        assert!(matches!(
-            parse_command_buffer("y"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("p"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("P"),
-            ParsedCommand::Complete(_)
-        ));
+        assert_matches!(parse_command_buffer("y"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("p"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("P"), ParsedCommand::Complete(_));
     }
 
     #[test]
     fn test_parse_command_buffer_undo_commands() {
-        assert!(matches!(
-            parse_command_buffer("u"),
-            ParsedCommand::Complete(_)
-        ));
-        assert!(matches!(
-            parse_command_buffer("U"),
-            ParsedCommand::Complete(_)
-        ));
+        assert_matches!(parse_command_buffer("u"), ParsedCommand::Complete(_));
+        assert_matches!(parse_command_buffer("U"), ParsedCommand::Complete(_));
     }
 
     #[test]
     fn test_parse_command_buffer_special_commands() {
         // Match mode prefix (waiting for second key)
-        assert!(matches!(parse_command_buffer("m"), ParsedCommand::Partial));
+        assert_matches!(parse_command_buffer("m"), ParsedCommand::Partial);
 
         // Match brackets (mm)
-        assert!(matches!(
-            parse_command_buffer("mm"),
-            ParsedCommand::Complete(_)
-        ));
+        assert_matches!(parse_command_buffer("mm"), ParsedCommand::Complete(_));
 
         // Repeat
-        assert!(matches!(
-            parse_command_buffer("."),
-            ParsedCommand::Complete(_)
-        ));
+        assert_matches!(parse_command_buffer("."), ParsedCommand::Complete(_));
     }
 
     #[test]
     fn test_parse_command_buffer_partial_all_prefixes() {
         // Goto prefix
-        assert!(matches!(parse_command_buffer("g"), ParsedCommand::Partial));
+        assert_matches!(parse_command_buffer("g"), ParsedCommand::Partial);
 
         // Match mode prefix
-        assert!(matches!(parse_command_buffer("m"), ParsedCommand::Partial));
+        assert_matches!(parse_command_buffer("m"), ParsedCommand::Partial);
 
         // Replace prefix
-        assert!(matches!(parse_command_buffer("r"), ParsedCommand::Partial));
+        assert_matches!(parse_command_buffer("r"), ParsedCommand::Partial);
 
         // Find prefixes
-        assert!(matches!(parse_command_buffer("f"), ParsedCommand::Partial));
-        assert!(matches!(parse_command_buffer("F"), ParsedCommand::Partial));
+        assert_matches!(parse_command_buffer("f"), ParsedCommand::Partial);
+        assert_matches!(parse_command_buffer("F"), ParsedCommand::Partial);
 
         // Till prefixes
-        assert!(matches!(parse_command_buffer("t"), ParsedCommand::Partial));
-        assert!(matches!(parse_command_buffer("T"), ParsedCommand::Partial));
+        assert_matches!(parse_command_buffer("t"), ParsedCommand::Partial);
+        assert_matches!(parse_command_buffer("T"), ParsedCommand::Partial);
     }
 
     #[test]
     fn test_parse_command_buffer_invalid_long_sequences() {
         // Three or more characters (except valid multi-key)
-        assert!(matches!(
-            parse_command_buffer("rrr"),
-            ParsedCommand::Invalid
-        ));
-        assert!(matches!(
-            parse_command_buffer("fff"),
-            ParsedCommand::Invalid
-        ));
-        assert!(matches!(
-            parse_command_buffer("abc"),
-            ParsedCommand::Invalid
-        ));
-        assert!(matches!(
-            parse_command_buffer("jjj"),
-            ParsedCommand::Invalid
-        ));
+        assert_matches!(parse_command_buffer("rrr"), ParsedCommand::Invalid);
+        assert_matches!(parse_command_buffer("fff"), ParsedCommand::Invalid);
+        assert_matches!(parse_command_buffer("abc"), ParsedCommand::Invalid);
+        assert_matches!(parse_command_buffer("jjj"), ParsedCommand::Invalid);
 
         // Invalid goto sequences
-        assert!(matches!(parse_command_buffer("gx"), ParsedCommand::Invalid));
-        assert!(matches!(parse_command_buffer("gz"), ParsedCommand::Invalid));
+        assert_matches!(parse_command_buffer("gx"), ParsedCommand::Invalid);
+        assert_matches!(parse_command_buffer("gz"), ParsedCommand::Invalid);
     }
 
     #[test]
     fn test_parse_command_buffer_invalid_double_char() {
         // dd is no longer valid (Helix uses xd for delete line)
-        assert!(matches!(parse_command_buffer("dd"), ParsedCommand::Invalid));
+        assert_matches!(parse_command_buffer("dd"), ParsedCommand::Invalid);
 
         // Other invalid doubles
-        assert!(matches!(parse_command_buffer("jj"), ParsedCommand::Invalid));
-        assert!(matches!(parse_command_buffer("kk"), ParsedCommand::Invalid));
+        assert_matches!(parse_command_buffer("jj"), ParsedCommand::Invalid);
+        assert_matches!(parse_command_buffer("kk"), ParsedCommand::Invalid);
     }
 
     #[test]

--- a/src/game/services/scenario_completion.rs
+++ b/src/game/services/scenario_completion.rs
@@ -229,6 +229,7 @@ impl ScenarioCompletionService {
     /// use helix_trainer::gamification::UserProfile;
     /// use helix_trainer::learning::PerformanceTracker;
     /// use helix_trainer::ui::NotificationType;
+    /// use std::assert_matches;
     ///
     /// let mut profile = UserProfile::new();
     /// profile.perfect_scenarios = 1;
@@ -239,10 +240,10 @@ impl ScenarioCompletionService {
     ///
     /// // Should unlock FirstPerfect
     /// assert_eq!(notifications.len(), 1);
-    /// assert!(matches!(
+    /// assert_matches!(
     ///     notifications[0].notification_type,
     ///     NotificationType::Achievement { .. }
-    /// ));
+    /// );
     /// ```
     #[must_use]
     pub fn check_and_notify_achievements(
@@ -270,12 +271,13 @@ impl ScenarioCompletionService {
     /// ```
     /// use helix_trainer::game::services::ScenarioCompletionService;
     /// use helix_trainer::ui::NotificationType;
+    /// use std::assert_matches;
     ///
     /// let notification = ScenarioCompletionService::level_up_notification(true, 5);
-    /// assert!(matches!(
+    /// assert_matches!(
     ///     notification.unwrap().notification_type,
     ///     NotificationType::LevelUp { new_level: 5 }
-    /// ));
+    /// );
     ///
     /// assert!(ScenarioCompletionService::level_up_notification(false, 5).is_none());
     /// ```

--- a/src/game/session/tests.rs
+++ b/src/game/session/tests.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 use crate::testing::ScenarioBuilder;
+use std::assert_matches;
 
 fn create_test_scenario() -> Scenario {
     ScenarioBuilder::new()
@@ -86,8 +87,9 @@ fn test_completion_detection() {
     let result = session.record_action("d".to_string()).unwrap();
 
     // Should be completed now
-    assert!(
-        matches!(result, SessionAfterAction::Completed(_)),
+    assert_matches!(
+        result,
+        SessionAfterAction::Completed(_),
         "Session should be completed after 'x' + 'd' commands"
     );
 }

--- a/src/gamification/storage.rs
+++ b/src/gamification/storage.rs
@@ -35,7 +35,7 @@ fn fsync_parent_dir(path: &Path) {
     // filename with no directory component; treat that the same as "no
     // parent given" and fsync the current directory instead of no-op'ing.
     let parent = match path.parent() {
-        Some(p) if !p.as_os_str().is_empty() => p,
+        Some(p) if !p.is_empty() => p,
         _ => Path::new("."),
     };
     if let Ok(dir) = fs::File::open(parent) {

--- a/src/gamification/streak.rs
+++ b/src/gamification/streak.rs
@@ -229,6 +229,7 @@ mod tests {
     use super::*;
     use crate::time::{Clock, FakeClock};
     use chrono::Duration;
+    use std::assert_matches;
 
     #[test]
     fn test_streak_same_day_continues() {
@@ -486,10 +487,10 @@ mod tests {
         profile.streak_freeze_available = true;
 
         let result = StreakManager::use_freeze(&mut profile, STREAK_FREEZE_MAX_GAP_DAYS + 1);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(GamificationError::StreakFreezeGapOutOfRange { .. })
-        ));
+        );
         assert!(
             profile.streak_freeze_available,
             "freeze must remain held when the gap exceeds the coverage cap"
@@ -507,10 +508,7 @@ mod tests {
         profile.streak_freeze_available = true;
 
         let result = StreakManager::use_freeze(&mut profile, 2);
-        assert!(matches!(
-            result,
-            Err(GamificationError::StreakFreezeNothingToProtect)
-        ));
+        assert_matches!(result, Err(GamificationError::StreakFreezeNothingToProtect));
         assert!(
             profile.streak_freeze_available,
             "freeze must remain held when there is no streak to protect"

--- a/src/input/handlers.rs
+++ b/src/input/handlers.rs
@@ -678,6 +678,8 @@ pub fn handle_minigame_keys(key: KeyEvent, state: &AppState) -> Option<Message> 
 #[cfg(test)]
 #[allow(unused_variables)]
 mod tests {
+    use std::assert_matches;
+
     use super::*;
     use crate::{
         config::Scenario,
@@ -1870,10 +1872,10 @@ mod tests {
                 let result = data
                     .input_state_mut()
                     .process_key(KeyEvent::new(KeyCode::Char('3'), KeyModifiers::NONE));
-                assert!(matches!(
+                assert_matches!(
                     result,
                     crate::input::typestate::HandlerResult::Transition(_)
-                ));
+                );
                 assert!(data.input_state().is_prefix_state());
             }
 
@@ -1881,8 +1883,9 @@ mod tests {
                 handle_minigame_keys(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE), &state);
             // Esc while a count is pending must route through the state
             // machine (Cancel), not pause the game.
-            assert!(
-                matches!(esc_msg, Some(Message::MiniGameCommand { .. })),
+            assert_matches!(
+                esc_msg,
+                Some(Message::MiniGameCommand { .. }),
                 "expected Esc to route as a MiniGameCommand (cancel) while a prefix state is pending, got {:?}",
                 esc_msg
             );
@@ -1899,8 +1902,9 @@ mod tests {
 
             let esc_msg =
                 handle_minigame_keys(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE), &state);
-            assert!(
-                matches!(esc_msg, Some(Message::MiniGameCommand { .. })),
+            assert_matches!(
+                esc_msg,
+                Some(Message::MiniGameCommand { .. }),
                 "expected Esc to route as a MiniGameCommand (cancel) while RegisterPending, got {:?}",
                 esc_msg
             );
@@ -2022,10 +2026,10 @@ mod tests {
                 &mut state,
                 KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE),
             );
-            assert!(matches!(
+            assert_matches!(
                 input_state(&state),
                 crate::input::typestate::InputState::RegisterOpPending { register: 'a' }
-            ));
+            );
 
             // Must not panic and must fall through to the stock key, which
             // RegisterOpPending cancels on (only y/p/P/R/d/c are recognized ops).

--- a/src/input/typestate/tests/base_handler_tests.rs
+++ b/src/input/typestate/tests/base_handler_tests.rs
@@ -1,5 +1,7 @@
 //! Tests for BaseState handler
 
+use std::assert_matches;
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::helix::commands::*;
@@ -13,10 +15,7 @@ fn test_base_state_goto_prefix() {
         &BaseState,
         KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
     );
-    assert!(matches!(
-        result,
-        HandlerResult::Transition(InputState::GotoPending)
-    ));
+    assert_matches!(result, HandlerResult::Transition(InputState::GotoPending));
 }
 
 #[test]
@@ -25,10 +24,7 @@ fn test_base_state_view_prefix() {
         &BaseState,
         KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE),
     );
-    assert!(matches!(
-        result,
-        HandlerResult::Transition(InputState::ViewPending)
-    ));
+    assert_matches!(result, HandlerResult::Transition(InputState::ViewPending));
 }
 
 #[test]
@@ -37,10 +33,7 @@ fn test_base_state_match_prefix() {
         &BaseState,
         KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE),
     );
-    assert!(matches!(
-        result,
-        HandlerResult::Transition(InputState::MatchPending)
-    ));
+    assert_matches!(result, HandlerResult::Transition(InputState::MatchPending));
 }
 
 #[test]
@@ -49,12 +42,12 @@ fn test_base_state_find_prefix() {
         &BaseState,
         KeyEvent::new(KeyCode::Char('f'), KeyModifiers::NONE),
     );
-    assert!(matches!(
+    assert_matches!(
         result,
         HandlerResult::Transition(InputState::FindCharPending {
             find_type: FindType::FindForward
         })
-    ));
+    );
 }
 
 #[test]
@@ -63,10 +56,10 @@ fn test_base_state_replace_prefix() {
         &BaseState,
         KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE),
     );
-    assert!(matches!(
+    assert_matches!(
         result,
         HandlerResult::Transition(InputState::ReplaceCharPending)
-    ));
+    );
 }
 
 #[test]
@@ -75,10 +68,10 @@ fn test_base_state_count_prefix() {
         &BaseState,
         KeyEvent::new(KeyCode::Char('3'), KeyModifiers::NONE),
     );
-    assert!(matches!(
+    assert_matches!(
         result,
         HandlerResult::Transition(InputState::CountPending { count: 3 })
-    ));
+    );
 }
 
 #[test]
@@ -87,14 +80,14 @@ fn test_base_state_single_key_command() {
         &BaseState,
         KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_MOVE_LEFT));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_MOVE_LEFT);
 }
 
 #[test]
 fn test_base_state_escape() {
     let result =
         KeyHandler::handle_key(&BaseState, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_ESCAPE));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_ESCAPE);
 }
 
 #[test]
@@ -103,12 +96,12 @@ fn test_base_state_find_backward_prefix() {
         &BaseState,
         KeyEvent::new(KeyCode::Char('F'), KeyModifiers::SHIFT),
     );
-    assert!(matches!(
+    assert_matches!(
         result,
         HandlerResult::Transition(InputState::FindCharPending {
             find_type: FindType::FindBackward
         })
-    ));
+    );
 }
 
 #[test]
@@ -117,12 +110,12 @@ fn test_base_state_till_backward_prefix() {
         &BaseState,
         KeyEvent::new(KeyCode::Char('T'), KeyModifiers::SHIFT),
     );
-    assert!(matches!(
+    assert_matches!(
         result,
         HandlerResult::Transition(InputState::FindCharPending {
             find_type: FindType::TillBackward
         })
-    ));
+    );
 }
 
 #[test]
@@ -134,7 +127,7 @@ fn test_base_state_unknown_key_stays() {
         &BaseState,
         KeyEvent::new(KeyCode::Char('@'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Stay));
+    assert_matches!(result, HandlerResult::Stay);
 }
 
 #[test]
@@ -200,25 +193,25 @@ fn test_base_state_page_movement_commands() {
         &BaseState,
         KeyEvent::new(KeyCode::Char('b'), KeyModifiers::CONTROL),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_PAGE_UP));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_PAGE_UP);
 
     let result = KeyHandler::handle_key(
         &BaseState,
         KeyEvent::new(KeyCode::Char('f'), KeyModifiers::CONTROL),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_PAGE_DOWN));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_PAGE_DOWN);
 
     let result = KeyHandler::handle_key(
         &BaseState,
         KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_HALF_PAGE_UP));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_HALF_PAGE_UP);
 
     let result = KeyHandler::handle_key(
         &BaseState,
         KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_HALF_PAGE_DOWN));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_HALF_PAGE_DOWN);
 }
 
 #[test]
@@ -229,5 +222,5 @@ fn test_base_state_replace_with_yanked() {
         &BaseState,
         KeyEvent::new(KeyCode::Char('R'), KeyModifiers::SHIFT),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_REPLACE_WITH_YANKED));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_REPLACE_WITH_YANKED);
 }

--- a/src/input/typestate/tests/count_handler_tests.rs
+++ b/src/input/typestate/tests/count_handler_tests.rs
@@ -1,5 +1,7 @@
 //! Tests for CountPending handler
 
+use std::assert_matches;
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::input::typestate::{
@@ -13,10 +15,10 @@ fn test_count_pending_more_digits() {
         &state,
         KeyEvent::new(KeyCode::Char('5'), KeyModifiers::NONE),
     );
-    assert!(matches!(
+    assert_matches!(
         result,
         HandlerResult::Transition(InputState::CountPending { count: 35 })
-    ));
+    );
 }
 
 #[test]
@@ -26,7 +28,7 @@ fn test_count_pending_command() {
         &state,
         KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "3j"));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "3j");
 }
 
 #[test]
@@ -37,14 +39,14 @@ fn test_count_pending_invalid_command_cancels() {
         &state,
         KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 #[test]
 fn test_count_pending_escape_cancels() {
     let state = CountPending { count: 5 };
     let result = KeyHandler::handle_key(&state, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 #[test]
@@ -84,7 +86,7 @@ fn test_count_pending_register_prefix_cancels() {
         &state,
         KeyEvent::new(KeyCode::Char('"'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 #[test]

--- a/src/input/typestate/tests/find_replace_tests.rs
+++ b/src/input/typestate/tests/find_replace_tests.rs
@@ -1,5 +1,7 @@
 //! Tests for FindCharPending and ReplaceCharPending handlers
 
+use std::assert_matches;
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::helix::commands::*;
@@ -21,7 +23,7 @@ fn test_find_char_pending_accept_char() {
         &state,
         KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "fa"));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "fa");
 }
 
 #[test]
@@ -33,7 +35,7 @@ fn test_find_char_pending_backward() {
         &state,
         KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "Fx"));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "Fx");
 }
 
 #[test]
@@ -45,7 +47,7 @@ fn test_till_char_pending() {
         &state,
         KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "te"));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "te");
 }
 
 #[test]
@@ -54,7 +56,7 @@ fn test_find_char_escape_cancels() {
         find_type: FindType::FindForward,
     };
     let result = KeyHandler::handle_key(&state, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 // ============================================================================
@@ -67,7 +69,7 @@ fn test_replace_char_pending_accept_char() {
         &ReplaceCharPending,
         KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "ra"));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "ra");
 }
 
 #[test]
@@ -76,7 +78,7 @@ fn test_replace_char_pending_enter_newline() {
         &ReplaceCharPending,
         KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "r\n"));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "r\n");
 }
 
 #[test]
@@ -85,7 +87,7 @@ fn test_replace_char_escape_cancels() {
         &ReplaceCharPending,
         KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 // ============================================================================
@@ -98,7 +100,7 @@ fn test_unmatched_prev_pending_p_produces_goto_prev_paragraph() {
         &UnmatchedPrevPending,
         KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_GOTO_PREV_PARAGRAPH));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_GOTO_PREV_PARAGRAPH);
 }
 
 #[test]
@@ -107,7 +109,7 @@ fn test_unmatched_prev_pending_escape_cancels() {
         &UnmatchedPrevPending,
         KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 #[test]
@@ -116,7 +118,7 @@ fn test_unmatched_prev_pending_other_key_cancels() {
         &UnmatchedPrevPending,
         KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 #[test]
@@ -125,7 +127,7 @@ fn test_unmatched_prev_pending_digit_cancels() {
         &UnmatchedPrevPending,
         KeyEvent::new(KeyCode::Char('5'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 // ============================================================================
@@ -138,7 +140,7 @@ fn test_unmatched_next_pending_p_produces_goto_next_paragraph() {
         &UnmatchedNextPending,
         KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_GOTO_NEXT_PARAGRAPH));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_GOTO_NEXT_PARAGRAPH);
 }
 
 #[test]
@@ -147,7 +149,7 @@ fn test_unmatched_next_pending_escape_cancels() {
         &UnmatchedNextPending,
         KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 #[test]
@@ -156,7 +158,7 @@ fn test_unmatched_next_pending_other_key_cancels() {
         &UnmatchedNextPending,
         KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 #[test]
@@ -165,5 +167,5 @@ fn test_unmatched_next_pending_digit_cancels() {
         &UnmatchedNextPending,
         KeyEvent::new(KeyCode::Char('3'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }

--- a/src/input/typestate/tests/goto_handler_tests.rs
+++ b/src/input/typestate/tests/goto_handler_tests.rs
@@ -1,5 +1,7 @@
 //! Tests for GotoPending handler
 
+use std::assert_matches;
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::helix::commands::*;
@@ -11,7 +13,7 @@ fn test_goto_pending_gg() {
         &GotoPending,
         KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_GOTO_FILE_START));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_GOTO_FILE_START);
 }
 
 #[test]
@@ -20,7 +22,7 @@ fn test_goto_pending_gh() {
         &GotoPending,
         KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_GOTO_LINE_START));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_GOTO_LINE_START);
 }
 
 #[test]
@@ -29,7 +31,7 @@ fn test_goto_pending_gl() {
         &GotoPending,
         KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_GOTO_LINE_END));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_GOTO_LINE_END);
 }
 
 #[test]
@@ -38,7 +40,7 @@ fn test_goto_pending_invalid_key_cancels() {
         &GotoPending,
         KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 #[test]
@@ -47,7 +49,7 @@ fn test_goto_pending_escape_cancels() {
         &GotoPending,
         KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 #[test]
@@ -56,7 +58,7 @@ fn test_goto_pending_gs() {
         &GotoPending,
         KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_GOTO_FIRST_NONWHITESPACE));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_GOTO_FIRST_NONWHITESPACE);
 }
 
 #[test]
@@ -65,5 +67,5 @@ fn test_goto_pending_ge() {
         &GotoPending,
         KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_GOTO_LAST_LINE));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_GOTO_LAST_LINE);
 }

--- a/src/input/typestate/tests/match_handler_tests.rs
+++ b/src/input/typestate/tests/match_handler_tests.rs
@@ -1,5 +1,7 @@
 //! Tests for MatchPending and surround handlers
 
+use std::assert_matches;
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::helix::commands::*;
@@ -18,7 +20,7 @@ fn test_match_pending_mm() {
         &MatchPending,
         KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_MATCH_BRACKETS));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_MATCH_BRACKETS);
 }
 
 #[test]
@@ -27,10 +29,10 @@ fn test_match_pending_ms_transitions_to_surround_add() {
         &MatchPending,
         KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE),
     );
-    assert!(matches!(
+    assert_matches!(
         result,
         HandlerResult::Transition(InputState::SurroundAddPending)
-    ));
+    );
 }
 
 #[test]
@@ -39,10 +41,10 @@ fn test_match_pending_md_transitions_to_surround_delete() {
         &MatchPending,
         KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE),
     );
-    assert!(matches!(
+    assert_matches!(
         result,
         HandlerResult::Transition(InputState::SurroundDeletePending)
-    ));
+    );
 }
 
 #[test]
@@ -51,10 +53,10 @@ fn test_match_pending_mr_transitions_to_surround_replace() {
         &MatchPending,
         KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE),
     );
-    assert!(matches!(
+    assert_matches!(
         result,
         HandlerResult::Transition(InputState::SurroundReplaceFromPending)
-    ));
+    );
 }
 
 #[test]
@@ -63,10 +65,10 @@ fn test_match_pending_ma_transitions_to_text_object_around() {
         &MatchPending,
         KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE),
     );
-    assert!(matches!(
+    assert_matches!(
         result,
         HandlerResult::Transition(InputState::TextObjectAroundPending)
-    ));
+    );
 }
 
 #[test]
@@ -75,10 +77,10 @@ fn test_match_pending_mi_transitions_to_text_object_inside() {
         &MatchPending,
         KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE),
     );
-    assert!(matches!(
+    assert_matches!(
         result,
         HandlerResult::Transition(InputState::TextObjectInsidePending)
-    ));
+    );
 }
 
 #[test]
@@ -87,7 +89,7 @@ fn test_match_pending_invalid_cancels() {
         &MatchPending,
         KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 // ============================================================================
@@ -100,7 +102,7 @@ fn test_surround_add_pending_accept_char() {
         &SurroundAddPending,
         KeyEvent::new(KeyCode::Char('('), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "ms("));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "ms(");
 }
 
 #[test]
@@ -109,7 +111,7 @@ fn test_surround_add_pending_accept_bracket() {
         &SurroundAddPending,
         KeyEvent::new(KeyCode::Char('['), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "ms["));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "ms[");
 }
 
 #[test]
@@ -118,7 +120,7 @@ fn test_surround_add_pending_accept_quote() {
         &SurroundAddPending,
         KeyEvent::new(KeyCode::Char('"'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "ms\""));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "ms\"");
 }
 
 #[test]
@@ -127,7 +129,7 @@ fn test_surround_add_pending_escape_cancels() {
         &SurroundAddPending,
         KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 // ============================================================================
@@ -140,7 +142,7 @@ fn test_surround_delete_pending_accept_char() {
         &SurroundDeletePending,
         KeyEvent::new(KeyCode::Char('('), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "md("));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "md(");
 }
 
 #[test]
@@ -149,7 +151,7 @@ fn test_surround_delete_pending_accept_bracket() {
         &SurroundDeletePending,
         KeyEvent::new(KeyCode::Char('{'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "md{"));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "md{");
 }
 
 #[test]
@@ -158,7 +160,7 @@ fn test_surround_delete_pending_escape_cancels() {
         &SurroundDeletePending,
         KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 // ============================================================================
@@ -171,10 +173,10 @@ fn test_surround_replace_from_transitions_to_to() {
         &SurroundReplaceFromPending,
         KeyEvent::new(KeyCode::Char('('), KeyModifiers::NONE),
     );
-    assert!(matches!(
+    assert_matches!(
         result,
         HandlerResult::Transition(InputState::SurroundReplaceToPending { from_char: '(' })
-    ));
+    );
 }
 
 #[test]
@@ -183,7 +185,7 @@ fn test_surround_replace_from_escape_cancels() {
         &SurroundReplaceFromPending,
         KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 #[test]
@@ -193,7 +195,7 @@ fn test_surround_replace_to_completes() {
         &state,
         KeyEvent::new(KeyCode::Char('['), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "mr(["));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "mr([");
 }
 
 #[test]
@@ -203,12 +205,12 @@ fn test_surround_replace_to_quotes() {
         &state,
         KeyEvent::new(KeyCode::Char('\''), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "mr\"'"));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "mr\"'");
 }
 
 #[test]
 fn test_surround_replace_to_escape_cancels() {
     let state = SurroundReplaceToPending { from_char: '(' };
     let result = KeyHandler::handle_key(&state, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }

--- a/src/input/typestate/tests/state_machine_tests.rs
+++ b/src/input/typestate/tests/state_machine_tests.rs
@@ -1,5 +1,7 @@
 //! Tests for InputStateMachine
 
+use std::assert_matches;
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::helix::commands::*;
@@ -136,7 +138,7 @@ fn test_state_machine_surround_add_sequence() {
     // Press 's' - transition to SurroundAddPending
     let result = sm.process_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
     assert!(result.is_transition());
-    assert!(matches!(sm.state(), InputState::SurroundAddPending));
+    assert_matches!(sm.state(), InputState::SurroundAddPending);
 
     // Press '(' - execute "ms("
     let result = sm.process_key(KeyEvent::new(KeyCode::Char('('), KeyModifiers::NONE));
@@ -156,7 +158,7 @@ fn test_state_machine_surround_delete_sequence() {
     // Press 'd' - transition to SurroundDeletePending
     let result = sm.process_key(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
     assert!(result.is_transition());
-    assert!(matches!(sm.state(), InputState::SurroundDeletePending));
+    assert_matches!(sm.state(), InputState::SurroundDeletePending);
 
     // Press '{' - execute "md{"
     let result = sm.process_key(KeyEvent::new(KeyCode::Char('{'), KeyModifiers::NONE));
@@ -176,15 +178,15 @@ fn test_state_machine_surround_replace_sequence() {
     // Press 'r' - transition to SurroundReplaceFromPending
     let result = sm.process_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE));
     assert!(result.is_transition());
-    assert!(matches!(sm.state(), InputState::SurroundReplaceFromPending));
+    assert_matches!(sm.state(), InputState::SurroundReplaceFromPending);
 
     // Press '(' - transition to SurroundReplaceToPending
     let result = sm.process_key(KeyEvent::new(KeyCode::Char('('), KeyModifiers::NONE));
     assert!(result.is_transition());
-    assert!(matches!(
+    assert_matches!(
         sm.state(),
         InputState::SurroundReplaceToPending { from_char: '(' }
-    ));
+    );
 
     // Press '[' - execute "mr(["
     let result = sm.process_key(KeyEvent::new(KeyCode::Char('['), KeyModifiers::NONE));
@@ -200,7 +202,7 @@ fn test_state_machine_surround_escape_cancels() {
     // Go to SurroundAddPending
     sm.process_key(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE));
     sm.process_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE));
-    assert!(matches!(sm.state(), InputState::SurroundAddPending));
+    assert_matches!(sm.state(), InputState::SurroundAddPending);
 
     // Press Escape - should cancel
     let result = sm.process_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
@@ -230,7 +232,7 @@ fn test_state_machine_text_object_around_sequence() {
     // Press 'a' - transition to TextObjectAroundPending
     let result = sm.process_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE));
     assert!(result.is_transition());
-    assert!(matches!(sm.state(), InputState::TextObjectAroundPending));
+    assert_matches!(sm.state(), InputState::TextObjectAroundPending);
 
     // Press 'w' - execute "maw"
     let result = sm.process_key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::NONE));
@@ -250,7 +252,7 @@ fn test_state_machine_text_object_inside_sequence() {
     // Press 'i' - transition to TextObjectInsidePending
     let result = sm.process_key(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE));
     assert!(result.is_transition());
-    assert!(matches!(sm.state(), InputState::TextObjectInsidePending));
+    assert_matches!(sm.state(), InputState::TextObjectInsidePending);
 
     // Press '(' - execute "mi("
     let result = sm.process_key(KeyEvent::new(KeyCode::Char('('), KeyModifiers::NONE));
@@ -266,7 +268,7 @@ fn test_state_machine_text_object_escape_cancels() {
     // Go to TextObjectAroundPending
     sm.process_key(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE));
     sm.process_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE));
-    assert!(matches!(sm.state(), InputState::TextObjectAroundPending));
+    assert_matches!(sm.state(), InputState::TextObjectAroundPending);
 
     // Press Escape - should cancel
     let result = sm.process_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
@@ -308,7 +310,7 @@ fn test_pending_surround_preview_none_in_surround_replace_from() {
     // Go to SurroundReplaceFromPending
     sm.process_key(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE));
     sm.process_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE));
-    assert!(matches!(sm.state(), InputState::SurroundReplaceFromPending));
+    assert_matches!(sm.state(), InputState::SurroundReplaceFromPending);
     // Still no preview - we don't know which bracket yet
     assert!(sm.pending_surround_preview().is_none());
 }
@@ -323,10 +325,10 @@ fn test_pending_surround_preview_replace() {
     sm.process_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE));
     sm.process_key(KeyEvent::new(KeyCode::Char('('), KeyModifiers::NONE));
 
-    assert!(matches!(
+    assert_matches!(
         sm.state(),
         InputState::SurroundReplaceToPending { from_char: '(' }
-    ));
+    );
 
     // Should return Replace variant with the from_char
     let preview = sm.pending_surround_preview();

--- a/src/input/typestate/tests/text_object_tests.rs
+++ b/src/input/typestate/tests/text_object_tests.rs
@@ -1,5 +1,7 @@
 //! Tests for TextObject handlers
 
+use std::assert_matches;
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::input::typestate::{
@@ -16,7 +18,7 @@ fn test_text_object_around_word() {
         &TextObjectAroundPending,
         KeyEvent::new(KeyCode::Char('w'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "maw"));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "maw");
 }
 
 #[test]
@@ -25,7 +27,7 @@ fn test_text_object_around_word_big() {
         &TextObjectAroundPending,
         KeyEvent::new(KeyCode::Char('W'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "maW"));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "maW");
 }
 
 #[test]
@@ -34,7 +36,7 @@ fn test_text_object_around_parens() {
         &TextObjectAroundPending,
         KeyEvent::new(KeyCode::Char('('), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "ma("));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "ma(");
 }
 
 #[test]
@@ -43,7 +45,7 @@ fn test_text_object_around_quotes() {
         &TextObjectAroundPending,
         KeyEvent::new(KeyCode::Char('"'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "ma\""));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "ma\"");
 }
 
 #[test]
@@ -52,7 +54,7 @@ fn test_text_object_around_paragraph() {
         &TextObjectAroundPending,
         KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "map"));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "map");
 }
 
 #[test]
@@ -61,7 +63,7 @@ fn test_text_object_around_escape_cancels() {
         &TextObjectAroundPending,
         KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 #[test]
@@ -70,7 +72,7 @@ fn test_text_object_around_invalid_cancels() {
         &TextObjectAroundPending,
         KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 // ============================================================================
@@ -83,7 +85,7 @@ fn test_text_object_inside_word() {
         &TextObjectInsidePending,
         KeyEvent::new(KeyCode::Char('w'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "miw"));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "miw");
 }
 
 #[test]
@@ -92,7 +94,7 @@ fn test_text_object_inside_brackets() {
         &TextObjectInsidePending,
         KeyEvent::new(KeyCode::Char('['), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "mi["));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "mi[");
 }
 
 #[test]
@@ -101,7 +103,7 @@ fn test_text_object_inside_braces() {
         &TextObjectInsidePending,
         KeyEvent::new(KeyCode::Char('{'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "mi{"));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "mi{");
 }
 
 #[test]
@@ -110,7 +112,7 @@ fn test_text_object_inside_angle_brackets() {
         &TextObjectInsidePending,
         KeyEvent::new(KeyCode::Char('<'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "mi<"));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "mi<");
 }
 
 #[test]
@@ -119,7 +121,7 @@ fn test_text_object_inside_single_quote() {
         &TextObjectInsidePending,
         KeyEvent::new(KeyCode::Char('\''), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "mi'"));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "mi'");
 }
 
 #[test]
@@ -128,7 +130,7 @@ fn test_text_object_inside_backtick() {
         &TextObjectInsidePending,
         KeyEvent::new(KeyCode::Char('`'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == "mi`"));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == "mi`");
 }
 
 #[test]
@@ -137,5 +139,5 @@ fn test_text_object_inside_escape_cancels() {
         &TextObjectInsidePending,
         KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }

--- a/src/input/typestate/tests/typestate_wrapper_tests.rs
+++ b/src/input/typestate/tests/typestate_wrapper_tests.rs
@@ -1,5 +1,7 @@
 //! Tests for TypestateHandler and TypestateHandlerState
 
+use std::assert_matches;
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::helix::commands::*;
@@ -11,7 +13,7 @@ fn test_typestate_handler_base_to_goto() {
     let (result, next) = handler.process_key(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE));
 
     assert!(result.is_transition());
-    assert!(matches!(next, TypestateHandlerState::GotoPending(_)));
+    assert_matches!(next, TypestateHandlerState::GotoPending(_));
 }
 
 #[test]
@@ -23,7 +25,7 @@ fn test_typestate_handler_state_process() {
     let (result, next) = state.process_key(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE));
     assert!(result.is_transition());
     state = next;
-    assert!(matches!(state, TypestateHandlerState::ViewPending(_)));
+    assert_matches!(state, TypestateHandlerState::ViewPending(_));
 
     // Press 'z' - execute "zz"
     let (result, next) = state.process_key(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE));

--- a/src/input/typestate/tests/unmatched_handler_tests.rs
+++ b/src/input/typestate/tests/unmatched_handler_tests.rs
@@ -1,5 +1,7 @@
 //! Tests for UnmatchedPrevPending and UnmatchedNextPending handlers
 
+use std::assert_matches;
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::helix::commands::*;
@@ -17,7 +19,7 @@ fn test_unmatched_prev_p_goto_prev_paragraph() {
         &UnmatchedPrevPending,
         KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_GOTO_PREV_PARAGRAPH));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_GOTO_PREV_PARAGRAPH);
 }
 
 #[test]
@@ -26,7 +28,7 @@ fn test_unmatched_prev_escape_cancels() {
         &UnmatchedPrevPending,
         KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 #[test]
@@ -35,7 +37,7 @@ fn test_unmatched_prev_invalid_key_cancels() {
         &UnmatchedPrevPending,
         KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 #[test]
@@ -44,7 +46,7 @@ fn test_unmatched_prev_number_cancels() {
         &UnmatchedPrevPending,
         KeyEvent::new(KeyCode::Char('5'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 // ============================================================================
@@ -57,7 +59,7 @@ fn test_unmatched_next_p_goto_next_paragraph() {
         &UnmatchedNextPending,
         KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_GOTO_NEXT_PARAGRAPH));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_GOTO_NEXT_PARAGRAPH);
 }
 
 #[test]
@@ -66,7 +68,7 @@ fn test_unmatched_next_escape_cancels() {
         &UnmatchedNextPending,
         KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 #[test]
@@ -75,7 +77,7 @@ fn test_unmatched_next_invalid_key_cancels() {
         &UnmatchedNextPending,
         KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 #[test]
@@ -84,5 +86,5 @@ fn test_unmatched_next_number_cancels() {
         &UnmatchedNextPending,
         KeyEvent::new(KeyCode::Char('9'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }

--- a/src/input/typestate/tests/view_handler_tests.rs
+++ b/src/input/typestate/tests/view_handler_tests.rs
@@ -1,5 +1,7 @@
 //! Tests for ViewPending handler
 
+use std::assert_matches;
+
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::helix::commands::*;
@@ -11,7 +13,7 @@ fn test_view_pending_zz() {
         &ViewPending,
         KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_VIEW_CENTER));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_VIEW_CENTER);
 }
 
 #[test]
@@ -20,7 +22,7 @@ fn test_view_pending_zt() {
         &ViewPending,
         KeyEvent::new(KeyCode::Char('t'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_VIEW_TOP));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_VIEW_TOP);
 }
 
 #[test]
@@ -29,7 +31,7 @@ fn test_view_pending_zb() {
         &ViewPending,
         KeyEvent::new(KeyCode::Char('b'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_VIEW_BOTTOM));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_VIEW_BOTTOM);
 }
 
 #[test]
@@ -38,7 +40,7 @@ fn test_view_pending_zm() {
         &ViewPending,
         KeyEvent::new(KeyCode::Char('m'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_VIEW_CENTER_HORIZONTAL));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_VIEW_CENTER_HORIZONTAL);
 }
 
 #[test]
@@ -47,7 +49,7 @@ fn test_view_pending_zj() {
         &ViewPending,
         KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_SCROLL_DOWN));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_SCROLL_DOWN);
 }
 
 #[test]
@@ -56,7 +58,7 @@ fn test_view_pending_zk() {
         &ViewPending,
         KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_SCROLL_UP));
+    assert_matches!(result, HandlerResult::Execute(cmd) if cmd == CMD_SCROLL_UP);
 }
 
 #[test]
@@ -65,7 +67,7 @@ fn test_view_pending_escape_cancels() {
         &ViewPending,
         KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }
 
 #[test]
@@ -74,5 +76,5 @@ fn test_view_pending_invalid_cancels() {
         &ViewPending,
         KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
     );
-    assert!(matches!(result, HandlerResult::Cancel));
+    assert_matches!(result, HandlerResult::Cancel);
 }

--- a/src/learning/performance.rs
+++ b/src/learning/performance.rs
@@ -489,6 +489,7 @@ mod tests {
 
     use super::*;
     use crate::time::FakeClock;
+    use std::assert_matches;
 
     #[test]
     fn test_new_command_defaults() {
@@ -544,10 +545,7 @@ mod tests {
         let perf = tracker.performance("x").unwrap();
         assert!(perf.stability > 0.0);
         assert_eq!(perf.reps, 1);
-        assert!(matches!(
-            perf.state,
-            CardState::Learning | CardState::Review
-        ));
+        assert_matches!(perf.state, CardState::Learning | CardState::Review);
 
         let first_stability = perf.stability;
 
@@ -575,10 +573,7 @@ mod tests {
         let perf = tracker.performance("x").unwrap();
         // Lapse count increases when failing
         assert_eq!(perf.lapses, lapses_before + 1);
-        assert!(matches!(
-            perf.state,
-            CardState::Relearning | CardState::Learning
-        ));
+        assert_matches!(perf.state, CardState::Relearning | CardState::Learning);
     }
 
     #[test]

--- a/src/learning/session.rs
+++ b/src/learning/session.rs
@@ -220,6 +220,7 @@ impl ReviewSession {
 mod tests {
     use super::*;
     use crate::learning::PerformanceTracker;
+    use std::assert_matches;
 
     fn create_populated_tracker() -> Rc<RefCell<PerformanceTracker>> {
         let tracker = Rc::new(RefCell::new(PerformanceTracker::new()));
@@ -300,20 +301,20 @@ mod tests {
 
             let result = &session.results[0];
             // Both old and new mastery should be set
-            assert!(matches!(
+            assert_matches!(
                 result.old_mastery,
                 MasteryLevel::Beginner
                     | MasteryLevel::Intermediate
                     | MasteryLevel::Advanced
                     | MasteryLevel::Master
-            ));
-            assert!(matches!(
+            );
+            assert_matches!(
                 result.new_mastery,
                 MasteryLevel::Beginner
                     | MasteryLevel::Intermediate
                     | MasteryLevel::Advanced
                     | MasteryLevel::Master
-            ));
+            );
         }
     }
 

--- a/src/minigame/stats.rs
+++ b/src/minigame/stats.rs
@@ -576,6 +576,7 @@ mod tests {
 
     mod multiplier_state_tests {
         use super::*;
+        use std::assert_matches;
 
         #[test]
         fn test_new_state() {
@@ -639,10 +640,10 @@ mod tests {
                 state.record_success();
             }
             assert_eq!(state.grace_remaining(), 1);
-            assert!(matches!(
+            assert_matches!(
                 state.take_change(),
                 Some(MultiplierChange::MilestoneReached { .. })
-            ));
+            );
         }
 
         #[test]
@@ -657,10 +658,7 @@ mod tests {
             state.record_failure();
             assert_eq!(state.grace_remaining(), 0);
             assert!((state.current() - multiplier_before).abs() < f64::EPSILON);
-            assert!(matches!(
-                state.take_change(),
-                Some(MultiplierChange::GraceUsed)
-            ));
+            assert_matches!(state.take_change(), Some(MultiplierChange::GraceUsed));
         }
 
         #[test]
@@ -675,10 +673,10 @@ mod tests {
             state.record_failure();
             assert!((state.current() - 1.0).abs() < f64::EPSILON);
             assert_eq!(state.streak(), 0);
-            assert!(matches!(
+            assert_matches!(
                 state.take_change(),
                 Some(MultiplierChange::Decreased { from, to }) if (from - old_mult).abs() < f64::EPSILON && (to - 1.0).abs() < f64::EPSILON
-            ));
+            );
         }
 
         #[test]
@@ -769,10 +767,10 @@ mod tests {
             state.take_change();
 
             state.record_success();
-            assert!(matches!(
+            assert_matches!(
                 state.take_change(),
                 Some(MultiplierChange::Increased { from, to }) if (from - 1.0).abs() < f64::EPSILON && (to - 1.5).abs() < f64::EPSILON
-            ));
+            );
         }
 
         #[test]

--- a/src/ui/state/handlers/minigame.rs
+++ b/src/ui/state/handlers/minigame.rs
@@ -542,6 +542,7 @@ mod tests {
     use crate::learning::PerformanceTracker;
     use crate::testing::ScenarioBuilder;
     use crate::ui::state::{ConfigState, GameState, ProgressState, UIState};
+    use std::assert_matches;
 
     fn create_test_scenario(id: &str) -> Scenario {
         create_test_scenario_with_difficulty(id, Difficulty::Beginner)
@@ -623,7 +624,7 @@ mod tests {
         start_minigame(&mut state);
 
         assert!(state.game.minigame_session.is_some());
-        assert!(matches!(state.screen, TypedScreen::MiniGame(_)));
+        assert_matches!(state.screen, TypedScreen::MiniGame(_));
 
         if let Some(ref session) = state.game.minigame_session {
             assert!(session.state().is_countdown());
@@ -931,7 +932,7 @@ mod tests {
         crate::ui::state::apply_outcome(&mut state, outcome);
 
         assert!(state.game.minigame_session.is_none());
-        assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
+        assert_matches!(state.screen, TypedScreen::ModeSelection(_));
     }
 
     #[test]
@@ -1536,7 +1537,7 @@ mod tests {
         );
         let outcome = handle_minigame_scenario_complete(&mut ctx).unwrap();
 
-        assert!(matches!(outcome, HandlerOutcome::Stay));
+        assert_matches!(outcome, HandlerOutcome::Stay);
     }
 
     #[test]
@@ -1554,7 +1555,7 @@ mod tests {
 
         let outcome = handle_minigame_next_scenario(&mut state).unwrap();
 
-        assert!(matches!(outcome, HandlerOutcome::Stay));
+        assert_matches!(outcome, HandlerOutcome::Stay);
     }
 
     /// Regression test for S4b: a half-typed prefix/register/command-line
@@ -1798,7 +1799,7 @@ mod tests {
         crate::ui::state::apply_outcome(&mut state, outcome);
 
         assert!(state.game.minigame_session.is_none());
-        assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
+        assert_matches!(state.screen, TypedScreen::ModeSelection(_));
     }
 
     #[test]
@@ -1830,7 +1831,7 @@ mod tests {
 
         // Session should be cleared
         assert!(state.game.minigame_session.is_none());
-        assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
+        assert_matches!(state.screen, TypedScreen::ModeSelection(_));
     }
 
     /// Regression test for #291: achievements must unlock through the live arcade
@@ -2173,7 +2174,7 @@ mod tests {
             "returning to menu from an already-processed game-over must not increment games_played again"
         );
         assert!(state.game.minigame_session.is_none());
-        assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
+        assert_matches!(state.screen, TypedScreen::ModeSelection(_));
     }
 
     /// Regression test for #309: a game-over that doesn't cross a level threshold must
@@ -2333,6 +2334,6 @@ mod tests {
             "returning to menu from an already-processed session timeout must not increment games_played again"
         );
         assert!(state.game.minigame_session.is_none());
-        assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
+        assert_matches!(state.screen, TypedScreen::ModeSelection(_));
     }
 }

--- a/src/ui/state/handlers/mode_selection.rs
+++ b/src/ui/state/handlers/mode_selection.rs
@@ -187,6 +187,7 @@ mod tests {
     use crate::learning::PerformanceTracker;
     use crate::testing::ScenarioBuilder;
     use crate::ui::state::{ConfigState, GameState, ProgressState, UIState};
+    use std::assert_matches;
 
     fn create_test_scenario(id: &str) -> crate::config::Scenario {
         ScenarioBuilder::new()
@@ -286,7 +287,7 @@ mod tests {
 
         assert!(outcome.is_transition());
         if let HandlerOutcome::Transition(screen) = outcome {
-            assert!(matches!(*screen, TypedScreen::Menu(_)));
+            assert_matches!(*screen, TypedScreen::Menu(_));
         }
     }
 
@@ -299,7 +300,7 @@ mod tests {
 
         assert!(outcome.is_transition());
         if let HandlerOutcome::Transition(screen) = outcome {
-            assert!(matches!(*screen, TypedScreen::MiniGame(_)));
+            assert_matches!(*screen, TypedScreen::MiniGame(_));
         }
     }
 
@@ -340,7 +341,7 @@ mod tests {
 
         assert!(outcome.is_transition());
         if let HandlerOutcome::Transition(screen) = outcome {
-            assert!(matches!(*screen, TypedScreen::Menu(_)));
+            assert_matches!(*screen, TypedScreen::Menu(_));
         }
     }
 
@@ -440,7 +441,7 @@ mod tests {
 
         assert!(outcome.is_transition());
         if let HandlerOutcome::Transition(screen) = outcome {
-            assert!(matches!(*screen, TypedScreen::MiniGame(_)));
+            assert_matches!(*screen, TypedScreen::MiniGame(_));
             if let TypedScreen::MiniGame(data) = *screen {
                 assert!(data.mode.as_ref().map(|m| m.is_survival()).unwrap_or(false));
             }
@@ -466,7 +467,7 @@ mod tests {
 
         assert!(outcome.is_transition());
         if let HandlerOutcome::Transition(screen) = outcome {
-            assert!(matches!(*screen, TypedScreen::MiniGame(_)));
+            assert_matches!(*screen, TypedScreen::MiniGame(_));
         }
 
         // Verify session is created with 3 lives
@@ -518,10 +519,10 @@ mod tests {
             ctx.ui.notifications.visible()[0].message(),
             rust_i18n::t!("minigame.challenge_no_attempts_left").to_string()
         );
-        assert!(matches!(
+        assert_matches!(
             ctx.ui.notifications.visible()[0].notification_type,
             crate::ui::notification::NotificationType::Info { .. }
-        ));
+        );
     }
 
     /// Regression guard: exhausting Daily Challenge attempts must not affect

--- a/src/ui/state/handlers/navigation.rs
+++ b/src/ui/state/handlers/navigation.rs
@@ -102,6 +102,7 @@ mod tests {
     use crate::gamification::{ProfileStorage, UserProfile};
     use crate::learning::PerformanceTracker;
     use crate::ui::state::{ConfigState, GameState, ProgressState, UIState};
+    use std::assert_matches;
 
     fn create_test_context() -> (UIState, GameState, ProgressState, ConfigState) {
         (
@@ -144,7 +145,7 @@ mod tests {
 
         assert!(outcome.is_transition());
         if let HandlerOutcome::Transition(screen) = outcome {
-            assert!(matches!(*screen, TypedScreen::ModeSelection(_)));
+            assert_matches!(*screen, TypedScreen::ModeSelection(_));
         }
     }
 
@@ -154,7 +155,7 @@ mod tests {
 
         assert!(outcome.is_transition());
         if let HandlerOutcome::Transition(screen) = outcome {
-            assert!(matches!(*screen, TypedScreen::Profile(_)));
+            assert_matches!(*screen, TypedScreen::Profile(_));
         }
     }
 
@@ -178,7 +179,7 @@ mod tests {
 
         assert!(outcome.is_transition());
         if let HandlerOutcome::Transition(new_screen) = outcome {
-            assert!(matches!(*new_screen, TypedScreen::ModeSelection(_)));
+            assert_matches!(*new_screen, TypedScreen::ModeSelection(_));
         }
     }
 
@@ -194,7 +195,7 @@ mod tests {
 
         assert!(outcome.is_transition());
         if let HandlerOutcome::Transition(new_screen) = outcome {
-            assert!(matches!(*new_screen, TypedScreen::ModeSelection(_)));
+            assert_matches!(*new_screen, TypedScreen::ModeSelection(_));
         }
     }
 
@@ -211,7 +212,7 @@ mod tests {
 
         assert!(outcome.is_transition());
         if let HandlerOutcome::Transition(new_screen) = outcome {
-            assert!(matches!(*new_screen, TypedScreen::ModeSelection(_)));
+            assert_matches!(*new_screen, TypedScreen::ModeSelection(_));
         }
     }
 
@@ -228,7 +229,7 @@ mod tests {
 
         assert!(outcome.is_transition());
         if let HandlerOutcome::Transition(new_screen) = outcome {
-            assert!(matches!(*new_screen, TypedScreen::MiniGame(_)));
+            assert_matches!(*new_screen, TypedScreen::MiniGame(_));
         }
     }
 
@@ -244,7 +245,7 @@ mod tests {
 
         assert!(outcome.is_transition());
         if let HandlerOutcome::Transition(new_screen) = outcome {
-            assert!(matches!(*new_screen, TypedScreen::MiniGame(_)));
+            assert_matches!(*new_screen, TypedScreen::MiniGame(_));
         }
     }
 
@@ -260,7 +261,7 @@ mod tests {
 
         assert!(outcome.is_transition());
         if let HandlerOutcome::Transition(new_screen) = outcome {
-            assert!(matches!(*new_screen, TypedScreen::MiniGame(_)));
+            assert_matches!(*new_screen, TypedScreen::MiniGame(_));
         }
     }
 
@@ -274,7 +275,7 @@ mod tests {
 
         assert!(outcome.is_transition());
         if let HandlerOutcome::Transition(new_screen) = outcome {
-            assert!(matches!(*new_screen, TypedScreen::ModeSelection(_)));
+            assert_matches!(*new_screen, TypedScreen::ModeSelection(_));
         }
     }
 
@@ -284,7 +285,7 @@ mod tests {
 
         assert!(outcome.is_transition());
         if let HandlerOutcome::Transition(screen) = outcome {
-            assert!(matches!(*screen, TypedScreen::Menu(_)));
+            assert_matches!(*screen, TypedScreen::Menu(_));
         }
     }
 
@@ -294,7 +295,7 @@ mod tests {
 
         assert!(outcome.is_transition());
         if let HandlerOutcome::Transition(screen) = outcome {
-            assert!(matches!(*screen, TypedScreen::Statistics(_)));
+            assert_matches!(*screen, TypedScreen::Statistics(_));
         }
     }
 
@@ -304,7 +305,7 @@ mod tests {
 
         assert!(outcome.is_transition());
         if let HandlerOutcome::Transition(screen) = outcome {
-            assert!(matches!(*screen, TypedScreen::Achievements(_)));
+            assert_matches!(*screen, TypedScreen::Achievements(_));
         }
     }
 
@@ -314,7 +315,7 @@ mod tests {
 
         assert!(outcome.is_transition());
         if let HandlerOutcome::Transition(screen) = outcome {
-            assert!(matches!(*screen, TypedScreen::MiniGame(_)));
+            assert_matches!(*screen, TypedScreen::MiniGame(_));
         }
     }
 
@@ -324,7 +325,7 @@ mod tests {
 
         assert!(outcome.is_transition());
         if let HandlerOutcome::Transition(screen) = outcome {
-            assert!(matches!(*screen, TypedScreen::CategoryFilters(_)));
+            assert_matches!(*screen, TypedScreen::CategoryFilters(_));
         }
     }
 
@@ -356,7 +357,7 @@ mod tests {
 
         assert!(outcome.is_transition());
         if let HandlerOutcome::Transition(new_screen) = outcome {
-            assert!(matches!(*new_screen, TypedScreen::ModeSelection(_)));
+            assert_matches!(*new_screen, TypedScreen::ModeSelection(_));
         }
     }
 
@@ -374,7 +375,7 @@ mod tests {
         assert!(outcome.is_transition());
         if let HandlerOutcome::Transition(new_screen) = outcome {
             // Should return to Menu (scenario list), not ModeSelection
-            assert!(matches!(*new_screen, TypedScreen::Menu(_)));
+            assert_matches!(*new_screen, TypedScreen::Menu(_));
         }
     }
 
@@ -391,7 +392,7 @@ mod tests {
 
         assert!(outcome.is_transition());
         if let HandlerOutcome::Transition(new_screen) = outcome {
-            assert!(matches!(*new_screen, TypedScreen::MiniGame(_)));
+            assert_matches!(*new_screen, TypedScreen::MiniGame(_));
         }
     }
 }

--- a/src/ui/state/handlers/scenario.rs
+++ b/src/ui/state/handlers/scenario.rs
@@ -524,6 +524,7 @@ mod tests {
     use crate::ui::state::{
         AppState, ConfigState, GameState, ProgressState, TaskData, TypedScreen, UIState,
     };
+    use std::assert_matches;
 
     fn create_test_scenario() -> Scenario {
         create_test_scenario_with_difficulty("test_scenario", Difficulty::Beginner)
@@ -568,10 +569,10 @@ mod tests {
 
         let outcome = handle_start_scenario(&mut ctx, 0).unwrap();
 
-        assert!(matches!(
+        assert_matches!(
             outcome,
             HandlerOutcome::Transition(ref screen) if matches!(**screen, TypedScreen::Task(_))
-        ));
+        );
         assert!(!ctx.ui.show_key_history);
         assert!(ctx.ui.completion_time.is_none());
     }
@@ -588,7 +589,7 @@ mod tests {
 
         let outcome = handle_start_scenario(&mut ctx, 999).unwrap();
 
-        assert!(matches!(outcome, HandlerOutcome::Stay));
+        assert_matches!(outcome, HandlerOutcome::Stay);
     }
 
     #[test]
@@ -599,12 +600,12 @@ mod tests {
 
         let screen = handle_abandon_scenario(task_data).unwrap();
 
-        assert!(matches!(screen, TypedScreen::Results(_)));
+        assert_matches!(screen, TypedScreen::Results(_));
         if let TypedScreen::Results(results) = screen {
-            assert!(matches!(
+            assert_matches!(
                 results.session,
                 crate::ui::state::CompletedOrAbandoned::Abandoned(_)
-            ));
+            );
         }
     }
 
@@ -640,7 +641,7 @@ mod tests {
 
         let screen = handle_retry_scenario(results_data, &mut ctx).unwrap();
 
-        assert!(matches!(screen, TypedScreen::Task(_)));
+        assert_matches!(screen, TypedScreen::Task(_));
         assert!(!ctx.ui.show_key_history);
         assert!(ctx.ui.completion_time.is_none());
     }
@@ -664,7 +665,7 @@ mod tests {
 
         let screen = handle_retry_scenario(results_data, &mut ctx).unwrap();
 
-        assert!(matches!(screen, TypedScreen::Task(_)));
+        assert_matches!(screen, TypedScreen::Task(_));
     }
 
     #[test]
@@ -679,10 +680,10 @@ mod tests {
 
         let outcome = handle_next_scenario(&mut ctx).unwrap();
 
-        assert!(matches!(
+        assert_matches!(
             outcome,
             HandlerOutcome::Transition(ref screen) if matches!(**screen, TypedScreen::Menu(_))
-        ));
+        );
     }
 
     /// Regression test for #292 finding F2 (impl-critic): `xp_breakdown.quest_bonuses`
@@ -804,10 +805,10 @@ mod tests {
 
         let outcome = handle_complete_scenario(&mut state).unwrap();
 
-        assert!(matches!(
+        assert_matches!(
             outcome,
             HandlerOutcome::Transition(ref screen) if matches!(**screen, TypedScreen::Menu(_))
-        ));
+        );
     }
 
     #[test]
@@ -835,10 +836,10 @@ mod tests {
 
         let outcome = handle_complete_scenario(&mut state).unwrap();
 
-        assert!(matches!(
+        assert_matches!(
             outcome,
             HandlerOutcome::Transition(ref screen) if matches!(**screen, TypedScreen::Results(_))
-        ));
+        );
     }
 
     #[test]
@@ -873,10 +874,10 @@ mod tests {
 
         let outcome = handle_complete_scenario(&mut state).unwrap();
 
-        assert!(matches!(
+        assert_matches!(
             outcome,
             HandlerOutcome::Transition(ref screen) if matches!(**screen, TypedScreen::Results(_))
-        ));
+        );
 
         assert!(state.progress.profile.total_xp > initial_xp);
         assert_eq!(state.progress.scenarios_completed_today, 1);
@@ -1442,7 +1443,7 @@ mod tests {
         let outcome = handle_start_scenario(&mut ctx, 0).unwrap();
 
         if let HandlerOutcome::Transition(screen) = outcome {
-            assert!(matches!(*screen, TypedScreen::Task(_)));
+            assert_matches!(*screen, TypedScreen::Task(_));
         } else {
             panic!("Expected Transition outcome");
         }
@@ -1457,10 +1458,10 @@ mod tests {
         let screen = handle_abandon_scenario(task_data).unwrap();
 
         if let TypedScreen::Results(results) = screen {
-            assert!(matches!(
+            assert_matches!(
                 results.session,
                 crate::ui::state::CompletedOrAbandoned::Abandoned(_)
-            ));
+            );
         } else {
             panic!("Expected Results screen");
         }
@@ -1479,7 +1480,7 @@ mod tests {
         let outcome = handle_next_scenario(&mut ctx).unwrap();
 
         if let HandlerOutcome::Transition(screen) = outcome {
-            assert!(matches!(*screen, TypedScreen::Menu(_)));
+            assert_matches!(*screen, TypedScreen::Menu(_));
         } else {
             panic!("Expected Transition outcome");
         }
@@ -1570,8 +1571,9 @@ mod tests {
         let outcome = handle_next_lesson(&results_data, &mut ctx).unwrap();
 
         // Should stay on results screen
-        assert!(
-            matches!(outcome, HandlerOutcome::Stay),
+        assert_matches!(
+            outcome,
+            HandlerOutcome::Stay,
             "Expected Stay outcome at end of list"
         );
     }
@@ -1592,10 +1594,7 @@ mod tests {
 
         // Should transition to Menu screen
         if let HandlerOutcome::Transition(screen) = outcome {
-            assert!(
-                matches!(*screen, TypedScreen::Menu(_)),
-                "Expected Menu screen"
-            );
+            assert_matches!(*screen, TypedScreen::Menu(_), "Expected Menu screen");
         } else {
             panic!("Expected Transition outcome");
         }
@@ -1617,10 +1616,7 @@ mod tests {
 
         // Should always transition to Menu screen
         if let HandlerOutcome::Transition(screen) = outcome {
-            assert!(
-                matches!(*screen, TypedScreen::Menu(_)),
-                "Expected Menu screen"
-            );
+            assert_matches!(*screen, TypedScreen::Menu(_), "Expected Menu screen");
         } else {
             panic!("Expected Transition outcome");
         }
@@ -1642,10 +1638,7 @@ mod tests {
 
         // Should always transition to Menu screen regardless of scenario_index
         if let HandlerOutcome::Transition(screen) = outcome {
-            assert!(
-                matches!(*screen, TypedScreen::Menu(_)),
-                "Expected Menu screen"
-            );
+            assert_matches!(*screen, TypedScreen::Menu(_), "Expected Menu screen");
         } else {
             panic!("Expected Transition outcome");
         }
@@ -1751,10 +1744,10 @@ mod tests {
         let outcome = handle_start_scenario(&mut ctx, 2).unwrap();
 
         // Verify transition to Task screen
-        assert!(matches!(
+        assert_matches!(
             outcome,
             HandlerOutcome::Transition(ref screen) if matches!(**screen, TypedScreen::Task(_))
-        ));
+        );
 
         // Verify menu position was saved
         assert_eq!(
@@ -2026,7 +2019,7 @@ mod tests {
 
         let outcome = handle_next_lesson(&results_data, &mut ctx).unwrap();
 
-        assert!(matches!(outcome, HandlerOutcome::Stay));
+        assert_matches!(outcome, HandlerOutcome::Stay);
         assert!(
             ctx.ui.notifications.visible().iter().any(|n| matches!(
                 n.notification_type,

--- a/src/ui/state/mod.rs
+++ b/src/ui/state/mod.rs
@@ -374,10 +374,11 @@ impl AppState {
     /// ```ignore
     /// use helix_trainer::ui::AppState;
     /// use helix_trainer::config::Scenario;
+    /// use std::assert_matches;
     ///
     /// let scenarios = vec![/* ... */];
     /// let state = AppState::new(scenarios, profile, storage, tracker);
-    /// assert!(matches!(state.screen, TypedScreen::Menu(_)));
+    /// assert_matches!(state.screen, TypedScreen::Menu(_));
     /// ```
     pub fn new(
         scenarios: Vec<Scenario>,

--- a/src/ui/state/substates.rs
+++ b/src/ui/state/substates.rs
@@ -540,6 +540,7 @@ impl ConfigState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
 
     #[test]
     fn test_ui_state_new() {
@@ -853,7 +854,7 @@ mod tests {
             .await
             .expect("save result should arrive")
             .expect("channel should not be closed");
-        assert!(matches!(msg, DataLoadMessage::ProfileSaved));
+        assert_matches!(msg, DataLoadMessage::ProfileSaved);
 
         let expected_xp = progress.profile.total_xp;
         // Drop every sender clone — including the one `progress` holds
@@ -951,8 +952,9 @@ mod tests {
 
         // Within the debounce window: should not dispatch another save.
         progress.save_debounced().unwrap();
-        assert!(
-            matches!(result_rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
+        assert_matches!(
+            result_rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty),
             "debounced call within the window must not dispatch a second save"
         );
     }
@@ -995,8 +997,9 @@ mod tests {
                 .await
                 .expect("save result should arrive")
                 .expect("channel should not be closed");
-            assert!(
-                matches!(msg, DataLoadMessage::ProfileSaved),
+            assert_matches!(
+                msg,
+                DataLoadMessage::ProfileSaved,
                 "every save must succeed, got {msg:?}"
             );
         }
@@ -1062,7 +1065,7 @@ mod tests {
                 .await
                 .expect("save result should arrive")
                 .expect("channel should not be closed");
-            assert!(matches!(msg, DataLoadMessage::ProfileSaved));
+            assert_matches!(msg, DataLoadMessage::ProfileSaved);
         }
 
         let persisted = ProfileStorage::with_path(&profile_path).load().unwrap();

--- a/src/ui/state/tests/app_state_tests.rs
+++ b/src/ui/state/tests/app_state_tests.rs
@@ -1,5 +1,7 @@
 //! Tests for AppState functionality
 
+use std::assert_matches;
+
 use super::common::{create_test_app_state, create_test_scenario};
 use crate::ui::state::TypedScreen;
 
@@ -48,7 +50,7 @@ fn test_scenario_invalid_index() {
 #[test]
 fn test_initial_screen_is_mode_selection() {
     let state = create_test_app_state(vec![]);
-    assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
+    assert_matches!(state.screen, TypedScreen::ModeSelection(_));
 }
 
 #[test]

--- a/src/ui/state/tests/menu_tests.rs
+++ b/src/ui/state/tests/menu_tests.rs
@@ -1,5 +1,7 @@
 //! Tests for menu navigation and selection
 
+use std::assert_matches;
+
 use super::common::{create_test_app_state, create_test_scenario};
 use crate::game::PlayableScenario;
 use crate::ui::state::{Message, TypedScreen, update};
@@ -136,7 +138,7 @@ fn test_menu_select_quit_awards_live_minigame_session_reached_via_review_detour(
     // `minigame_session` - reproducing the menu-Quit-reachable-with-a-live-
     // session path without needing due reviews to be seeded.
     update(&mut state, Message::AbandonReviewSession).unwrap();
-    assert!(matches!(state.screen, TypedScreen::Menu(_)));
+    assert_matches!(state.screen, TypedScreen::Menu(_));
     assert!(
         state.game.minigame_session.is_some(),
         "the paused arcade session must still be live once the Menu screen is reached"
@@ -170,7 +172,7 @@ fn test_menu_select_profile() {
     }
 
     update(&mut state, Message::MenuSelect).unwrap();
-    assert!(matches!(state.screen, TypedScreen::Profile(_)));
+    assert_matches!(state.screen, TypedScreen::Profile(_));
 }
 
 #[test]
@@ -185,7 +187,7 @@ fn test_menu_select_statistics() {
     }
 
     update(&mut state, Message::MenuSelect).unwrap();
-    assert!(matches!(state.screen, TypedScreen::Statistics(_)));
+    assert_matches!(state.screen, TypedScreen::Statistics(_));
 }
 
 #[test]
@@ -198,14 +200,14 @@ fn test_menu_with_zero_scenarios() {
     // Review should be at index 0 (no scenarios)
     update(&mut state, Message::MenuSelect).unwrap();
     // Should stay on MainMenu if no reviews are due
-    assert!(matches!(state.screen, TypedScreen::Menu(_)));
+    assert_matches!(state.screen, TypedScreen::Menu(_));
 
     // Profile at index 1
     if let TypedScreen::Menu(menu_data) = &mut state.screen {
         menu_data.selected_item = 1;
     }
     update(&mut state, Message::MenuSelect).unwrap();
-    assert!(matches!(state.screen, TypedScreen::Profile(_)));
+    assert_matches!(state.screen, TypedScreen::Profile(_));
 
     // Statistics at index 2
     state.screen = TypedScreen::Menu(Default::default());
@@ -213,7 +215,7 @@ fn test_menu_with_zero_scenarios() {
         menu_data.selected_item = 2;
     }
     update(&mut state, Message::MenuSelect).unwrap();
-    assert!(matches!(state.screen, TypedScreen::Statistics(_)));
+    assert_matches!(state.screen, TypedScreen::Statistics(_));
 
     // Quit at index 3
     state.screen = TypedScreen::Menu(Default::default());
@@ -361,5 +363,5 @@ fn test_menu_select_review_no_due() {
     update(&mut state, Message::MenuSelect).unwrap();
 
     // No reviews due, should stay on menu
-    assert!(matches!(state.screen, TypedScreen::Menu(_)));
+    assert_matches!(state.screen, TypedScreen::Menu(_));
 }

--- a/src/ui/state/tests/mode_selection_tests.rs
+++ b/src/ui/state/tests/mode_selection_tests.rs
@@ -1,5 +1,7 @@
 //! Tests for mode selection handlers
 
+use std::assert_matches;
+
 use super::common::{create_test_app_state, create_test_scenario};
 use crate::ui::state::{Message, TypedScreen, update};
 
@@ -7,7 +9,7 @@ use crate::ui::state::{Message, TypedScreen, update};
 fn test_mode_selection_up() {
     let mut state = create_test_app_state(vec![]);
     // Should start on ModeSelection screen
-    assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
+    assert_matches!(state.screen, TypedScreen::ModeSelection(_));
 
     // Set selected mode to 1
     if let TypedScreen::ModeSelection(mode_data) = &mut state.screen {
@@ -93,7 +95,7 @@ fn test_select_training_mode() {
     update(&mut state, Message::SelectTrainingMode).unwrap();
 
     // Should navigate to Menu screen
-    assert!(matches!(state.screen, TypedScreen::Menu(_)));
+    assert_matches!(state.screen, TypedScreen::Menu(_));
 }
 
 #[test]
@@ -104,7 +106,7 @@ fn test_select_arcade_mode() {
     update(&mut state, Message::SelectArcadeMode).unwrap();
 
     // Should navigate to MiniGame selection screen
-    assert!(matches!(state.screen, TypedScreen::MiniGame(_)));
+    assert_matches!(state.screen, TypedScreen::MiniGame(_));
 }
 
 #[test]
@@ -114,13 +116,13 @@ fn test_navigate_back_from_menu_to_mode_selection() {
 
     // Go to Training Mode
     update(&mut state, Message::SelectTrainingMode).unwrap();
-    assert!(matches!(state.screen, TypedScreen::Menu(_)));
+    assert_matches!(state.screen, TypedScreen::Menu(_));
 
     // Go back
     update(&mut state, Message::BackToMenu).unwrap();
 
     // Should return to ModeSelection
-    assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
+    assert_matches!(state.screen, TypedScreen::ModeSelection(_));
 }
 
 #[test]
@@ -135,13 +137,13 @@ fn test_navigate_back_from_minigame_to_mode_selection() {
 
     // Go to Arcade Mode
     update(&mut state, Message::SelectArcadeMode).unwrap();
-    assert!(matches!(state.screen, TypedScreen::MiniGame(_)));
+    assert_matches!(state.screen, TypedScreen::MiniGame(_));
 
     // Go back
     update(&mut state, Message::MiniGameBackToMenu).unwrap();
 
     // Should return to ModeSelection
-    assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
+    assert_matches!(state.screen, TypedScreen::ModeSelection(_));
 }
 
 #[test]

--- a/src/ui/state/tests/navigation_tests.rs
+++ b/src/ui/state/tests/navigation_tests.rs
@@ -1,5 +1,7 @@
 //! Tests for navigation and screen transitions
 
+use std::assert_matches;
+
 use super::common::{create_test_app_state, create_test_scenario};
 use crate::ui::state::{Message, Screen, TypedScreen, update};
 
@@ -214,21 +216,21 @@ fn test_quit_app_persists_fsrs_data_from_live_action() {
 #[test]
 fn test_navigate_to_screen() {
     let mut state = create_test_app_state(vec![]);
-    assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
+    assert_matches!(state.screen, TypedScreen::ModeSelection(_));
 
     // After TypedScreen refactoring, only screens with standalone data can be navigated to
     // Task and Results require active sessions, so only test Profile/Statistics/Menu/ModeSelection
     update(&mut state, Message::NavigateTo(Screen::Profile)).unwrap();
-    assert!(matches!(state.screen, TypedScreen::Profile(_)));
+    assert_matches!(state.screen, TypedScreen::Profile(_));
 
     update(&mut state, Message::NavigateTo(Screen::Statistics)).unwrap();
-    assert!(matches!(state.screen, TypedScreen::Statistics(_)));
+    assert_matches!(state.screen, TypedScreen::Statistics(_));
 
     update(&mut state, Message::NavigateTo(Screen::MainMenu)).unwrap();
-    assert!(matches!(state.screen, TypedScreen::Menu(_)));
+    assert_matches!(state.screen, TypedScreen::Menu(_));
 
     update(&mut state, Message::NavigateTo(Screen::ModeSelection)).unwrap();
-    assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
+    assert_matches!(state.screen, TypedScreen::ModeSelection(_));
 }
 
 #[test]
@@ -238,11 +240,11 @@ fn test_back_to_menu_clears_session() {
 
     update(&mut state, Message::StartScenario(0)).unwrap();
     // After TypedScreen refactoring, verify we're on Task screen
-    assert!(matches!(state.screen, TypedScreen::Task(_)));
+    assert_matches!(state.screen, TypedScreen::Task(_));
 
     update(&mut state, Message::BackToMenu).unwrap();
     // Should transition back to ModeSelection screen (the main menu)
-    assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
+    assert_matches!(state.screen, TypedScreen::ModeSelection(_));
 }
 
 #[test]

--- a/src/ui/state/tests/review_tests.rs
+++ b/src/ui/state/tests/review_tests.rs
@@ -9,6 +9,7 @@
 //! constructing `ReviewSessionState` directly, since `StartReviewSession` cannot be
 //! relied on to produce a due review deterministically.
 
+use std::assert_matches;
 use std::time::{Duration, Instant};
 
 use super::common::{create_test_app_state, create_test_scenario};
@@ -30,9 +31,9 @@ fn test_review_session_with_no_due_reviews() {
     // May or may not have reviews due - depends on FSRS algorithm
     // If no reviews due, should stay on menu
     if state.game.review_session.is_none() {
-        assert!(matches!(state.screen, TypedScreen::Menu(_)));
+        assert_matches!(state.screen, TypedScreen::Menu(_));
     } else {
-        assert!(matches!(state.screen, TypedScreen::Review(_)));
+        assert_matches!(state.screen, TypedScreen::Review(_));
     }
 }
 
@@ -43,7 +44,7 @@ fn test_review_session_message_handlers() {
     let state = create_test_app_state(vec![scenario]);
 
     // Test AbandonReviewSession message handler
-    assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
+    assert_matches!(state.screen, TypedScreen::ModeSelection(_));
 
     // The actual review session behavior depends on FSRS scheduling
     // This test verifies the message handlers are correctly wired
@@ -55,12 +56,12 @@ fn test_review_session_no_due_reviews_stays_on_menu() {
     let mut state = create_test_app_state(vec![scenario]);
 
     // Don't add any reviews to tracker
-    assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
+    assert_matches!(state.screen, TypedScreen::ModeSelection(_));
 
     update(&mut state, Message::StartReviewSession).unwrap();
 
     // Should stay on ModeSelection when no reviews are due
-    assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
+    assert_matches!(state.screen, TypedScreen::ModeSelection(_));
     assert!(state.game.review_session.is_none());
 }
 
@@ -131,7 +132,7 @@ fn test_review_session_completion_persists_xp_and_fsrs_data() {
     // Session should be cleared and XP awarded (1 completed * 10 + 100% success * 20).
     assert!(state.game.review_session.is_none());
     assert_eq!(state.progress.profile.total_xp, initial_xp + 30);
-    assert!(matches!(state.screen, TypedScreen::Menu(_)));
+    assert_matches!(state.screen, TypedScreen::Menu(_));
 
     let persisted = ProfileStorage::with_path(state.progress.storage.path())
         .load()
@@ -260,7 +261,7 @@ fn test_abandon_review_session_persists_partial_progress() {
     update(&mut state, Message::AbandonReviewSession).unwrap();
 
     assert!(state.game.review_session.is_none());
-    assert!(matches!(state.screen, TypedScreen::Menu(_)));
+    assert_matches!(state.screen, TypedScreen::Menu(_));
 
     let persisted = ProfileStorage::with_path(&profile_path).load().unwrap();
     assert!(

--- a/src/ui/state/tests/scenario_tests.rs
+++ b/src/ui/state/tests/scenario_tests.rs
@@ -1,5 +1,7 @@
 //! Tests for scenario lifecycle (start, complete, abandon, retry)
 
+use std::assert_matches;
+
 use super::common::{create_test_app_state, create_test_scenario, exec};
 use crate::game::PlayableScenario;
 use crate::helix::commands::{CMD_DELETE_SELECTION, CMD_SELECT_LINE};
@@ -13,7 +15,7 @@ fn test_start_scenario() {
     update(&mut state, Message::StartScenario(0)).unwrap();
 
     // After typestate refactoring, session is in TypedScreen::Task, not game.session
-    assert!(matches!(state.screen, TypedScreen::Task(_)));
+    assert_matches!(state.screen, TypedScreen::Task(_));
     if let TypedScreen::Task(task_data) = &state.screen {
         // Verify session exists in task data
         assert!(!task_data.session.current_content().is_empty());
@@ -28,7 +30,7 @@ fn test_start_invalid_scenario_index() {
     update(&mut state, Message::StartScenario(999)).unwrap();
 
     // Should stay on current screen (not transition to Task)
-    assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
+    assert_matches!(state.screen, TypedScreen::ModeSelection(_));
 }
 
 #[test]
@@ -42,7 +44,7 @@ fn test_complete_scenario_navigates_to_results() {
     state.progress.storage = ProfileStorage::with_path(temp_dir.path().join("profile.json"));
 
     update(&mut state, Message::StartScenario(0)).unwrap();
-    assert!(matches!(state.screen, TypedScreen::Task(_)));
+    assert_matches!(state.screen, TypedScreen::Task(_));
 
     // Execute the solution command to reach target state
     // In Helix, 'xd' = select line + delete selection (or legacy 'x')
@@ -52,13 +54,13 @@ fn test_complete_scenario_navigates_to_results() {
     // After completing the scenario, completion_time is set (success animation starts)
     // Screen stays on Task until CompleteScenario message is sent after delay
     assert!(state.ui.completion_time.is_some());
-    assert!(matches!(state.screen, TypedScreen::Task(_)));
+    assert_matches!(state.screen, TypedScreen::Task(_));
 
     // Simulate the delayed transition (event loop sends CompleteScenario after 1.5s)
     update(&mut state, Message::CompleteScenario).unwrap();
 
     // Now should be on Results screen
-    assert!(matches!(state.screen, TypedScreen::Results(_)));
+    assert_matches!(state.screen, TypedScreen::Results(_));
 }
 
 #[test]
@@ -68,7 +70,7 @@ fn test_abandon_scenario_navigates_to_results() {
 
     update(&mut state, Message::StartScenario(0)).unwrap();
     // After TypedScreen refactoring, verify we're on Task screen
-    assert!(matches!(state.screen, TypedScreen::Task(_)));
+    assert_matches!(state.screen, TypedScreen::Task(_));
 
     update(&mut state, Message::AbandonScenario).unwrap();
     // Should transition to Results screen
@@ -118,7 +120,7 @@ fn test_retry_scenario_resets_state() {
 
     // Abandon to go to Results screen
     update(&mut state, Message::AbandonScenario).unwrap();
-    assert!(matches!(state.screen, TypedScreen::Results(_)));
+    assert_matches!(state.screen, TypedScreen::Results(_));
 
     // Now retry - this should create a fresh session with action count = 0
     update(&mut state, Message::RetryScenario).unwrap();
@@ -136,11 +138,11 @@ fn test_next_scenario_clears_session() {
 
     update(&mut state, Message::StartScenario(0)).unwrap();
     // Verify we're on Task screen with active session
-    assert!(matches!(state.screen, TypedScreen::Task(_)));
+    assert_matches!(state.screen, TypedScreen::Task(_));
 
     update(&mut state, Message::NextScenario).unwrap();
     // Should return to menu
-    assert!(matches!(state.screen, TypedScreen::Menu(_)));
+    assert_matches!(state.screen, TypedScreen::Menu(_));
 }
 
 #[test]
@@ -183,8 +185,9 @@ fn test_previously_completed_quests_tracking() {
         state.ui.completion_time.is_some(),
         "completion_time should be set after completing scenario"
     );
-    assert!(
-        matches!(state.screen, TypedScreen::Task(_)),
+    assert_matches!(
+        state.screen,
+        TypedScreen::Task(_),
         "Should stay on Task screen during success animation"
     );
 
@@ -203,8 +206,9 @@ fn test_previously_completed_quests_tracking() {
     update(&mut state, Message::CompleteScenario).unwrap();
 
     // Now should be on Results screen
-    assert!(
-        matches!(state.screen, TypedScreen::Results(_)),
+    assert_matches!(
+        state.screen,
+        TypedScreen::Results(_),
         "Should be on Results screen after CompleteScenario"
     );
 }

--- a/src/ui/state/tests/sound_tests.rs
+++ b/src/ui/state/tests/sound_tests.rs
@@ -1,5 +1,7 @@
 //! Tests for sound toggle functionality
 
+use std::assert_matches;
+
 use super::common::create_test_app_state;
 use crate::ui::state::{Message, update};
 
@@ -37,19 +39,19 @@ fn test_toggle_sound_works_on_any_screen() {
     let mut state = create_test_app_state(vec![]);
 
     // Test on ModeSelection screen (default)
-    assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
+    assert_matches!(state.screen, TypedScreen::ModeSelection(_));
     update(&mut state, Message::ToggleSound).unwrap();
     assert!(!state.progress.sound_manager.config().enabled);
 
     // Navigate to Profile and test
     update(&mut state, Message::NavigateTo(Screen::Profile)).unwrap();
-    assert!(matches!(state.screen, TypedScreen::Profile(_)));
+    assert_matches!(state.screen, TypedScreen::Profile(_));
     update(&mut state, Message::ToggleSound).unwrap();
     assert!(state.progress.sound_manager.config().enabled);
 
     // Navigate to Statistics and test
     update(&mut state, Message::NavigateTo(Screen::Statistics)).unwrap();
-    assert!(matches!(state.screen, TypedScreen::Statistics(_)));
+    assert_matches!(state.screen, TypedScreen::Statistics(_));
     update(&mut state, Message::ToggleSound).unwrap();
     assert!(!state.progress.sound_manager.config().enabled);
 }

--- a/tests/gamification.rs
+++ b/tests/gamification.rs
@@ -2,6 +2,7 @@
 
 use helix_trainer::gamification::*;
 use helix_trainer::learning::PerformanceTracker;
+use std::assert_matches;
 use std::time::Duration;
 use tempfile::TempDir;
 
@@ -41,10 +42,10 @@ fn test_complete_user_flow() {
 
     // Update streak
     let change = StreakManager::update_streak(&mut profile, chrono::Utc::now());
-    assert!(matches!(
+    assert_matches!(
         change,
         StreakChange::Continued | StreakChange::Incremented { .. }
-    ));
+    );
 
     // Check achievements
     profile.perfect_scenarios = 1;

--- a/tests/review_session.rs
+++ b/tests/review_session.rs
@@ -11,6 +11,7 @@ use helix_trainer::gamification::{ProfileStorage, UserProfile};
 use helix_trainer::learning::PerformanceTracker;
 use helix_trainer::ui::state::{AppState, Message, TypedScreen};
 use helix_trainer::ui::update;
+use std::assert_matches;
 use std::time::Duration;
 
 /// Helper: Create test app state with optional due reviews
@@ -44,14 +45,14 @@ fn create_test_app_state_with_reviews(due_count: usize) -> AppState {
 #[test]
 fn test_start_review_session_with_due_reviews() {
     let mut state = create_test_app_state_with_reviews(5);
-    assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
+    assert_matches!(state.screen, TypedScreen::ModeSelection(_));
     assert!(state.game.review_session.is_none());
 
     // Start review session
     update(&mut state, Message::StartReviewSession).unwrap();
 
     // Should transition to Review screen and create session state
-    assert!(matches!(state.screen, TypedScreen::Review(_)));
+    assert_matches!(state.screen, TypedScreen::Review(_));
     assert!(state.game.review_session.is_some());
 
     let session = state.game.review_session.as_ref().unwrap();
@@ -64,13 +65,13 @@ fn test_start_review_session_with_due_reviews() {
 #[test]
 fn test_start_review_session_with_zero_due_reviews() {
     let mut state = create_test_app_state_with_reviews(0);
-    assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
+    assert_matches!(state.screen, TypedScreen::ModeSelection(_));
 
     // Try to start review session with no due reviews
     update(&mut state, Message::StartReviewSession).unwrap();
 
     // Should stay on ModeSelection (no reviews available)
-    assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
+    assert_matches!(state.screen, TypedScreen::ModeSelection(_));
     assert!(state.game.review_session.is_none());
 }
 
@@ -80,7 +81,7 @@ fn test_start_review_session_with_one_review_boundary() {
 
     update(&mut state, Message::StartReviewSession).unwrap();
 
-    assert!(matches!(state.screen, TypedScreen::Review(_)));
+    assert_matches!(state.screen, TypedScreen::Review(_));
     let session = state.game.review_session.as_ref().unwrap();
     assert_eq!(session.due_commands.len(), 1);
     assert_eq!(session.current_index, 0);
@@ -92,7 +93,7 @@ fn test_start_review_session_with_many_reviews_stress_test() {
 
     update(&mut state, Message::StartReviewSession).unwrap();
 
-    assert!(matches!(state.screen, TypedScreen::Review(_)));
+    assert_matches!(state.screen, TypedScreen::Review(_));
     let session = state.game.review_session.as_ref().unwrap();
     assert_eq!(session.due_commands.len(), 100);
     assert_eq!(session.current_index, 0);
@@ -104,7 +105,7 @@ fn test_abandon_review_session_mid_way() {
 
     // Start session
     update(&mut state, Message::StartReviewSession).unwrap();
-    assert!(matches!(state.screen, TypedScreen::Review(_)));
+    assert_matches!(state.screen, TypedScreen::Review(_));
 
     // Complete 2 reviews
     update(&mut state, Message::CompleteReviewCommand { success: true }).unwrap();
@@ -118,7 +119,7 @@ fn test_abandon_review_session_mid_way() {
     update(&mut state, Message::AbandonReviewSession).unwrap();
 
     // Should return to menu and clear session
-    assert!(matches!(state.screen, TypedScreen::Menu(_)));
+    assert_matches!(state.screen, TypedScreen::Menu(_));
     assert!(state.game.review_session.is_none());
 }
 
@@ -139,7 +140,7 @@ fn test_complete_all_reviews_successfully() {
     }
 
     // Should return to menu and award XP
-    assert!(matches!(state.screen, TypedScreen::Menu(_)));
+    assert_matches!(state.screen, TypedScreen::Menu(_));
     assert!(state.game.review_session.is_none());
 
     // Verify XP was awarded
@@ -257,7 +258,7 @@ fn test_next_review_command_ends_session() {
     update(&mut state, Message::CompleteReviewCommand { success: true }).unwrap();
 
     // Session should end and return to menu
-    assert!(matches!(state.screen, TypedScreen::Menu(_)));
+    assert_matches!(state.screen, TypedScreen::Menu(_));
     assert!(state.game.review_session.is_none());
 }
 
@@ -306,15 +307,15 @@ fn test_state_transition_review_to_next_to_review() {
 
     // MainMenu → Review
     update(&mut state, Message::StartReviewSession).unwrap();
-    assert!(matches!(state.screen, TypedScreen::Review(_)));
+    assert_matches!(state.screen, TypedScreen::Review(_));
 
     // Review → Next → Still Review
     update(&mut state, Message::CompleteReviewCommand { success: true }).unwrap();
-    assert!(matches!(state.screen, TypedScreen::Review(_)));
+    assert_matches!(state.screen, TypedScreen::Review(_));
 
     // Review → Complete → MainMenu
     update(&mut state, Message::CompleteReviewCommand { success: true }).unwrap();
-    assert!(matches!(state.screen, TypedScreen::Menu(_)));
+    assert_matches!(state.screen, TypedScreen::Menu(_));
 }
 
 #[test]
@@ -323,11 +324,11 @@ fn test_state_transition_review_to_abandon_to_menu() {
 
     // MainMenu → Review
     update(&mut state, Message::StartReviewSession).unwrap();
-    assert!(matches!(state.screen, TypedScreen::Review(_)));
+    assert_matches!(state.screen, TypedScreen::Review(_));
 
     // Review → Abandon → MainMenu
     update(&mut state, Message::AbandonReviewSession).unwrap();
-    assert!(matches!(state.screen, TypedScreen::Menu(_)));
+    assert_matches!(state.screen, TypedScreen::Menu(_));
 }
 
 #[test]
@@ -336,7 +337,7 @@ fn test_state_transition_menu_to_review_no_due() {
 
     // ModeSelection → (Try Review) → Stay on ModeSelection
     update(&mut state, Message::StartReviewSession).unwrap();
-    assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
+    assert_matches!(state.screen, TypedScreen::ModeSelection(_));
 }
 
 // ============================================================================
@@ -510,7 +511,7 @@ fn test_complete_flow_all_successful() {
 
     // Start review session
     update(&mut state, Message::StartReviewSession).unwrap();
-    assert!(matches!(state.screen, TypedScreen::Review(_)));
+    assert_matches!(state.screen, TypedScreen::Review(_));
 
     // Complete all 5 reviews successfully
     for i in 0..5 {
@@ -522,7 +523,7 @@ fn test_complete_flow_all_successful() {
     }
 
     // Session should end
-    assert!(matches!(state.screen, TypedScreen::Menu(_)));
+    assert_matches!(state.screen, TypedScreen::Menu(_));
     assert!(state.game.review_session.is_none());
 
     // XP should be awarded
@@ -554,7 +555,7 @@ fn test_complete_flow_all_failed() {
     }
 
     // Session should still end and award base XP
-    assert!(matches!(state.screen, TypedScreen::Menu(_)));
+    assert_matches!(state.screen, TypedScreen::Menu(_));
     assert!(state.game.review_session.is_none());
 
     let final_xp = {
@@ -583,7 +584,7 @@ fn test_complete_flow_abandoned_after_partial() {
     update(&mut state, Message::AbandonReviewSession).unwrap();
 
     // Should return to menu without awarding XP (session incomplete)
-    assert!(matches!(state.screen, TypedScreen::Menu(_)));
+    assert_matches!(state.screen, TypedScreen::Menu(_));
     assert!(state.game.review_session.is_none());
 
     let final_xp = {
@@ -603,7 +604,7 @@ fn test_complete_flow_zero_reviews() {
     update(&mut state, Message::StartReviewSession).unwrap();
 
     // Should stay on ModeSelection (initial screen)
-    assert!(matches!(state.screen, TypedScreen::ModeSelection(_)));
+    assert_matches!(state.screen, TypedScreen::ModeSelection(_));
     assert!(state.game.review_session.is_none());
 }
 
@@ -625,7 +626,7 @@ fn test_boundary_single_review() {
     update(&mut state, Message::CompleteReviewCommand { success: true }).unwrap();
 
     // Should immediately end session
-    assert!(matches!(state.screen, TypedScreen::Menu(_)));
+    assert_matches!(state.screen, TypedScreen::Menu(_));
     assert!(state.game.review_session.is_none());
 }
 
@@ -644,7 +645,7 @@ fn test_boundary_large_review_count() {
     }
 
     // Should handle large count gracefully
-    assert!(matches!(state.screen, TypedScreen::Menu(_)));
+    assert_matches!(state.screen, TypedScreen::Menu(_));
     assert!(state.game.review_session.is_none());
 }
 

--- a/tests/spaced_repetition.rs
+++ b/tests/spaced_repetition.rs
@@ -10,6 +10,7 @@
 use helix_trainer::learning::{
     Analytics, MasteryLevel, PerformanceTracker, ReviewSession, Scheduler,
 };
+use std::assert_matches;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::Duration;
@@ -75,13 +76,13 @@ fn test_complete_learning_workflow() {
     assert_eq!(x_perf.attempts, 3);
     assert_eq!(x_perf.successes, 3);
     // Mastery level is calculated by FSRS, don't assert specific level
-    assert!(matches!(
+    assert_matches!(
         x_perf.mastery_level,
         MasteryLevel::Beginner
             | MasteryLevel::Intermediate
             | MasteryLevel::Advanced
             | MasteryLevel::Master
-    ));
+    );
 
     let yy_perf = tracker.performance("yy").unwrap();
     assert_eq!(yy_perf.attempts, 3);
@@ -135,13 +136,13 @@ fn test_mastery_progression() {
     let perf = tracker.performance("x").unwrap();
 
     // With 20 successful attempts, should have valid mastery level
-    assert!(matches!(
+    assert_matches!(
         perf.mastery_level,
         MasteryLevel::Beginner
             | MasteryLevel::Intermediate
             | MasteryLevel::Advanced
             | MasteryLevel::Master
-    ));
+    );
     assert_eq!(perf.attempts, 20);
     assert_eq!(perf.successes, 20);
 

--- a/tests/ui_multi_key_commands.rs
+++ b/tests/ui_multi_key_commands.rs
@@ -10,6 +10,7 @@ use helix_trainer::input::keymap::CanonicalKeys;
 use helix_trainer::learning::PerformanceTracker;
 use helix_trainer::ui::state::{InputStateAccess, TypedScreen};
 use helix_trainer::ui::{AppState, Message, update};
+use std::assert_matches;
 use std::borrow::Cow;
 
 /// Build an `ExecuteCommand` message for a single physical key with no
@@ -362,10 +363,10 @@ fn test_register_yank_paste_multi_key() {
     // '"' - transitions to RegisterPending
     update(&mut state, exec("\"")).unwrap();
     if let TypedScreen::Task(task_data) = &state.screen {
-        assert!(matches!(
+        assert_matches!(
             task_data.input_state().state(),
             helix_trainer::input::typestate::InputState::RegisterPending
-        ));
+        );
     } else {
         panic!("Should be on Task screen");
     }
@@ -373,10 +374,10 @@ fn test_register_yank_paste_multi_key() {
     // 'a' - selects register a, transitions to RegisterOpPending
     update(&mut state, exec("a")).unwrap();
     if let TypedScreen::Task(task_data) = &state.screen {
-        assert!(matches!(
+        assert_matches!(
             task_data.input_state().state(),
             helix_trainer::input::typestate::InputState::RegisterOpPending { register: 'a' }
-        ));
+        );
         // Nothing executed yet
         assert_eq!(task_data.session.current_content(), "alpha beta");
     } else {


### PR DESCRIPTION
## Summary
- Raise `rust-version` in `Cargo.toml` from 1.91 to 1.98; no dependency blocks the bump (highest declared dep MSRV is 1.88.0) and the crate does not publish to crates.io, so the cost is zero
- Adopt the newly-stable `Path::is_empty()` in `ProfileStorage`'s path-emptiness check (`src/gamification/storage.rs`), replacing `p.as_os_str().is_empty()`
- Update README badge/build-from-source note and `specs/constitution.md` to reference 1.98; add CHANGELOG entries
- Migrate `assert!(matches!(...))` to `assert_matches!` across the test suite (~325 call sites, 37 files, including custom-message variants), now that MSRV covers its Rust 1.96 stabilization — prints the actual value's `Debug` output on assertion failure instead of just "assertion failed"

One intentionally-unconverted `assert!(matches!(...))` remains at `src/input/typestate/mod.rs:41`, inside a non-compiled ` ```ignore ` doc-comment example.

Fixes #407

## Test plan
- [x] `cargo build --workspace --all-features`
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (2253 passed)
- [x] `cargo nextest run scenario` (277 passed)
- [x] `cargo test --doc` (67 passed)
- [x] `cargo audit` / `cargo deny check` — 0 vulnerabilities, pass
- [x] Every `assert_matches!` conversion verified byte-identical to its original expr/pattern/message (automated balanced-paren diff, independently spot-checked in review)